### PR TITLE
feat(mam): Implement send_mam_req

### DIFF
--- a/request/BUILD
+++ b/request/BUILD
@@ -10,5 +10,6 @@ cc_library(
     visibility = ["//visibility:public"],
     deps = [
         "@entangled//cclient/types",
+        "//accelerator:ta_errors",
     ],
 )

--- a/request/request.h
+++ b/request/request.h
@@ -1,6 +1,7 @@
 #ifndef REQUEST_REQUEST_H_
 #define REQUEST_REQUEST_H_
 
+#include "request/ta_send_mam_req.h"
 #include "request/ta_send_transfer.h"
 
 /**

--- a/request/ta_send_mam_req.c
+++ b/request/ta_send_mam_req.c
@@ -1,0 +1,40 @@
+#include "ta_send_mam_req.h"
+
+send_mam_req_t* send_mam_req_new() {
+  send_mam_req_t* req = (send_mam_req_t*)malloc(sizeof(send_mam_req_t));
+  if (req) {
+    req->payload_trytes = NULL;
+  }
+
+  return req;
+}
+
+status_t send_mam_req_set_payload(send_mam_req_t* req, const tryte_t* payload) {
+  status_t ret = SC_OK;
+  size_t payload_size = sizeof(payload) / sizeof(tryte_t);
+
+  if ((!payload) || (payload_size == 0) || ((payload_size * 3) > SIZE_MAX)) {
+    return SC_MAM_OOM;
+  }
+
+  req->payload_trytes = (tryte_t*)malloc(payload_size * sizeof(tryte_t));
+  if (!req->payload_trytes) {
+    return SC_MAM_OOM;
+  }
+  memcpy(req->payload_trytes, payload, payload_size);
+  req->payload_trytes_size = payload_size;
+
+  return ret;
+}
+
+void send_mam_req_free(send_mam_req_t** req) {
+  if (!req || !(*req)) {
+    return;
+  }
+  if ((*req)->payload_trytes) {
+    free((*req)->payload_trytes);
+    (*req)->payload_trytes = NULL;
+  }
+  free(*req);
+  *req = NULL;
+}

--- a/request/ta_send_mam_req.h
+++ b/request/ta_send_mam_req.h
@@ -1,0 +1,27 @@
+#ifndef REQUEST_TA_SEND_MAM_REQ_H_
+#define REQUEST_TA_SEND_MAM_REQ_H_
+
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+#include "accelerator/errors.h"
+#include "cclient/types/types.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct send_mam_req_s {
+  tryte_t* payload_trytes;
+  size_t payload_trytes_size;
+} send_mam_req_t;
+
+send_mam_req_t* send_mam_req_new();
+status_t send_mam_req_set_payload(send_mam_req_t* req, const tryte_t* payload);
+void send_mam_req_free(send_mam_req_t** req);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // REQUEST_TA_SEND_MAM_REQ_H_


### PR DESCRIPTION
Use send_mam_req object to simplify the arg of api_mam_send_message().