### PR TITLE
feat(serializer): Add send_mam_message (de)serializer

### DIFF
--- a/accelerator/BUILD
+++ b/accelerator/BUILD
@@ -28,7 +28,6 @@ cc_library(
         ":ta_errors",
         "//serializer",
         "@entangled//common/trinary:trit_tryte",
-        "@entangled//common/trinary:tryte_ascii",
         "@entangled//mam/api",
     ],
 )

--- a/accelerator/apis.h
+++ b/accelerator/apis.h
@@ -5,7 +5,6 @@
 #include "accelerator/errors.h"
 #include "cclient/types/types.h"
 #include "common/trinary/trit_tryte.h"
-#include "common/trinary/tryte_ascii.h"
 #include "mam/api/api.h"
 #include "mam/mam/mam_channel_t_set.h"
 #include "serializer/serializer.h"
@@ -102,8 +101,7 @@ status_t api_receive_mam_message(const iota_client_service_t* const service,
  * @param[in] tangle IOTA API parameter configurations
  * @param[in] service IRI node end point service
  * @param[in] payload message to send undecoded ascii string.
- * @param[out] bundle_hashes_result the bundle hash of sent message
- * @param[out] channel_id_result the channel id the sent message to
+ * @param[out] json_result Result containing channel id and bundle hash
  *
  * @return
  * - SC_OK on success
@@ -111,9 +109,7 @@ status_t api_receive_mam_message(const iota_client_service_t* const service,
  */
 status_t api_mam_send_message(const iota_config_t* const tangle,
                               const iota_client_service_t* const service,
-                              char const* const payload,
-                              char** bundle_hash_result,
-                              char** channel_id_result);
+                              char const* const payload, char** json_result);
 
 /**
  * @brief Send transfer to tangle.

--- a/accelerator/server.cc
+++ b/accelerator/server.cc
@@ -87,7 +87,6 @@ int main(int, char const**) {
       .post([&](served::response& res, const served::request& req) {
         status_t ret = SC_OK;
         char* json_result;
-        char* chid_result;
 
         if (req.header("content-type").find("application/json") ==
             std::string::npos) {
@@ -100,7 +99,7 @@ int main(int, char const**) {
           cJSON_Delete(json_obj);
         } else {
           api_mam_send_message(&ta_core.tangle, &ta_core.service,
-                               req.body().c_str(), &json_result, &chid_result);
+                               req.body().c_str(), &json_result);
           ret = set_response_content(ret, &json_result);
           res.set_status(ret);
         }

--- a/request/BUILD
+++ b/request/BUILD
@@ -9,7 +9,7 @@ cc_library(
     include_prefix = "request",
     visibility = ["//visibility:public"],
     deps = [
-        "@entangled//cclient/types",
         "//accelerator:ta_errors",
+        "@entangled//cclient/types",
     ],
 )

--- a/request/request.h
+++ b/request/request.h
@@ -1,7 +1,7 @@
 #ifndef REQUEST_REQUEST_H_
 #define REQUEST_REQUEST_H_
 
-#include "request/ta_send_mam_req.h"
+#include "request/ta_send_mam.h"
 #include "request/ta_send_transfer.h"
 
 /**

--- a/request/ta_send_mam.c
+++ b/request/ta_send_mam.c
@@ -1,4 +1,4 @@
-#include "ta_send_mam_req.h"
+#include "ta_send_mam.h"
 
 send_mam_req_t* send_mam_req_new() {
   send_mam_req_t* req = (send_mam_req_t*)malloc(sizeof(send_mam_req_t));

--- a/request/ta_send_mam.h
+++ b/request/ta_send_mam.h
@@ -1,5 +1,5 @@
-#ifndef REQUEST_TA_SEND_MAM_REQ_H_
-#define REQUEST_TA_SEND_MAM_REQ_H_
+#ifndef REQUEST_TA_SEND_MAM_H_
+#define REQUEST_TA_SEND_MAM_H_
 
 #include "accelerator/errors.h"
 #include "cclient/types/types.h"
@@ -21,4 +21,4 @@ void send_mam_req_free(send_mam_req_t** req);
 }
 #endif
 
-#endif  // REQUEST_TA_SEND_MAM_REQ_H_
+#endif  // REQUEST_TA_SEND_MAM_H_

--- a/response/BUILD
+++ b/response/BUILD
@@ -9,8 +9,8 @@ cc_library(
     include_prefix = "response",
     visibility = ["//visibility:public"],
     deps = [
+        "//accelerator:ta_errors",
         "@entangled//cclient/types",
         "@entangled//common/model:transaction",
-        "//accelerator:ta_errors",
     ],
 )

--- a/response/response.h
+++ b/response/response.h
@@ -6,7 +6,7 @@
 #include "response/ta_generate_address.h"
 #include "response/ta_get_tips.h"
 #include "response/ta_get_transaction_object.h"
-#include "response/ta_send_mam_res.h"
+#include "response/ta_send_mam.h"
 #include "response/ta_send_transfer.h"
 
 /**

--- a/response/ta_send_mam.c
+++ b/response/ta_send_mam.c
@@ -2,57 +2,35 @@
 
 send_mam_res_t* send_mam_res_new() {
   send_mam_res_t* res = (send_mam_res_t*)malloc(sizeof(send_mam_res_t));
-  if (res) {
-    res->bundle_hash = NULL;
-    res->channel_id = NULL;
-  }
 
   return res;
 }
 
 status_t send_mam_res_set_bundle_hash(send_mam_res_t* res,
                                       const tryte_t* bundle_hash) {
-  if (res->bundle_hash || !bundle_hash) {
+  if (!bundle_hash || !res) {
     return SC_RES_NULL;
   }
 
-  size_t bundle_hash_size = NUM_TRYTES_ADDRESS * sizeof(char);
-  res->bundle_hash = (char*)malloc(bundle_hash_size);
-  if (!res->bundle_hash) {
-    return SC_RES_OOM;
-  }
-
-  memcpy(res->bundle_hash, bundle_hash, bundle_hash_size);
+  memcpy(res->bundle_hash, bundle_hash, NUM_TRYTES_HASH);
+  res->bundle_hash[NUM_TRYTES_HASH] = '\0';
   return SC_OK;
 }
 
 status_t send_mam_res_set_channel_id(send_mam_res_t* res,
                                      const tryte_t* channel_id) {
-  if (res->channel_id || !channel_id) {
+  if (!channel_id || !res) {
     return SC_RES_NULL;
   }
 
-  size_t channel_id_size = NUM_TRYTES_ADDRESS * sizeof(char);
-  res->channel_id = (char*)malloc(channel_id_size);
-  if (!res->channel_id) {
-    return SC_RES_OOM;
-  }
-
-  memcpy(res->channel_id, channel_id, channel_id_size);
+  memcpy(res->channel_id, channel_id, NUM_TRYTES_HASH);
+  res->channel_id[NUM_TRYTES_HASH] = '\0';
   return SC_OK;
 }
 
 void send_mam_res_free(send_mam_res_t** res) {
   if (!res || !(*res)) {
     return;
-  }
-  if ((*res)->bundle_hash) {
-    free((*res)->bundle_hash);
-    (*res)->bundle_hash = NULL;
-  }
-  if ((*res)->channel_id) {
-    free((*res)->channel_id);
-    (*res)->channel_id = NULL;
   }
 
   free(*res);

--- a/response/ta_send_mam.c
+++ b/response/ta_send_mam.c
@@ -1,4 +1,4 @@
-#include "ta_send_mam_res.h"
+#include "ta_send_mam.h"
 
 send_mam_res_t* send_mam_res_new() {
   send_mam_res_t* res = (send_mam_res_t*)malloc(sizeof(send_mam_res_t));

--- a/response/ta_send_mam.h
+++ b/response/ta_send_mam.h
@@ -15,9 +15,9 @@ extern "C" {
 /** struct of ta_send_mam_res_t */
 typedef struct send_mam_res_s {
   /** ascii string bundle hash */
-  char* bundle_hash;
+  char bundle_hash[NUM_TRYTES_HASH + 1];
   /** ascii string channel id */
-  char* channel_id;
+  char channel_id[NUM_TRYTES_HASH + 1];
 } send_mam_res_t;
 
 /**

--- a/response/ta_send_mam.h
+++ b/response/ta_send_mam.h
@@ -1,5 +1,5 @@
-#ifndef RESPONSE_TA_SEND_MAM_RES_H_
-#define RESPONSE_TA_SEND_MAM_RES_H_
+#ifndef RESPONSE_TA_SEND_MAM_H_
+#define RESPONSE_TA_SEND_MAM_H_
 
 #include "accelerator/errors.h"
 #include "common/model/transaction.h"
@@ -76,4 +76,4 @@ void send_mam_res_free(send_mam_res_t** res);
 }
 #endif
 
-#endif  // RESPONSE_TA_SEND_MAM_RES_H_
+#endif  // RESPONSE_TA_SEND_MAM_H_

--- a/serializer/BUILD
+++ b/serializer/BUILD
@@ -11,5 +11,6 @@ cc_library(
         "//response",
         "@cJSON",
         "@entangled//cclient/types",
+        "@entangled//common/trinary:tryte_ascii",
     ],
 )

--- a/serializer/serializer.h
+++ b/serializer/serializer.h
@@ -6,6 +6,7 @@
 #include "accelerator/errors.h"
 #include "cJSON.h"
 #include "cclient/types/types.h"
+#include "common/trinary/tryte_ascii.h"
 #include "request/request.h"
 #include "response/response.h"
 
@@ -122,6 +123,30 @@ status_t ta_find_transactions_obj_res_serialize(
  * - non-zero on error
  */
 status_t receive_mam_message_serialize(char** obj, const char** res);
+
+/**
+ * @brief Serialze type of send_mam_res_t to JSON string
+ *
+ * @param[out] obj send mam response object in JSON
+ * @param[in] res Response data in type of send_mam_res_t
+ *
+ * @return
+ * - SC_OK on success
+ * - non-zero on error
+ */
+status_t send_mam_res_serialize(char** obj, const send_mam_res_t* const res);
+
+/**
+ * @brief Deserialze JSON string to type of send_mam_req_t
+ *
+ * @param[in] obj Input values in JSON
+ * @param[out] req Request data in type of send_mam_req_t
+ *
+ * @return
+ * - SC_OK on success
+ * - non-zero on error
+ */
+status_t send_mam_req_deserialize(const char* const obj, send_mam_req_t* req);
 #ifdef __cplusplus
 }
 #endif

