### PR TITLE
Extend scope of pre-commit hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,12 +21,13 @@ both footprint and startup time are behaved pretty well.
 `Tangle-accelerator` is built and launched through [bazel](https://www.bazel.build/):
 
 ```
-$ bazel run //tangle_accelerator
+$ bazel run //:tangle_accelerator
 ```
 
 
 ## Developing
 
+The codebase of this repository follows [Google's C++ guidelines](https://google.github.io/styleguide/cppguide.html): 
 - Please run `hooks/autohook.sh install` after initial checkout.
 - Pass `-c dbg` for building with debug symbols.
 

--- a/hooks/scripts/format_check
+++ b/hooks/scripts/format_check
@@ -2,7 +2,7 @@
 
 root=$(git rev-parse --show-toplevel)
 status=0
-for file in $(git diff --staged --name-only | grep -E "\.(c|cc|cpp|h|hh|hpp)\$")
+for file in $(find . -type f | grep -E "\.(c|cc|cpp|h|hh|hpp)\$")
 do
   filepath="$root/$file"
   output=$(diff <(cat $filepath) <(clang-format -style=file -fallback-style=none $filepath))


### PR DESCRIPTION
* Extend scope of all pre-commit hooks to all files
* Add style note in README.md

Format check for CI pipeline can be simpler in this way, and it doesn't take too much time to check all files actually.