### PR TITLE
feat(config): Move utils initialize/destroy to config

### DIFF
--- a/accelerator/BUILD
+++ b/accelerator/BUILD
@@ -44,7 +44,6 @@ cc_library(
         "//request",
         "//response",
         "//utils:cache",
-        "//utils:pow",
         "@com_github_uthash//:uthash",
         "@entangled//common/model:bundle",
         "@entangled//utils:time",
@@ -58,6 +57,7 @@ cc_library(
     visibility = ["//visibility:public"],
     deps = [
         ":ta_errors",
+        "//utils:pow",
         "@entangled//cclient/api",
         "@entangled//cclient/types",
     ],

--- a/accelerator/BUILD
+++ b/accelerator/BUILD
@@ -43,7 +43,6 @@ cc_library(
         ":ta_errors",
         "//request",
         "//response",
-        "//utils:cache",
         "@com_github_uthash//:uthash",
         "@entangled//common/model:bundle",
         "@entangled//utils:time",
@@ -57,6 +56,7 @@ cc_library(
     visibility = ["//visibility:public"],
     deps = [
         ":ta_errors",
+        "//utils:cache",
         "//utils:pow",
         "@entangled//cclient/api",
         "@entangled//cclient/types",

--- a/accelerator/common_core.c
+++ b/accelerator/common_core.c
@@ -1,6 +1,5 @@
 #include "common_core.h"
 #include <sys/time.h>
-#include "utils/cache.h"
 
 status_t cclient_get_txn_to_approve(const iota_client_service_t* const service,
                                     uint8_t const depth,
@@ -113,7 +112,6 @@ status_t ta_attach_to_tangle(const attach_to_tangle_req_t* const req,
   flex_trit_t* elt = NULL;
   char cache_key[NUM_TRYTES_HASH] = {0};
   char cache_value[NUM_TRYTES_SERIALIZED_TRANSACTION] = {0};
-  cache_init();
 
   // create bundle
   bundle_transactions_new(&bundle);
@@ -154,7 +152,6 @@ status_t ta_attach_to_tangle(const attach_to_tangle_req_t* const req,
   }
 
 done:
-  cache_stop();
   bundle_transactions_free(&bundle);
   return ret;
 }
@@ -355,7 +352,6 @@ status_t ta_get_transaction_object(const iota_client_service_t* const service,
   char cache_value[FLEX_TRIT_SIZE_8019] = {0};
 
   // get raw transaction data of transaction hashes
-  cache_init();
   get_trytes_req_t* get_trytes_req = get_trytes_req_new();
   get_trytes_res_t* get_trytes_res = get_trytes_res_new();
   if (get_trytes_req == NULL || get_trytes_res == NULL) {
@@ -406,7 +402,6 @@ status_t ta_get_transaction_object(const iota_client_service_t* const service,
   transaction_set_hash(res->txn, hash_trits);
 
 done:
-  cache_stop();
   get_trytes_req_free(&get_trytes_req);
   get_trytes_res_free(&get_trytes_res);
   return ret;

--- a/accelerator/common_core.c
+++ b/accelerator/common_core.c
@@ -113,7 +113,7 @@ status_t ta_attach_to_tangle(const attach_to_tangle_req_t* const req,
   flex_trit_t* elt = NULL;
   char cache_key[NUM_TRYTES_HASH] = {0};
   char cache_value[NUM_TRYTES_SERIALIZED_TRANSACTION] = {0};
-  cache_t* cache = cache_init();
+  cache_init();
 
   // create bundle
   bundle_transactions_new(&bundle);
@@ -127,7 +127,7 @@ status_t ta_attach_to_tangle(const attach_to_tangle_req_t* const req,
     flex_trits_to_trytes(
         (tryte_t*)cache_value, NUM_TRYTES_SERIALIZED_TRANSACTION, elt,
         NUM_TRITS_SERIALIZED_TRANSACTION, NUM_TRITS_SERIALIZED_TRANSACTION);
-    ret = cache_set(cache, cache_key, cache_value);
+    ret = cache_set(cache_key, cache_value);
     if (ret) {
       goto done;
     }
@@ -154,7 +154,7 @@ status_t ta_attach_to_tangle(const attach_to_tangle_req_t* const req,
   }
 
 done:
-  cache_stop(&cache);
+  cache_stop();
   bundle_transactions_free(&bundle);
   return ret;
 }
@@ -355,16 +355,16 @@ status_t ta_get_transaction_object(const iota_client_service_t* const service,
   char cache_value[FLEX_TRIT_SIZE_8019] = {0};
 
   // get raw transaction data of transaction hashes
-  cache_t* cache = cache_init();
+  cache_init();
   get_trytes_req_t* get_trytes_req = get_trytes_req_new();
   get_trytes_res_t* get_trytes_res = get_trytes_res_new();
-  if (cache == NULL || get_trytes_req == NULL || get_trytes_res == NULL) {
+  if (get_trytes_req == NULL || get_trytes_res == NULL) {
     ret = SC_CCLIENT_OOM;
     goto done;
   }
 
   // get in cache first, then get from full node if no result in cache
-  ret = cache_get(cache, req, cache_value);
+  ret = cache_get(req, cache_value);
   if (ret == SC_OK) {
     flex_trits_from_trytes(
         tx_trits, NUM_TRITS_SERIALIZED_TRANSACTION, (const tryte_t*)cache_value,
@@ -390,7 +390,7 @@ status_t ta_get_transaction_object(const iota_client_service_t* const service,
       flex_trits_to_trytes(
           (tryte_t*)cache_value, NUM_TRYTES_SERIALIZED_TRANSACTION, tx_trits,
           NUM_TRITS_SERIALIZED_TRANSACTION, NUM_TRITS_SERIALIZED_TRANSACTION);
-      cache_set(cache, req, cache_value);
+      cache_set(req, cache_value);
     } else {
       ret = SC_CCLIENT_NOT_FOUND;
       goto done;
@@ -406,7 +406,7 @@ status_t ta_get_transaction_object(const iota_client_service_t* const service,
   transaction_set_hash(res->txn, hash_trits);
 
 done:
-  cache_stop(&cache);
+  cache_stop();
   get_trytes_req_free(&get_trytes_req);
   get_trytes_res_free(&get_trytes_res);
   return ret;

--- a/accelerator/common_core.c
+++ b/accelerator/common_core.c
@@ -1,7 +1,6 @@
 #include "common_core.h"
 #include <sys/time.h>
 #include "utils/cache.h"
-#include "utils/pow.h"
 
 status_t cclient_get_txn_to_approve(const iota_client_service_t* const service,
                                     uint8_t const depth,
@@ -115,7 +114,6 @@ status_t ta_attach_to_tangle(const attach_to_tangle_req_t* const req,
   char cache_key[NUM_TRYTES_HASH] = {0};
   char cache_value[NUM_TRYTES_SERIALIZED_TRANSACTION] = {0};
   cache_t* cache = cache_init();
-  pow_init();
 
   // create bundle
   bundle_transactions_new(&bundle);
@@ -157,7 +155,6 @@ status_t ta_attach_to_tangle(const attach_to_tangle_req_t* const req,
 
 done:
   cache_stop(&cache);
-  pow_destroy();
   bundle_transactions_free(&bundle);
   return ret;
 }

--- a/accelerator/config.c
+++ b/accelerator/config.c
@@ -41,6 +41,8 @@ status_t ta_config_init(ta_config_t* const info, iota_config_t* const tangle,
   }
   iota_client_extended_init();
 
+  pow_init();
+
   return ret;
 }
 
@@ -48,5 +50,7 @@ void ta_config_destroy(iota_client_service_t* const service) {
   log_info(logger_id, "Destroying IRI connection\n");
   iota_client_extended_destroy();
   iota_client_core_destroy(service);
+
+  pow_destroy();
   logger_helper_release(logger_id);
 }

--- a/accelerator/config.c
+++ b/accelerator/config.c
@@ -43,6 +43,8 @@ status_t ta_config_init(ta_config_t* const info, iota_config_t* const tangle,
 
   pow_init();
 
+  cache_init(REDIS_HOST, REDIS_PORT);
+
   return ret;
 }
 
@@ -52,5 +54,6 @@ void ta_config_destroy(iota_client_service_t* const service) {
   iota_client_core_destroy(service);
 
   pow_destroy();
+  cache_stop();
   logger_helper_release(logger_id);
 }

--- a/accelerator/config.c
+++ b/accelerator/config.c
@@ -41,8 +41,10 @@ status_t ta_config_init(ta_config_t* const info, iota_config_t* const tangle,
   }
   iota_client_extended_init();
 
+  log_info(logger_id, "Initializing PoW implementation context\n");
   pow_init();
 
+  log_info(logger_id, "Initializing cache connection\n");
   cache_init(REDIS_HOST, REDIS_PORT);
 
   return ret;

--- a/accelerator/config.h
+++ b/accelerator/config.h
@@ -5,6 +5,7 @@
 #include "cclient/api/core/core_api.h"
 #include "cclient/api/extended/extended_api.h"
 #include "cclient/types/types.h"
+#include "utils/pow.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/accelerator/config.h
+++ b/accelerator/config.h
@@ -5,6 +5,7 @@
 #include "cclient/api/core/core_api.h"
 #include "cclient/api/extended/extended_api.h"
 #include "cclient/types/types.h"
+#include "utils/cache.h"
 #include "utils/pow.h"
 
 #ifdef __cplusplus

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -86,7 +86,7 @@ cc_library(
     name = "test_define",
     hdrs = ["test_define.h"],
     deps = [
-        "@entangled//cclient/types",
+        "//accelerator:ta_config",
         "@unity",
     ],
 )

--- a/tests/test_cache.c
+++ b/tests/test_cache.c
@@ -22,7 +22,7 @@ void test_cache_set(void) {
 
 int main(void) {
   UNITY_BEGIN();
-  cache_init();
+  cache_init(REDIS_HOST, REDIS_PORT);
   RUN_TEST(test_cache_set);
   RUN_TEST(test_cache_get);
   RUN_TEST(test_cache_del);

--- a/tests/test_cache.c
+++ b/tests/test_cache.c
@@ -2,35 +2,30 @@
 #include "utils/cache.h"
 
 void test_cache_del(void) {
-  cache_t* cache = cache_init();
   const char* key = TRYTES_81_1;
-  cache_del(cache, key);
-  cache_stop(&cache);
+  cache_del(key);
 }
 
 void test_cache_get(void) {
-  cache_t* cache = cache_init();
   const char* key = TRYTES_81_1;
   char res[TRYTES_2673_LEN + 1] = {0};
-  cache_get(cache, key, res);
+  cache_get(key, res);
   res[TRYTES_2673_LEN] = '\0';
   TEST_ASSERT_EQUAL_STRING(res, TRYTES_2673_1);
-  cache_stop(&cache);
 }
 
 void test_cache_set(void) {
-  cache_t* cache = cache_init();
   const char* key = TRYTES_81_1;
   const char* value = TRYTES_2673_1;
-  cache_set(cache, key, value);
-  cache_stop(&cache);
+  cache_set(key, value);
 }
 
 int main(void) {
   UNITY_BEGIN();
-
+  cache_init();
   RUN_TEST(test_cache_set);
   RUN_TEST(test_cache_get);
   RUN_TEST(test_cache_del);
+  cache_stop();
   return UNITY_END();
 }

--- a/tests/test_common.cc
+++ b/tests/test_common.cc
@@ -194,6 +194,8 @@ TEST(GetBundleTest, RetreiveBundleTest) {
 }
 
 int main(int argc, char** argv) {
+  // GTest manage to cleanup after testing, so only need to initialize here
+  cache_init(REDIS_HOST, REDIS_PORT);
   ::testing::GTEST_FLAG(throw_on_failure) = true;
   ::testing::InitGoogleMock(&argc, argv);
   return RUN_ALL_TESTS();

--- a/tests/test_define.h
+++ b/tests/test_define.h
@@ -2,7 +2,7 @@
 #define TESTS_TEST_DEFINE_H_
 
 #include <unity/unity.h>
-#include "cclient/types/types.h"
+#include "accelerator/config.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/utils/BUILD
+++ b/utils/BUILD
@@ -17,7 +17,6 @@ cc_library(
     srcs = ["pow.c"],
     hdrs = ["pow.h"],
     deps = [
-        "//accelerator:ta_config",
         "//accelerator:ta_errors",
         "//third_party:dcurl",
         "@entangled//cclient/types",

--- a/utils/BUILD
+++ b/utils/BUILD
@@ -5,7 +5,6 @@ cc_library(
     srcs = ["backend_redis.c"],
     hdrs = ["cache.h"],
     deps = [
-        "//accelerator:ta_config",
         "//accelerator:ta_errors",
         "//third_party:hiredis",
         "@entangled//cclient/types",

--- a/utils/backend_redis.c
+++ b/utils/backend_redis.c
@@ -1,4 +1,3 @@
-#include "accelerator/config.h"
 #include "cache.h"
 #include "third_party/hiredis/hiredis.h"
 
@@ -70,9 +69,9 @@ static status_t redis_set(redisContext* c, const char* const key,
  * Public functions
  */
 
-bool cache_init() {
+bool cache_init(const char* host, int port) {
   cache.conn = (connection_private*)malloc(sizeof(connection_private));
-  CONN(cache)->rc = redisConnect(REDIS_HOST, REDIS_PORT);
+  CONN(cache)->rc = redisConnect(host, port);
   if (CONN(cache)->rc) {
     return true;
   }

--- a/utils/backend_redis.c
+++ b/utils/backend_redis.c
@@ -6,7 +6,9 @@
 typedef struct {
   redisContext* rc;
 } connection_private;
-#define CONN(c) ((connection_private*)(c->conn))
+#define CONN(c) ((connection_private*)(c.conn))
+
+static cache_t cache;
 
 /*
  * Private functions
@@ -68,39 +70,33 @@ static status_t redis_set(redisContext* c, const char* const key,
  * Public functions
  */
 
-cache_t* cache_init() {
-  cache_t* cache = (cache_t*)malloc(sizeof(cache_t));
-  if (cache != NULL) {
-    cache->conn = (connection_private*)malloc(sizeof(connection_private));
-    CONN(cache)->rc = redisConnect(REDIS_HOST, REDIS_PORT);
-    return cache;
+bool cache_init() {
+  cache.conn = (connection_private*)malloc(sizeof(connection_private));
+  CONN(cache)->rc = redisConnect(REDIS_HOST, REDIS_PORT);
+  if (CONN(cache)->rc) {
+    return true;
   }
-  return NULL;
+  return false;
 }
 
-void cache_stop(cache_t** cache) {
-  if (*cache) {
-    redisFree(CONN((*cache))->rc);
+void cache_stop() {
+  if (CONN(cache)->rc) {
+    redisFree(CONN(cache)->rc);
 
-    if (CONN((*cache))) {
-      free(CONN((*cache)));
+    if (CONN(cache)) {
+      free(CONN(cache));
     }
-
-    free(*cache);
-    *cache = NULL;
   }
 }
 
-status_t cache_del(const cache_t* const cache, const char* const key) {
+status_t cache_del(const char* const key) {
   return redis_del(CONN(cache)->rc, key);
 }
 
-status_t cache_get(const cache_t* const cache, const char* const key,
-                   char* res) {
+status_t cache_get(const char* const key, char* res) {
   return redis_get(CONN(cache)->rc, key, res);
 }
 
-status_t cache_set(const cache_t* const cache, const char* const key,
-                   const char* const value) {
+status_t cache_set(const char* const key, const char* const value) {
   return redis_set(CONN(cache)->rc, key, value);
 }

--- a/utils/cache.h
+++ b/utils/cache.h
@@ -25,45 +25,40 @@ typedef struct {
  * Initiate cache module
  *
  * @return
- * - struct of cache_t on success
- * - NULL on error
+ * - True on success
+ * - False on error
  */
-cache_t* cache_init();
+bool cache_init();
 
 /**
  * Stop interacting with cache module
  *
- * @param cache Data type for Cache module
- *
  * @return NULL
  */
-void cache_stop(cache_t** cache);
+void cache_stop();
 
 /**
  * Delete certain key-value store from cache
  *
- * @param[in] cache Data type for Cache module
  * @param[in] key Key string to search
  *
  * @return
  * - SC_OK on success
- * - 1 on error
+ * - non-zero on error
  */
-status_t cache_del(const cache_t* const cache, const char* const key);
+status_t cache_del(const char* const key);
 
 /**
  * Get key-value store from in-memory cache
  *
- * @param[in] cache Data type for Cache module
  * @param[in] key Key string to search
  * @param[out] res Result of GET key
  *
  * @return
  * - SC_OK on success
- * - 1 on error
+ * - non-zero on error
  */
-status_t cache_get(const cache_t* const cache, const char* const key,
-                   char* res);
+status_t cache_get(const char* const key, char* res);
 
 /**
  * Set key-value store into in-memory cache
@@ -74,10 +69,9 @@ status_t cache_get(const cache_t* const cache, const char* const key,
  *
  * @return
  * - SC_OK on success
- * - 1 on error
+ * - non-zero on error
  */
-status_t cache_set(const cache_t* const cache, const char* const key,
-                   const char* const value);
+status_t cache_set(const char* const key, const char* const value);
 
 #ifdef __cplusplus
 }

--- a/utils/cache.h
+++ b/utils/cache.h
@@ -8,6 +8,10 @@
 #include "accelerator/errors.h"
 #include "cclient/types/types.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * @file cache.h
  * @brief Implementation of cache interface
@@ -24,11 +28,14 @@ typedef struct {
 /**
  * Initiate cache module
  *
+ * @param[in] host cache server host
+ * @param[in] port cache server port
+ *
  * @return
  * - True on success
  * - False on error
  */
-bool cache_init();
+bool cache_init(const char* host, int port);
 
 /**
  * Stop interacting with cache module


### PR DESCRIPTION
Move initialize and destroy of utils interfaces to config. This PR also refactor cache interface for the need of configuration. Following modules are affected:
- cache
- pow

Part of #114  
