### PR TITLE
Update CClient commit in WORKSPACE

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -8,7 +8,7 @@ git_repository(
 
 git_repository(
     name = "entangled",
-    commit = "5d635690759abe9c76b8a17def1e02edb8bb4c8d",
+    commit = "8f160ff30e82bcfd9e15210231aa6a129574799a",
     remote = "https://github.com/iotaledger/entangled.git",
 )
 

--- a/accelerator/apis.h
+++ b/accelerator/apis.h
@@ -2,8 +2,8 @@
 #define ACCELERATOR_APIS_H_
 
 #include "accelerator/common_core.h"
+#include "cclient/types/types.h"
 #include "serializer/serializer.h"
-#include "types/types.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/accelerator/common_core.h
+++ b/accelerator/common_core.h
@@ -4,11 +4,11 @@
 #include "accelerator/config.h"
 #include "cclient/iota_client_core_api.h"
 #include "cclient/iota_client_extended_api.h"
+#include "cclient/types/types.h"
 #include "common/model/bundle.h"
 #include "common/model/transfer.h"
 #include "request/request.h"
 #include "response/response.h"
-#include "types/types.h"
 #include "utils/time.h"
 
 #ifdef __cplusplus

--- a/request/ta_send_transfer.h
+++ b/request/ta_send_transfer.h
@@ -1,7 +1,7 @@
 #ifndef REQUEST_TA_SEND_TRANSFER_H_
 #define REQUEST_TA_SEND_TRANSFER_H_
 
-#include "types/types.h"
+#include "cclient/types/types.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/response/ta_find_transactions.h
+++ b/response/ta_find_transactions.h
@@ -1,7 +1,7 @@
 #ifndef RESPONSE_TA_FIND_TRANSACTIONS_H_
 #define RESPONSE_TA_FIND_TRANSACTIONS_H_
 
-#include "types/types.h"
+#include "cclient/types/types.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/response/ta_find_transactions_obj.h
+++ b/response/ta_find_transactions_obj.h
@@ -1,7 +1,7 @@
 #ifndef RESPONSE_TA_FIND_TRANSACTIONS_OBJ_H_
 #define RESPONSE_TA_FIND_TRANSACTIONS_OBJ_H_
 
-#include "types/types.h"
+#include "cclient/types/types.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/response/ta_generate_address.h
+++ b/response/ta_generate_address.h
@@ -1,7 +1,7 @@
 #ifndef RESPONSE_TA_GENERATE_ADDRESS_H_
 #define RESPONSE_TA_GENERATE_ADDRESS_H_
 
-#include "types/types.h"
+#include "cclient/types/types.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/response/ta_get_tips.h
+++ b/response/ta_get_tips.h
@@ -1,7 +1,7 @@
 #ifndef RESPONSE_TA_GET_TIPS_H_
 #define RESPONSE_TA_GET_TIPS_H_
 
-#include "types/types.h"
+#include "cclient/types/types.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/response/ta_get_transaction_object.h
+++ b/response/ta_get_transaction_object.h
@@ -1,7 +1,7 @@
 #ifndef RESPONSE_TA_GET_TRANSACTION_OBJECT_H_
 #define RESPONSE_TA_GET_TRANSACTION_OBJECT_H_
 
-#include "types/types.h"
+#include "cclient/types/types.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/response/ta_send_transfer.h
+++ b/response/ta_send_transfer.h
@@ -1,7 +1,7 @@
 #ifndef RESPONSE_TA_SEND_TRANSFER_H_
 #define RESPONSE_TA_SEND_TRANSFER_H_
 
-#include "types/types.h"
+#include "cclient/types/types.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/serializer/serializer.c
+++ b/serializer/serializer.c
@@ -6,8 +6,9 @@ void fill_tag(char* new_tag, char* old_tag, size_t tag_len) {
   sprintf(new_tag, "%s%*.*s", old_tag, pad_len, pad_len, nines);
 }
 
-int hash243_stack_to_json_array(hash243_stack_t stack, cJSON* const json_root,
-                                char const* const obj_name) {
+int ta_hash243_stack_to_json_array(hash243_stack_t stack,
+                                   cJSON* const json_root,
+                                   char const* const obj_name) {
   size_t array_count = 0;
   cJSON* array_obj = NULL;
   hash243_stack_entry_t* s_iter = NULL;
@@ -38,8 +39,9 @@ int hash243_stack_to_json_array(hash243_stack_t stack, cJSON* const json_root,
   return 0;
 }
 
-int hash243_queue_to_json_array(hash243_queue_t queue, cJSON* const json_root,
-                                char const* const obj_name) {
+int ta_hash243_queue_to_json_array(hash243_queue_t queue,
+                                   cJSON* const json_root,
+                                   char const* const obj_name) {
   size_t array_count;
   cJSON* array_obj = NULL;
   hash243_queue_entry_t* q_iter = NULL;
@@ -69,9 +71,9 @@ int hash243_queue_to_json_array(hash243_queue_t queue, cJSON* const json_root,
   return 0;
 }
 
-int json_array_to_hash243_queue(cJSON const* const obj,
-                                char const* const obj_name,
-                                hash243_queue_t* queue) {
+int ta_json_array_to_hash243_queue(cJSON const* const obj,
+                                   char const* const obj_name,
+                                   hash243_queue_t* queue) {
   retcode_t ret_code = RC_OK;
   flex_trit_t hash[FLEX_TRIT_SIZE_243] = {};
   cJSON* json_item = cJSON_GetObjectItemCaseSensitive(obj, obj_name);
@@ -198,7 +200,7 @@ int ta_generate_address_res_serialize(
   if (json_root == NULL) {
     return -1;
   }
-  ret = hash243_queue_to_json_array(res->addresses, json_root, "address");
+  ret = ta_hash243_queue_to_json_array(res->addresses, json_root, "address");
   if (ret) {
     return ret;
   }
@@ -217,7 +219,7 @@ int ta_get_tips_res_serialize(char** obj, const ta_get_tips_res_t* const res) {
   if (json_root == NULL) {
     return -1;
   }
-  ret = hash243_stack_to_json_array(res->tips, json_root, "tips");
+  ret = ta_hash243_stack_to_json_array(res->tips, json_root, "tips");
   if (ret) {
     return ret;
   }
@@ -343,7 +345,7 @@ int ta_find_transactions_res_serialize(
     goto done;
   }
 
-  hash243_queue_to_json_array(res->hashes, json_root, "hashes");
+  ta_hash243_queue_to_json_array(res->hashes, json_root, "hashes");
   *obj = cJSON_PrintUnformatted(json_root);
   if (*obj == NULL) {
     ret = -1;

--- a/serializer/serializer.h
+++ b/serializer/serializer.h
@@ -4,9 +4,9 @@
 #include <stdlib.h>
 
 #include "cJSON.h"
+#include "cclient/types/types.h"
 #include "request/request.h"
 #include "response/response.h"
-#include "types/types.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/tests/test_define.h
+++ b/tests/test_define.h
@@ -2,7 +2,7 @@
 #define TESTS_TEST_DEFINE_H_
 
 #include <unity/unity.h>
-#include "types/types.h"
+#include "cclient/types/types.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/utils/cache.h
+++ b/utils/cache.h
@@ -5,7 +5,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include "types/types.h"
+#include "cclient/types/types.h"
 
 /**
  * @file cache.h

--- a/utils/pow.h
+++ b/utils/pow.h
@@ -2,8 +2,8 @@
 #define UTILS_POW_H_
 
 #include <stdint.h>
+#include "cclient/types/types.h"
 #include "common/model/bundle.h"
-#include "types/types.h"
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
* Modify `types.h` include path, include_prefix is removed in CClient
* Rename helper functions in serializer, since the function names are
  same as the one in CClient. Renaming resolves function redefined
  error.

Close #80 