### PR TITLE
Add cache operations to ta_get_transaction_object

### DIFF
--- a/accelerator/BUILD
+++ b/accelerator/BUILD
@@ -30,6 +30,7 @@ cc_library(
     visibility = ["//visibility:public"],
     deps = [
         ":ta_config",
+        "//cache",
         "//request",
         "//response",
         "@com_github_uthash//:uthash",

--- a/accelerator/common_core.c
+++ b/accelerator/common_core.c
@@ -133,7 +133,7 @@ int ta_get_transaction_object(const iota_client_service_t* const service,
 
     // set into cache if get_trytes response is not null trytes
     if (!flex_trits_are_null(tx_trits, FLEX_TRIT_SIZE_8019)) {
-      flex_trits_from_trytes(
+      flex_trits_to_trytes(
           (tryte_t*)cache_value, NUM_TRYTES_SERIALIZED_TRANSACTION, tx_trits,
           NUM_TRITS_SERIALIZED_TRANSACTION, NUM_TRITS_SERIALIZED_TRANSACTION);
       cache_set(cache, req, cache_value);

--- a/cache/BUILD
+++ b/cache/BUILD
@@ -7,5 +7,6 @@ cc_library(
     deps = [
         "//accelerator:ta_config",
         "//third_party:hiredis",
+        "@entangled//cclient/types",
     ],
 )

--- a/cache/backend_redis.c
+++ b/cache/backend_redis.c
@@ -37,7 +37,7 @@ static int redis_get(redisContext* c, const char* const key, char* res) {
 
   redisReply* reply = redisCommand(c, "GET %s", key);
   if (reply->type == REDIS_REPLY_STRING) {
-    strcpy(res, reply->str);
+    strncpy(res, reply->str, FLEX_TRIT_SIZE_8019);
     ret = 0;
   }
 
@@ -53,7 +53,8 @@ static int redis_set(redisContext* c, const char* const key,
     return ret;
   }
 
-  redisReply* reply = redisCommand(c, "SETNX %s %s", key, value);
+  redisReply* reply = redisCommand(c, "SETNX %b %b", key, FLEX_TRIT_SIZE_243,
+                                   value, FLEX_TRIT_SIZE_8019);
   if (reply->integer) {
     ret = 0;
   }

--- a/cache/cache.h
+++ b/cache/cache.h
@@ -5,6 +5,8 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include "types/types.h"
+
 typedef struct {
   void* conn;
 } cache_t;

--- a/tests/test_common.cc
+++ b/tests/test_common.cc
@@ -86,7 +86,7 @@ TEST(GetTxnObjTest, GetTrytesTest) {
   const char req[FLEX_TRIT_SIZE_243] = {};
   ta_get_transaction_object_res_t* res = ta_get_transaction_object_res_new();
 
-  EXPECT_CALL(APIMockObj, iota_client_get_trytes(_, _, _)).Times(AtLeast(1));
+  EXPECT_CALL(APIMockObj, iota_client_get_trytes(_, _, _)).Times(AtLeast(0));
 
   EXPECT_EQ(ta_get_transaction_object(&service, req, res), 0);
   flex_trit_t hash[FLEX_TRIT_SIZE_6561];
@@ -109,7 +109,7 @@ TEST(FindTxnObjTest, TxnObjTest) {
 
   EXPECT_CALL(APIMockObj, iota_client_find_transactions(_, _, _))
       .Times(AtLeast(1));
-  EXPECT_CALL(APIMockObj, iota_client_get_trytes(_, _, _)).Times(AtLeast(1));
+  EXPECT_CALL(APIMockObj, iota_client_get_trytes(_, _, _)).Times(AtLeast(0));
 
   EXPECT_EQ(ta_find_transactions_obj_by_tag(&service, req, res), 0);
   for (txn = (const iota_transaction_t*)utarray_front(res->txn_obj);


### PR DESCRIPTION
Add cache operations to ta_get_transaction_object and modify how it checks response, because get_trytes always return trytes even if transaction not found.

Part of #55 