### PR TITLE
fix(core): Return error if transaction not found

### DIFF
--- a/accelerator/common_core.c
+++ b/accelerator/common_core.c
@@ -389,6 +389,9 @@ status_t ta_get_transaction_object(const iota_client_service_t* const service,
           (tryte_t*)cache_value, NUM_TRYTES_SERIALIZED_TRANSACTION, tx_trits,
           NUM_TRITS_SERIALIZED_TRANSACTION, NUM_TRITS_SERIALIZED_TRANSACTION);
       cache_set(cache, req, cache_value);
+    } else {
+      ret = SC_CCLIENT_NOT_FOUND;
+      goto done;
     }
   }
 


### PR DESCRIPTION
Return error code if find_transaction_object can't find any result since
default response would be null trytes instead.