### PR TITLE
feat: Package code files coverage into .tar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,6 +76,8 @@ bazel*
 cclient/bazel*
 cclient/cmake-*
 
+coverage
+
 # Atom conf
 .clang_complete
 

--- a/BUILD
+++ b/BUILD
@@ -1,0 +1,7 @@
+load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
+
+pkg_tar(
+    name = "pkg_coverage",
+    srcs = glob(["coverage/*"]),
+    package_dir = "./coverage"
+)


### PR DESCRIPTION
The bazel rule `pkg_coverage` can package the folder `coverage`
into tar file, but it can't be called before run code coverage.

The code coverage result `/coverage` is hidden from git.