### PR TITLE
fix(driver): Redesign test driver for target tx disapearing

### DIFF
--- a/accelerator/errors.h
+++ b/accelerator/errors.h
@@ -75,6 +75,10 @@ typedef enum {
   /**< flex_trits conversion error */
   SC_CCLIENT_HASH = 0x06 | SC_MODULE_CCLIENT | SC_SEVERITY_MAJOR,
   /**< hash container operation error */
+  SC_CCLIENT_JSON_KEY = 0x07 | SC_MODULE_CCLIENT | SC_SEVERITY_MAJOR,
+  /**< JSON key not found */
+  SC_CCLIENT_JSON_PARSE = 0x08 | SC_MODULE_CCLIENT | SC_SEVERITY_MAJOR,
+  /**< json parsing error, might the wrong format */
 
   // Serializer module
   SC_SERIALIZER_JSON_CREATE = 0x01 | SC_MODULE_SERIALIZER | SC_SEVERITY_FATAL,

--- a/serializer/serializer.c
+++ b/serializer/serializer.c
@@ -6,9 +6,9 @@ void fill_tag(char* new_tag, char* old_tag, size_t tag_len) {
   sprintf(new_tag, "%s%*.*s", old_tag, pad_len, pad_len, nines);
 }
 
-status_t ta_hash243_stack_to_json_array(hash243_stack_t stack,
-                                        cJSON* const json_root,
-                                        char const* const obj_name) {
+static status_t ta_hash243_stack_to_json_array(hash243_stack_t stack,
+                                               cJSON* const json_root,
+                                               char const* const obj_name) {
   size_t array_count = 0;
   cJSON* array_obj = NULL;
   hash243_stack_entry_t* s_iter = NULL;
@@ -41,9 +41,9 @@ status_t ta_hash243_stack_to_json_array(hash243_stack_t stack,
   return SC_OK;
 }
 
-status_t ta_hash243_queue_to_json_array(hash243_queue_t queue,
-                                        cJSON* const json_root,
-                                        char const* const obj_name) {
+static status_t ta_hash243_queue_to_json_array(hash243_queue_t queue,
+                                               cJSON* const json_root,
+                                               char const* const obj_name) {
   size_t array_count;
   cJSON* array_obj = NULL;
   hash243_queue_entry_t* q_iter = NULL;
@@ -73,6 +73,25 @@ status_t ta_hash243_queue_to_json_array(hash243_queue_t queue,
     return SC_CCLIENT_NOT_FOUND;
   }
   return SC_OK;
+}
+
+static status_t ta_json_get_string(cJSON const* const json_obj,
+                                   char const* const obj_name,
+                                   char* const text) {
+  retcode_t ret = SC_OK;
+
+  cJSON* json_value = cJSON_GetObjectItemCaseSensitive(json_obj, obj_name);
+  if (json_value == NULL) {
+    return RC_CCLIENT_JSON_KEY;
+  }
+
+  if (cJSON_IsString(json_value) && (json_value->valuestring != NULL)) {
+    strcpy(text, json_value->valuestring);
+  } else {
+    return RC_CCLIENT_JSON_PARSE;
+  }
+
+  return ret;
 }
 
 status_t iota_transaction_to_json_object(iota_transaction_t const* const txn,
@@ -428,6 +447,37 @@ status_t send_mam_res_serialize(char** obj, const send_mam_res_t* const res) {
 
 done:
   cJSON_Delete(json_root);
+  return ret;
+}
+
+status_t send_mam_res_deserialize(const char* const obj,
+                                  send_mam_res_t* const res) {
+  if (obj == NULL) {
+    return SC_SERIALIZER_NULL;
+  }
+  cJSON* json_obj = cJSON_Parse(obj);
+  status_t ret = SC_OK;
+  tryte_t addr[NUM_TRYTES_ADDRESS + 1];
+
+  if (json_obj == NULL) {
+    ret = SC_SERIALIZER_JSON_PARSE;
+    goto done;
+  }
+
+  if (ta_json_get_string(json_obj, "channel", (char*)addr) != SC_OK) {
+    ret = SC_SERIALIZER_NULL;
+    goto done;
+  }
+  send_mam_res_set_channel_id(res, addr);
+
+  if (ta_json_get_string(json_obj, "bundle_hash", (char*)addr) != SC_OK) {
+    ret = SC_SERIALIZER_NULL;
+    goto done;
+  }
+  send_mam_res_set_bundle_hash(res, addr);
+
+done:
+  cJSON_Delete(json_obj);
   return ret;
 }
 

--- a/serializer/serializer.c
+++ b/serializer/serializer.c
@@ -78,17 +78,20 @@ static status_t ta_hash243_queue_to_json_array(hash243_queue_t queue,
 static status_t ta_json_get_string(cJSON const* const json_obj,
                                    char const* const obj_name,
                                    char* const text) {
-  retcode_t ret = SC_OK;
+  status_t ret = SC_OK;
+  if (json_obj == NULL || obj_name == NULL || text == NULL) {
+    return SC_SERIALIZER_NULL;
+  }
 
   cJSON* json_value = cJSON_GetObjectItemCaseSensitive(json_obj, obj_name);
   if (json_value == NULL) {
-    return RC_CCLIENT_JSON_KEY;
+    return SC_CCLIENT_JSON_KEY;
   }
 
   if (cJSON_IsString(json_value) && (json_value->valuestring != NULL)) {
     strcpy(text, json_value->valuestring);
   } else {
-    return RC_CCLIENT_JSON_PARSE;
+    return SC_CCLIENT_JSON_PARSE;
   }
 
   return ret;

--- a/serializer/serializer.h
+++ b/serializer/serializer.h
@@ -137,6 +137,19 @@ status_t receive_mam_message_serialize(char** obj, const char** res);
 status_t send_mam_res_serialize(char** obj, const send_mam_res_t* const res);
 
 /**
+ * @brief Deserialze JSON string to type of send_mam_res_t
+ *
+ * @param[in] obj Input values in JSON
+ * @param[out] res Response data in type of send_mam_res_t
+ *
+ * @return
+ * - SC_OK on success
+ * - non-zero on error
+ */
+status_t send_mam_res_deserialize(const char* const obj,
+                                  send_mam_res_t* const res);
+
+/**
  * @brief Deserialze JSON string to type of send_mam_req_t
  *
  * @param[in] obj Input values in JSON

--- a/tests/test_serializer.c
+++ b/tests/test_serializer.c
@@ -269,6 +269,20 @@ void test_serialize_send_mam_message(void) {
   send_mam_res_free(&res);
 }
 
+void test_deserialize_send_mam_message_response(void) {
+  const char* json = "{\"channel\":\"" TRYTES_81_1
+                     "\","
+                     "\"bundle_hash\":\"" TRYTES_81_2 "\"}";
+  send_mam_res_t* res = send_mam_res_new();
+
+  send_mam_res_deserialize(json, res);
+
+  TEST_ASSERT_EQUAL_STRING(TRYTES_81_1, res->channel_id);
+  TEST_ASSERT_EQUAL_STRING(TRYTES_81_2, res->bundle_hash);
+
+  send_mam_res_free(&res);
+}
+
 void test_deserialize_send_mam_message(void) {
   const char* json = "{\"message\":\"" TEST_PAYLOAD "\"}";
   send_mam_req_t* req = send_mam_req_new();
@@ -296,6 +310,7 @@ int main(void) {
   RUN_TEST(test_serialize_ta_find_transactions_by_tag);
   RUN_TEST(test_serialize_ta_find_transactions_obj_by_tag);
   RUN_TEST(test_serialize_send_mam_message);
+  RUN_TEST(test_deserialize_send_mam_message_response);
   RUN_TEST(test_deserialize_send_mam_message);
   return UNITY_END();
 }


### PR DESCRIPTION
Testing target transaction would disapear after snapshot (both local and global ones). 
Redisgn test driver which use the result of sending tx APIs as thr input of receiving tx APIs.
fixes #144 