### PR TITLE
fix(MAM): Add MAM save file

### DIFF
--- a/accelerator/config.c
+++ b/accelerator/config.c
@@ -72,6 +72,7 @@ status_t ta_config_default_init(ta_config_t* const info,
                                 ta_cache_t* const cache,
                                 iota_client_service_t* const service) {
   status_t ret = SC_OK;
+  char mss_tmp[] = "/tmp/XXXXXX";
   if (info == NULL || tangle == NULL || cache == NULL || service == NULL) {
     return SC_TA_NULL;
   }
@@ -92,6 +93,8 @@ status_t ta_config_default_init(ta_config_t* const info,
 
   log_info(logger_id, "Initializing IRI configuration\n");
   tangle->milestone_depth = MILESTONE_DEPTH;
+  mkstemp(mss_tmp);
+  strncpy(tangle->mam_file, mss_tmp, FSIZE);
   tangle->mss_depth = MSS_DEPTH;
   tangle->mwm = MWM;
   tangle->seed = SEED;

--- a/accelerator/config.h
+++ b/accelerator/config.h
@@ -27,6 +27,7 @@ extern "C" {
 #define IRI_HOST "localhost"
 #define IRI_PORT 14265
 #define MILESTONE_DEPTH 3
+#define FSIZE 11
 #define MSS_DEPTH 4
 #define MWM 14
 #define SEED                                                                   \
@@ -50,6 +51,7 @@ typedef struct ta_info_s {
 /** struct type of iota configuration */
 typedef struct ta_config_s {
   uint8_t milestone_depth; /**< Depth of API argument */
+  char mam_file[FSIZE];    /** Save file for mam struct like MSS, skn... */
   uint8_t mss_depth;       /**< Depth of MSS layer merkle tree */
   uint8_t mwm;             /**< Minimum weight magnitude of API argument */
   /** Seed to generate address. This does not do any signature yet. */


### PR DESCRIPTION
MAM API can be serialized and saved into files. This PR create a
temporarily file to save MSS after first time. Send MAM message can be
faster in second call and after in this way.

Here's the result of test driver:
Average time of send_transfer: 2.613634
tests/driver.c:214:test_send_transfer:PASS
Average time of send_mam_message: 3.906628
tests/driver.c:218:test_send_mam_message:PASS

Resolve #149 