### PR TITLE
fix: Add response header to allow CORS requests

### DIFF
--- a/accelerator/server.cc
+++ b/accelerator/server.cc
@@ -44,6 +44,7 @@ int main(int, char const**) {
         api_find_transactions_by_tag(&service, req.params["tag"].c_str(),
                                      &json_result);
         res.set_header("Content-Type", "application/json");
+        res.set_header("Access-Control-Allow-Origin", "*");
         res << json_result;
       });
 
@@ -65,6 +66,7 @@ int main(int, char const**) {
         api_get_transaction_object(&service, req.params["tx"].c_str(),
                                    &json_result);
         res.set_header("Content-Type", "application/json");
+        res.set_header("Access-Control-Allow-Origin", "*");
         res << json_result;
       });
 
@@ -86,6 +88,7 @@ int main(int, char const**) {
         api_find_transactions_obj_by_tag(&service, req.params["tag"].c_str(),
                                          &json_result);
         res.set_header("Content-Type", "application/json");
+        res.set_header("Access-Control-Allow-Origin", "*");
         res << json_result;
       });
 
@@ -104,6 +107,7 @@ int main(int, char const**) {
 
         api_get_tips_pair(&service, &json_result);
         res.set_header("Content-Type", "application/json");
+        res.set_header("Access-Control-Allow-Origin", "*");
         res << json_result;
       });
 
@@ -122,6 +126,7 @@ int main(int, char const**) {
 
         api_get_tips(&service, &json_result);
         res.set_header("Content-Type", "application/json");
+        res.set_header("Access-Control-Allow-Origin", "*");
         res << json_result;
       });
 
@@ -140,6 +145,7 @@ int main(int, char const**) {
 
         api_generate_address(&service, &json_result);
         res.set_header("Content-Type", "application/json");
+        res.set_header("Access-Control-Allow-Origin", "*");
         res << json_result;
       });
 
@@ -170,6 +176,7 @@ int main(int, char const**) {
         }
 
         res.set_header("Content-Type", "application/json");
+        res.set_header("Access-Control-Allow-Origin", "*");
         res << json_result;
       });
 
@@ -191,6 +198,7 @@ int main(int, char const**) {
 
         res.set_status(SC_BAD_REQUEST);
         res.set_header("Content-Type", "application/json");
+        res.set_header("Access-Control-Allow-Origin", "*");
         res << json;
 
         cJSON_Delete(json_obj);


### PR DESCRIPTION
Since API does not respond with "Access-Control-Allow-Origin" header,
the response data are blocked when calling the API from browser.

To eliminate this problem, add "Access-Control-Allow-Origin" header
to each API response.