--- a/tests/driver.c
+++ b/tests/driver.c
@@ -149,30 +149,16 @@ void test_find_transactions_obj_by_tag(void) {
 
 void test_send_mam_message(void) {
   double sum = 0;
-
-  char* bundle_hash_result;
-  char* channel_id_result;
+  const char* json = "{\"message\":\"" TEST_PAYLOAD "\"}";
+  char* json_result;
 
   for (size_t count = 0; count < TEST_COUNT; count++) {
     test_time_start(&start_time);
     TEST_ASSERT_EQUAL_INT32(
-        SC_OK,
-        api_mam_send_message(&ta_core.tangle, &ta_core.service, TEST_PAYLOAD,
-                             &bundle_hash_result, &channel_id_result));
+        SC_OK, api_mam_send_message(&ta_core.tangle, &ta_core.service, json,
+                                    &json_result));
     test_time_end(&start_time, &end_time, &sum);
-
-    for (size_t i = 0; i < FLEX_TRIT_SIZE_243; i++) {
-      printf("%c", channel_id_result[i]);
-    }
-    printf("\n");
-    printf("Bundle: ");
-    for (size_t i = 0; i < FLEX_TRIT_SIZE_243; i++) {
-      printf("%c", bundle_hash_result[i]);
-    }
-    printf("\n");
-
-    free(bundle_hash_result);
-    free(channel_id_result);
+    free(json_result);
   }
   printf("Average time of receive_mam_message: %lf\n", sum / TEST_COUNT);
 }

