### PR TITLE
feat(mam): Implement send_mam_res object

### DIFF
--- a/accelerator/errors.h
+++ b/accelerator/errors.h
@@ -40,6 +40,7 @@ extern "C" {
 #define SC_MODULE_SERIALIZER (0x03 << SC_MODULE_SHIFT)
 #define SC_MODULE_CACHE (0x04 << SC_MODULE_SHIFT)
 #define SC_MODULE_MAM (0x05 << SC_MODULE_SHIFT)
+#define SC_MODULE_RES (0x06 << SC_MODULE_SHIFT)
 /** @} */
 
 /** @name serverity code */
@@ -105,6 +106,12 @@ typedef enum {
   /**< No payload or no chid */
   SC_MAM_FAILED_WRITE = 0x08 | SC_MODULE_MAM | SC_SEVERITY_FATAL,
   /**< Failed to write */
+
+  // response module
+  SC_RES_OOM = 0x01 | SC_MODULE_RES | SC_SEVERITY_FATAL,
+  /**< Fail to create response object */
+  SC_RES_NULL = 0x02 | SC_MODULE_RES | SC_SEVERITY_FATAL,
+  /**< NULL object in response */
 } status_t;
 
 typedef enum {

--- a/response/BUILD
+++ b/response/BUILD
@@ -10,5 +10,7 @@ cc_library(
     visibility = ["//visibility:public"],
     deps = [
         "@entangled//cclient/types",
+        "@entangled//common/model:transaction",
+        "//accelerator:ta_errors",
     ],
 )

--- a/response/response.h
+++ b/response/response.h
@@ -6,6 +6,7 @@
 #include "response/ta_generate_address.h"
 #include "response/ta_get_tips.h"
 #include "response/ta_get_transaction_object.h"
+#include "response/ta_send_mam_res.h"
 #include "response/ta_send_transfer.h"
 
 /**

--- a/response/ta_send_mam_res.c
+++ b/response/ta_send_mam_res.c
@@ -1,0 +1,60 @@
+#include "ta_send_mam_res.h"
+
+send_mam_res_t* send_mam_res_new() {
+  send_mam_res_t* res = (send_mam_res_t*)malloc(sizeof(send_mam_res_t));
+  if (res) {
+    res->bundle_hash = NULL;
+    res->channel_id = NULL;
+  }
+
+  return res;
+}
+
+status_t send_mam_res_set_bundle_hash(send_mam_res_t* res,
+                                      const tryte_t* bundle_hash) {
+  if (res->bundle_hash || !bundle_hash) {
+    return SC_RES_NULL;
+  }
+
+  size_t bundle_hash_size = NUM_TRYTES_ADDRESS * sizeof(char);
+  res->bundle_hash = (char*)malloc(bundle_hash_size);
+  if (!res->bundle_hash) {
+    return SC_RES_OOM;
+  }
+
+  memcpy(res->bundle_hash, bundle_hash, bundle_hash_size);
+  return SC_OK;
+}
+
+status_t send_mam_res_set_channel_id(send_mam_res_t* res,
+                                     const tryte_t* channel_id) {
+  if (res->channel_id || !channel_id) {
+    return SC_RES_NULL;
+  }
+
+  size_t channel_id_size = NUM_TRYTES_ADDRESS * sizeof(char);
+  res->channel_id = (char*)malloc(channel_id_size);
+  if (!res->channel_id) {
+    return SC_RES_OOM;
+  }
+
+  memcpy(res->channel_id, channel_id, channel_id_size);
+  return SC_OK;
+}
+
+void send_mam_res_free(send_mam_res_t** res) {
+  if (!res || !(*res)) {
+    return;
+  }
+  if ((*res)->bundle_hash) {
+    free((*res)->bundle_hash);
+    (*res)->bundle_hash = NULL;
+  }
+  if ((*res)->channel_id) {
+    free((*res)->channel_id);
+    (*res)->channel_id = NULL;
+  }
+
+  free(*res);
+  *res = NULL;
+}

--- a/response/ta_send_mam_res.h
+++ b/response/ta_send_mam_res.h
@@ -1,0 +1,79 @@
+#ifndef RESPONSE_TA_SEND_MAM_RES_H_
+#define RESPONSE_TA_SEND_MAM_RES_H_
+
+#include "accelerator/errors.h"
+#include "common/model/transaction.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @file response/ta_send_mam_res.h
+ */
+
+/** struct of ta_send_mam_res_t */
+typedef struct send_mam_res_s {
+  /** ascii string bundle hash */
+  char* bundle_hash;
+  /** ascii string channel id */
+  char* channel_id;
+} send_mam_res_t;
+
+/**
+ * Allocate memory of send_mam_res_t
+ *
+ * @return
+ * - struct of send_mam_res_t on success
+ * - NULL on error
+ */
+send_mam_res_t* send_mam_res_new();
+
+/**
+ * @brief Set the bundle_hash field of send_mam_res object.
+ *
+ * Receive a bundle hash tryte_t array which is 81 trytes long,
+ * and convert (instead of decoding) the received bundle hash to ascii string.
+ * After conversion, set the  bundle_hash field of send_mam_res object.
+ *
+ * @param[in] res send_mam_res_t struct object
+ * @param[in] bundle_hash bundle hash decoded in trytes string
+ *
+ * @return
+ * - SC_OK on success
+ * - non-zero on error
+ */
+status_t send_mam_res_set_bundle_hash(send_mam_res_t* res,
+                                      const tryte_t* bundle_hash);
+
+/**
+ * @brief Set the channel_id field of send_mam_res object.
+ *
+ * Receive a channel id tryte_t array which is 81 trytes long,
+ * and convert (instead of decoding) the received channel id to ascii string.
+ * After conversion, set the  channel_id field of send_mam_res object.
+ *
+ * @param[in] res send_mam_res_t struct object
+ * @param[in] channel_id channel id decoded in trytes string
+ *
+ * @return
+ * - SC_OK on success
+ * - non-zero on error
+ */
+status_t send_mam_res_set_channel_id(send_mam_res_t* res,
+                                     const tryte_t* channel_id);
+
+/**
+ * Free memory of send_mam_res_t
+ *
+ * @param req Data type of send_mam_res_t
+ *
+ * @return NULL
+ */
+void send_mam_res_free(send_mam_res_t** res);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // RESPONSE_TA_SEND_MAM_RES_H_


### PR DESCRIPTION
Use send_mam_res object to simplify the arg of api_mam_send_message().