### PR TITLE
feat(conf): Implement CLI configuration interface

### DIFF
--- a/accelerator/BUILD
+++ b/accelerator/BUILD
@@ -54,6 +54,7 @@ cc_library(
     hdrs = ["config.h"],
     visibility = ["//visibility:public"],
     deps = [
+        ":message",
         ":ta_errors",
         "//utils:cache",
         "//utils:pow",

--- a/accelerator/config.c
+++ b/accelerator/config.c
@@ -5,10 +5,74 @@
 
 static logger_id_t logger_id;
 
-status_t ta_config_init(ta_config_t* const info, iota_config_t* const tangle,
-                        iota_client_service_t* const service) {
+struct option* cli_build_options() {
+  struct option* long_options =
+      (struct option*)malloc(cli_cmd_num * sizeof(struct option));
+  for (int i = 0; i < cli_cmd_num; ++i) {
+    long_options[i].name = ta_cli_arguments_g[i].name;
+    long_options[i].has_arg = ta_cli_arguments_g[i].has_arg;
+    long_options[i].flag = NULL;
+    long_options[i].val = ta_cli_arguments_g[i].val;
+  }
+  return long_options;
+}
+
+status_t cli_config_set(ta_config_t* const info, iota_config_t* const tangle,
+                        ta_cache_t* const cache,
+                        iota_client_service_t* const service, int key,
+                        char* const value) {
+  if (value == NULL || info == NULL || tangle == NULL || cache == NULL ||
+      service == NULL) {
+    return SC_CONF_NULL;
+  }
+  switch (key) {
+    // TA configuration
+    case TA_HOST_CLI:
+      info->host = value;
+      break;
+    case TA_PORT_CLI:
+      info->port = value;
+      break;
+    case TA_THREAD_COUNT_CLI:
+      info->thread_count = atoi(value);
+      break;
+
+    // IRI configuration
+    case IRI_HOST_CLI:
+      service->http.host = value;
+      break;
+    case IRI_PORT_CLI:
+      service->http.port = atoi(value);
+      break;
+
+    // Cache configuration
+    case REDIS_HOST_CLI:
+      cache->host = value;
+      break;
+    case REDIS_PORT_CLI:
+      cache->port = atoi(value);
+      break;
+
+    // Tangle configuration
+    case MILESTONE_DEPTH_CLI:
+      tangle->milestone_depth = atoi(value);
+      break;
+    case MWM_CLI:
+      tangle->mwm = atoi(value);
+      break;
+    case SEED_CLI:
+      tangle->seed = value;
+      break;
+  }
+  return SC_OK;
+}
+
+status_t ta_config_default_init(ta_config_t* const info,
+                                iota_config_t* const tangle,
+                                ta_cache_t* const cache,
+                                iota_client_service_t* const service) {
   status_t ret = SC_OK;
-  if (info == NULL || tangle == NULL || service == NULL) {
+  if (info == NULL || tangle == NULL || cache == NULL || service == NULL) {
     return SC_TA_NULL;
   }
 
@@ -21,6 +85,10 @@ status_t ta_config_init(ta_config_t* const info, iota_config_t* const tangle,
   info->host = TA_HOST;
   info->port = TA_PORT;
   info->thread_count = TA_THREAD_COUNT;
+
+  log_info(logger_id, "Initializing Redis information\n");
+  cache->host = REDIS_HOST;
+  cache->port = REDIS_PORT;
 
   log_info(logger_id, "Initializing IRI configuration\n");
   tangle->milestone_depth = MILESTONE_DEPTH;
@@ -36,6 +104,49 @@ status_t ta_config_init(ta_config_t* const info, iota_config_t* const tangle,
   service->http.port = IRI_PORT;
   service->http.api_version = 1;
   service->serializer_type = SR_JSON;
+  return ret;
+}
+
+status_t ta_config_cli_init(ta_core_t* const conf, int argc, char** argv) {
+  int key = 0;
+  status_t ret = SC_OK;
+  struct option* long_options = cli_build_options();
+
+  while ((key = getopt_long(argc, argv, "hv", long_options, NULL)) != -1) {
+    switch (key) {
+      case ':':
+        ret = SC_CONF_MISSING_ARGUMENT;
+        break;
+      case '?':
+        ret = SC_CONF_UNKNOWN_OPTION;
+        break;
+      case 'h':
+        ta_usage();
+        exit(EXIT_SUCCESS);
+      case 'v':
+        printf("%s\n", TA_VERSION);
+        exit(EXIT_SUCCESS);
+      default:
+        ret = cli_config_set(&conf->info, &conf->tangle, &conf->cache,
+                             &conf->service, key, optarg);
+        break;
+    }
+    if (ret != SC_OK) {
+      break;
+    }
+  }
+
+  free(long_options);
+  return ret;
+}
+
+status_t ta_config_set(ta_cache_t* const cache,
+                       iota_client_service_t* const service) {
+  status_t ret = SC_OK;
+  if (cache == NULL || service == NULL) {
+    return SC_TA_NULL;
+  }
+
   if (iota_client_core_init(service)) {
     log_critical(logger_id, "Initializing IRI connection failed!\n");
     ret = SC_TA_OOM;
@@ -46,8 +157,7 @@ status_t ta_config_init(ta_config_t* const info, iota_config_t* const tangle,
   pow_init();
 
   log_info(logger_id, "Initializing cache connection\n");
-  cache_init(REDIS_HOST, REDIS_PORT);
-
+  cache_init(cache->host, cache->port);
   return ret;
 }
 

--- a/accelerator/config.h
+++ b/accelerator/config.h
@@ -1,7 +1,10 @@
 #ifndef ACCELERATOR_CONFIG_H_
 #define ACCELERATOR_CONFIG_H_
 
+#include <getopt.h>
+
 #include "accelerator/errors.h"
+#include "accelerator/message.h"
 #include "cclient/api/core/core_api.h"
 #include "cclient/api/extended/extended_api.h"
 #include "cclient/types/types.h"
@@ -53,9 +56,16 @@ typedef struct ta_config_s {
   const char* seed;
 } iota_config_t;
 
+/** struct type of accelerator cache */
+typedef struct ta_cache_s {
+  char* host;    /**< Binding address of redis server */
+  uint16_t port; /**< Binding port of redis server */
+} ta_cache_t;
+
 /** struct type of accelerator core */
 typedef struct ta_core_s {
   ta_config_t info;              /**< accelerator configiuration structure */
+  ta_cache_t cache;              /**< redis configiuration structure */
   iota_config_t tangle;          /**< iota configuration structure */
   iota_client_service_t service; /**< iota connection structure */
 } ta_core_t;
@@ -66,14 +76,44 @@ typedef struct ta_core_s {
  *
  * @param info[in] Tangle-accelerator configuration variables
  * @param tangle[in] iota configuration variables
+ * @param cache[in] redis configuration variables
  * @param service[in] IRI connection configuration variables
  *
  * @return
  * - SC_OK on success
  * - non-zero on error
  */
-status_t ta_config_init(ta_config_t* const info, iota_config_t* const tangle,
-                        iota_client_service_t* const service);
+status_t ta_config_default_init(ta_config_t* const info,
+                                iota_config_t* const tangle,
+                                ta_cache_t* const cache,
+                                iota_client_service_t* const service);
+
+/**
+ * Initializes configurations with CLI values
+ * Should be called third
+ *
+ * @param ta_conf[in] All configuration variables
+ * @param argc[in] Number of argumentof CLI
+ * @param argv[in] Argument of CLI
+ *
+ * @return
+ * - SC_OK on success
+ * - non-zero on error
+ */
+status_t ta_config_cli_init(ta_core_t* const ta_conf, int argc, char** argv);
+
+/**
+ * Start services after configurations are set
+ *
+ * @param cache[in] Redis server configuration variables
+ * @param service[in] IRI connection configuration variables
+ *
+ * @return
+ * - SC_OK on success
+ * - non-zero on error
+ */
+status_t ta_config_set(ta_cache_t* const cache,
+                       iota_client_service_t* const service);
 
 /**
  * Free memory of configuration variables

--- a/accelerator/errors.h
+++ b/accelerator/errors.h
@@ -41,6 +41,7 @@ extern "C" {
 #define SC_MODULE_CACHE (0x04 << SC_MODULE_SHIFT)
 #define SC_MODULE_MAM (0x05 << SC_MODULE_SHIFT)
 #define SC_MODULE_RES (0x06 << SC_MODULE_SHIFT)
+#define SC_MODULE_CONF (0x07 << SC_MODULE_SHIFT)
 /** @} */
 
 /** @name serverity code */
@@ -112,6 +113,14 @@ typedef enum {
   /**< Fail to create response object */
   SC_RES_NULL = 0x02 | SC_MODULE_RES | SC_SEVERITY_FATAL,
   /**< NULL object in response */
+
+  // configuration module
+  SC_CONF_NULL = 0x02 | SC_MODULE_CONF | SC_SEVERITY_FATAL,
+  /**< NULL object in response */
+  SC_CONF_MISSING_ARGUMENT = 0x04 | SC_MODULE_CONF | SC_SEVERITY_FATAL,
+  /**< No argument in CLI */
+  SC_CONF_UNKNOWN_OPTION = 0x05 | SC_MODULE_CONF | SC_SEVERITY_FATAL,
+  /**< undefined option in CLI */
 } status_t;
 
 typedef enum {

--- a/accelerator/message.h
+++ b/accelerator/message.h
@@ -6,13 +6,10 @@ extern "C" {
 #endif
 
 typedef enum ta_cli_arg_value_e {
-  HELP_CLI,
-
   /** TA */
-  TA_HOST_CLI,
+  TA_HOST_CLI = 127,
   TA_PORT_CLI,
   TA_THREAD_COUNT_CLI,
-  TA_VERSION_CLI,
 
   /** IRI */
   IRI_HOST_CLI,
@@ -35,12 +32,24 @@ typedef enum ta_cli_arg_requirement_e {
 } ta_cli_arg_requirement_t;
 
 static struct ta_cli_argument_s {
-  char* name;
+  char const* name;
   int val;
-  char* desc;
+  char const* desc;
   ta_cli_arg_requirement_t has_arg;
 } ta_cli_arguments_g[] = {
-    {"ta-help", HELP_CLI, "Show tangle-accelerator usage.", NO_ARG}};
+    {"help", 'h', "Show tangle-accelerator usage", NO_ARG},
+    {"version", 'v', "tangle-accelerator version", NO_ARG},
+    {"ta_host", TA_HOST_CLI, "TA listening host", REQUIRED_ARG},
+    {"ta_port", TA_PORT_CLI, "TA listening port", REQUIRED_ARG},
+    {"ta_thread", TA_THREAD_COUNT_CLI, "TA executing thread", OPTIONAL_ARG},
+    {"iri_host", IRI_HOST_CLI, "IRI listening host", REQUIRED_ARG},
+    {"iri_port", IRI_PORT_CLI, "IRI listening port", REQUIRED_ARG},
+    {"redis_host", REDIS_HOST_CLI, "Redis server listening host", REQUIRED_ARG},
+    {"redis_port", REDIS_PORT_CLI, "Redis server listening port", REQUIRED_ARG},
+    {"milestone_depth", MILESTONE_DEPTH_CLI, "IRI milestone depth",
+     OPTIONAL_ARG},
+    {"mwm", MWM_CLI, "minimum weight magnitude", OPTIONAL_ARG},
+    {"seed", SEED_CLI, "IOTA seed", OPTIONAL_ARG}};
 
 static const int cli_cmd_num =
     sizeof(ta_cli_arguments_g) / sizeof(struct ta_cli_argument_s);

--- a/tests/driver.c
+++ b/tests/driver.c
@@ -182,7 +182,9 @@ void test_receive_mam_message(void) {
 int main(void) {
   UNITY_BEGIN();
 
-  ta_config_init(&ta_core.info, &ta_core.tangle, &ta_core.service);
+  ta_config_default_init(&ta_core.info, &ta_core.tangle, &ta_core.cache,
+                         &ta_core.service);
+  ta_config_set(&ta_core.cache, &ta_core.service);
 
   printf("Total samples for each API test: %d\n", TEST_COUNT);
   RUN_TEST(test_generate_address);


### PR DESCRIPTION
This PR contains following changes:
* Rename default config function to `ta_config_default_init`
* Implement `ta_config_cli_init` to get config value from CLI
* Move `iota_client_core_init` and `cache_init` to `ta_config_set`
Configuration variables should all be confirmed then start the connection to IRI or redis
* Add `ta_config_print` to print out all configurations for confirmation

Close #114 

## Test
After successfully build, and make sure you're under `tangle-accelerator/`, then execute like below:
`$  bazel-bin/accelerator/accelerator --help`

output:
```
jkrvivian:tangle-accelerator $ bazel-bin/accelerator/accelerator --help
tangle-accelerator usage:
--help                                          Show tangle-accelerator usage 
--version                                       tangle-accelerator version 
--ta_host                                  arg  TA listening host 
--ta_port                                  arg  TA listening port 
--ta_thread                               [arg] TA executing thread 
--iri_host                                 arg  IRI listening host 
--iri_port                                 arg  IRI listening port 
--redis_host                               arg  Redis server listening host 
--redis_port                               arg  Redis server listening port 
--milestone_depth                         [arg] IRI milestone depth 
--mwm                                     [arg] minimum weight magnitude 
--seed                                    [arg] IOTA seed 
```