### PR TITLE
feat(bazel): Import hiredis dependency through bazel

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,4 +1,5 @@
 load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository", "new_git_repository")
+load("//third_party:third_party.bzl", "third_party_deps")
 
 git_repository(
     name = "rules_iota",
@@ -28,5 +29,7 @@ load("@rules_iota//:defs.bzl", "iota_deps")
 load("@io_bazel_rules_docker//cc:image.bzl", _cc_image_repos = "repositories")
 
 iota_deps()
+
+third_party_deps()
 
 _cc_image_repos()

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -48,7 +48,7 @@ cc_binary(
     ],
 )
 
-cc_binary(
+cc_test(
     name = "test_cache",
     srcs = [
         "test_cache.c",

--- a/third_party/BUILD
+++ b/third_party/BUILD
@@ -8,18 +8,3 @@ cc_import(
     ],
     shared_library = "dcurl/build/libdcurl.so",
 )
-
-cc_import(
-    name = "hiredis",
-    hdrs = [
-        "hiredis/async.h",
-        "hiredis/dict.h",
-        "hiredis/fmacros.h",
-        "hiredis/hiredis.h",
-        "hiredis/net.h",
-        "hiredis/read.h",
-        "hiredis/sds.h",
-        "hiredis/sdsalloc.h",
-    ],
-    static_library = "hiredis/libhiredis.a",
-)

--- a/third_party/BUILD.hiredis
+++ b/third_party/BUILD.hiredis
@@ -1,0 +1,26 @@
+cc_library(
+    name = "hiredis",
+    srcs = [
+        "dict.h",
+        "fmacros.h",
+        "hiredis.h",
+        "net.h",
+        "read.h",
+        "sdsalloc.h",
+        "sds.h",
+        "dict.c",
+        "hiredis.c",
+        "net.c",
+        "read.c",
+        "sds.c",
+    ],
+    hdrs = [
+        "hiredis.h",
+        "net.h",
+    ],
+    include_prefix = "hiredis",
+    copts = [
+        "-Wno-unused-function"
+    ],
+    visibility = ["//visibility:public"],
+)

--- a/third_party/third_party.bzl
+++ b/third_party/third_party.bzl
@@ -1,0 +1,14 @@
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+def load_hiredis():
+    http_archive(
+        name = "hiredis",
+        url = "https://github.com/redis/hiredis/archive/v0.14.0.tar.gz",
+        strip_prefix = "hiredis-0.14.0",
+        sha256 =
+            "042f965e182b80693015839a9d0278ae73fae5d5d09d8bf6d0e6a39a8c4393bd",
+        build_file = "//third_party:BUILD.hiredis",
+    )
+
+def third_party_deps():
+    load_hiredis()

--- a/utils/BUILD
+++ b/utils/BUILD
@@ -6,8 +6,8 @@ cc_library(
     hdrs = ["cache.h"],
     deps = [
         "//accelerator:ta_errors",
-        "//third_party:hiredis",
         "@entangled//cclient/types",
+        "@hiredis",
     ],
 )
 

--- a/utils/backend_redis.c
+++ b/utils/backend_redis.c
@@ -1,5 +1,5 @@
+#include <hiredis/hiredis.h>
 #include "cache.h"
-#include "third_party/hiredis/hiredis.h"
 
 /* private data used by cache_t */
 typedef struct {


### PR DESCRIPTION
Import shared library is available in bazle, while it's still have lots
of restrictions. As of now we use git submodule and makefile to compile
dependencies. This may cause unwanted update from git submodule and
env errors. Introduce bazel rules to compile can make sure these being
take care of.

Close #184 