### PR TITLE
Remove redundant function and json column

### DIFF
--- a/apis.h
+++ b/apis.h
@@ -9,8 +9,6 @@
 extern "C" {
 #endif
 
-int handle_request(const iota_client_service_t* const service,
-                   const char* const obj);
 int api_generate_address(const iota_client_service_t* const service,
                          char** json_result);
 int api_get_tips_pair(const iota_client_service_t* const service,

--- a/serializer/test/test_serializer.c
+++ b/serializer/test/test_serializer.c
@@ -28,7 +28,7 @@ void test_serialize_ta_generate_address(void) {
 
 void test_deserialize_ta_send_transfer(void) {
   const char* json =
-      "{\"command\":\"send_transfer\",\"value\":100,"
+      "{\"value\":100,"
       "\"message\":\"" TAG_MSG "\",\"tag\":\"" TAG_MSG
       "\","
       "\"address\":\"" TRYTES_81_1 "\"}";


### PR DESCRIPTION
We handle requests according to request path,
thus function `handle_request` and `command:` in send_transfer request are no longer needed.