### PR TITLE
feat(serialzer): Add message format in send transfer

### DIFF
--- a/tests/test_serializer.c
+++ b/tests/test_serializer.c
@@ -47,6 +47,7 @@ void test_serialize_ta_generate_address(void) {
 void test_deserialize_ta_send_transfer(void) {
   const char* json =
       "{\"value\":100,"
+      "\"message_format\":\"trytes\","
       "\"message\":\"" TAG_MSG "\",\"tag\":\"" TAG_MSG
       "\","
       "\"address\":\"" TRYTES_81_1 "\"}";


### PR DESCRIPTION
Allow send transfer in ASCII format message and set default to ascii.
Current message format are trytes and ascii, so we check only "trytes"
to differ than default.

Resolve #145 