### PR TITLE
feat(docker): Add docker image rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,20 @@ Before running tangle-accelerator, please edit binding address/port of accelerat
 $ make && bazel run //accelerator
 ```
 
+### Build from docker
+
+If you prefer building a docker image, tangle-accelerator also provides build rules for it. Note that you still have to edit configurations in `accelerator/config.h`.
+
+```
+$ make && bazel run //accelerator:ta_image
+```
+
+There's also an easier option to pull image from docker hub then simply run with default configs. Please do remember a redis-server is still required in this way.
+
+```
+$ docker run -d --net=host --name tangle-accelerator wusyong/tangel-accelerator:latest
+```
+
 ## Developing
 
 The codebase of this repository follows [Google's C++ guidelines](https://google.github.io/styleguide/cppguide.html):

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -18,6 +18,15 @@ git_repository(
     remote = "https://github.com/meltwater/served.git",
 )
 
+git_repository(
+    name = "io_bazel_rules_docker",
+    remote = "https://github.com/bazelbuild/rules_docker.git",
+    tag = "v0.6.0",
+)
+
 load("@rules_iota//:defs.bzl", "iota_deps")
+load("@io_bazel_rules_docker//cc:image.bzl", _cc_image_repos = "repositories")
 
 iota_deps()
+
+_cc_image_repos()

--- a/accelerator/BUILD
+++ b/accelerator/BUILD
@@ -1,5 +1,7 @@
 package(default_visibility = ["//visibility:public"])
 
+load("@io_bazel_rules_docker//cc:image.bzl", "cc_image")
+
 cc_binary(
     name = "accelerator",
     srcs = ["server.cc"],
@@ -9,6 +11,11 @@ cc_binary(
         ":ta_errors",
         "@served",
     ],
+)
+
+cc_image(
+    name = "ta_image",
+    binary = ":accelerator",
 )
 
 cc_library(


### PR DESCRIPTION
Add docker image support for easier installation. User can now use bazel
rules to build a docker image. The image is also uploaded to docker hub
for faster deployment with default settings.

Resolve #24 