### PR TITLE
Implement api_send_transfer

### DIFF
--- a/accelerator/apis.c
+++ b/accelerator/apis.c
@@ -120,3 +120,45 @@ done:
   ta_find_transactions_obj_res_free(&res);
   return ret;
 }
+
+int api_send_transfer(const iota_client_service_t* const service,
+                      const char* const obj, char** json_result) {
+  int ret = 0;
+  char hash_trytes[NUM_TRYTES_HASH + 1];
+  ta_send_transfer_req_t* req = ta_send_transfer_req_new();
+  ta_send_transfer_res_t* res = ta_send_transfer_res_new();
+  ta_get_transaction_object_res_t* txn_obj_res =
+      ta_get_transaction_object_res_new();
+
+  if (req == NULL || res == NULL || txn_obj_res == NULL) {
+    goto done;
+  }
+
+  ret = ta_send_transfer_req_deserialize(obj, req);
+  if (ret) {
+    goto done;
+  }
+
+  ret = ta_send_transfer(service, req, res);
+  if (ret) {
+    goto done;
+  }
+
+  // return transaction object
+  flex_trits_to_trytes((tryte_t*)hash_trytes, NUM_TRYTES_HASH,
+                       hash243_queue_peek(res->hash), NUM_TRITS_HASH,
+                       NUM_TRITS_HASH);
+  hash_trytes[NUM_TRYTES_HASH] = '\0';
+  ret = ta_get_transaction_object(service, hash_trytes, txn_obj_res);
+  if (ret) {
+    goto done;
+  }
+
+  ret = ta_get_transaction_object_res_serialize(json_result, txn_obj_res);
+
+done:
+  ta_send_transfer_req_free(&req);
+  ta_send_transfer_res_free(&res);
+  ta_get_transaction_object_res_free(&txn_obj_res);
+  return ret;
+}

--- a/accelerator/common_core.c
+++ b/accelerator/common_core.c
@@ -105,6 +105,7 @@ int ta_attach_to_tangle(const attach_to_tangle_req_t* const req,
   bundle_transactions_t* bundle = NULL;
   iota_transaction_t tx;
   flex_trit_t* elt = NULL;
+  pow_init();
 
   // create bundle
   bundle_transactions_new(&bundle);
@@ -134,6 +135,7 @@ int ta_attach_to_tangle(const attach_to_tangle_req_t* const req,
   }
 
 done:
+  pow_destroy();
   bundle_transactions_free(&bundle);
   return ret;
 }

--- a/accelerator/server.cc
+++ b/accelerator/server.cc
@@ -119,7 +119,18 @@ int main(int, char const**) {
       .post([&](served::response& res, const served::request& req) {
         char* json_result;
 
-        api_send_transfer(&service, req.body().c_str(), &json_result);
+        if (req.header("content-type") != "application/json") {
+          cJSON* json_obj = cJSON_CreateObject();
+          cJSON_AddStringToObject(json_obj, "message",
+                                  "Invalid request header");
+          json_result = cJSON_PrintUnformatted(json_obj);
+
+          res.set_status(SC_BAD_REQUEST);
+          cJSON_Delete(json_obj);
+        } else {
+          api_send_transfer(&service, req.body().c_str(), &json_result);
+        }
+
         res.set_header("content-type", "application/json");
         res << json_result;
       });

--- a/accelerator/server.cc
+++ b/accelerator/server.cc
@@ -111,6 +111,20 @@ int main(int, char const**) {
       });
 
   /**
+   * @method {post} /transaction send transfer
+   *
+   * @return {String} transaction object
+   */
+  mux.handle("/transaction")
+      .post([&](served::response& res, const served::request& req) {
+        char* json_result;
+
+        api_send_transfer(&service, req.body().c_str(), &json_result);
+        res.set_header("content-type", "application/json");
+        res << json_result;
+      });
+
+  /**
    * @method {get} / Client bad request
    *
    * @return {String} message Error message

--- a/serializer/serializer.c
+++ b/serializer/serializer.c
@@ -271,27 +271,6 @@ done:
   return ret;
 }
 
-int ta_send_transfer_res_serialize(char** obj,
-                                   const ta_send_transfer_res_t* const res) {
-  cJSON* json_root = cJSON_CreateObject();
-  if (json_root == NULL) {
-    return -1;
-  }
-
-  char trytes_out[NUM_TRYTES_HASH + 1];
-  flex_trits_to_trytes((tryte_t*)trytes_out, NUM_TRYTES_HASH, res->hash->hash,
-                       NUM_TRITS_HASH, NUM_TRITS_HASH);
-  trytes_out[NUM_TRYTES_HASH] = '\0';
-
-  cJSON_AddStringToObject(json_root, "hash", trytes_out);
-  *obj = cJSON_PrintUnformatted(json_root);
-  if (*obj == NULL) {
-    return -1;
-  }
-  cJSON_Delete(json_root);
-  return 0;
-}
-
 int ta_get_transaction_object_res_serialize(
     char** obj, const ta_get_transaction_object_res_t* const res) {
   int ret = 0;

--- a/serializer/serializer.h
+++ b/serializer/serializer.h
@@ -17,8 +17,6 @@ int ta_generate_address_res_serialize(
 int ta_get_tips_res_serialize(char** obj, const ta_get_tips_res_t* const res);
 int ta_send_transfer_req_deserialize(const char* const obj,
                                      ta_send_transfer_req_t* req);
-int ta_send_transfer_res_serialize(char** obj,
-                                   const ta_send_transfer_res_t* const res);
 int ta_get_transaction_object_res_serialize(
     char** obj, const ta_get_transaction_object_res_t* const res);
 int ta_find_transactions_res_serialize(

--- a/tests/test_serializer.c
+++ b/tests/test_serializer.c
@@ -72,22 +72,6 @@ void test_deserialize_ta_send_transfer(void) {
   ta_send_transfer_req_free(&req);
 }
 
-void test_serialize_ta_send_transfer(void) {
-  const char* json = "{\"hash\":\"" TRYTES_81_1 "\"}";
-  char* json_result;
-  flex_trit_t hash_trits_1[FLEX_TRIT_SIZE_243];
-  ta_send_transfer_res_t* res = ta_send_transfer_res_new();
-
-  flex_trits_from_trytes(hash_trits_1, NUM_TRITS_HASH,
-                         (const tryte_t*)TRYTES_81_1, NUM_TRYTES_HASH,
-                         NUM_TRYTES_HASH);
-  hash243_queue_push(&res->hash, hash_trits_1);
-  ta_send_transfer_res_serialize(&json_result, res);
-  TEST_ASSERT_EQUAL_STRING(json, json_result);
-  ta_send_transfer_res_free(&res);
-  free(json_result);
-}
-
 void test_serialize_ta_get_transaction_object(void) {
   const char* json =
       "{\"hash\":\"" TRYTES_81_1 "\","
@@ -273,7 +257,6 @@ int main(void) {
   RUN_TEST(test_serialize_ta_get_tips);
   RUN_TEST(test_serialize_ta_generate_address);
   RUN_TEST(test_deserialize_ta_send_transfer);
-  RUN_TEST(test_serialize_ta_send_transfer);
   RUN_TEST(test_serialize_ta_get_transaction_object);
   RUN_TEST(test_serialize_ta_find_transactions_by_tag);
   RUN_TEST(test_serialize_ta_find_transactions_obj_by_tag);


### PR DESCRIPTION
`ta_send_transfer_res_serialize` is removed because `api_send_transfer` returns the transaction object instead of transaction hash.

Close #8 