--- a/tests/test_serializer.c
+++ b/tests/test_serializer.c
@@ -251,6 +251,41 @@ void test_serialize_ta_find_transactions_obj_by_tag(void) {
   transaction_free(txn);
   free(json_result);
 }
+
+void test_serialize_send_mam_message(void) {
+  const char* json = "{\"channel\":\"" TRYTES_81_1
+                     "\","
+                     "\"bundle_hash\":\"" TRYTES_81_2 "\"}";
+  char* json_result;
+  send_mam_res_t* res = send_mam_res_new();
+
+  send_mam_res_set_bundle_hash(res, (tryte_t*)TRYTES_81_2);
+  send_mam_res_set_channel_id(res, (tryte_t*)TRYTES_81_1);
+
+  send_mam_res_serialize(&json_result, res);
+  TEST_ASSERT_EQUAL_STRING(json, json_result);
+
+  free(json_result);
+  send_mam_res_free(&res);
+}
+
+void test_deserialize_send_mam_message(void) {
+  const char* json = "{\"message\":\"" TEST_PAYLOAD "\"}";
+  send_mam_req_t* req = send_mam_req_new();
+
+  send_mam_req_deserialize(json, req);
+
+  size_t payload_size = strlen(TEST_PAYLOAD) * 2;
+  tryte_t* payload_trytes = (tryte_t*)malloc(payload_size * sizeof(tryte_t));
+  ascii_to_trytes(TEST_PAYLOAD, payload_trytes);
+
+  TEST_ASSERT_EQUAL_UINT(payload_size, req->payload_trytes_size);
+  TEST_ASSERT_EQUAL_MEMORY(payload_trytes, req->payload_trytes, payload_size);
+
+  free(payload_trytes);
+  send_mam_req_free(&req);
+}
+
 int main(void) {
   UNITY_BEGIN();
 
@@ -260,5 +295,7 @@ int main(void) {
   RUN_TEST(test_serialize_ta_get_transaction_object);
   RUN_TEST(test_serialize_ta_find_transactions_by_tag);
   RUN_TEST(test_serialize_ta_find_transactions_obj_by_tag);
+  RUN_TEST(test_serialize_send_mam_message);
+  RUN_TEST(test_deserialize_send_mam_message);
   return UNITY_END();
 }


### PR DESCRIPTION
This PR contains following changes:
- Rename send_mam request/response type to unity with other types
- Add send_mam request/ response (de)serializer and test case
- Apply (de)serializer to send_mam API