### PR TITLE
fix(api): Patch nines for `api_find_transactions_by_tag()`

### DIFF
--- a/accelerator/apis.c
+++ b/accelerator/apis.c
@@ -96,7 +96,19 @@ status_t api_find_transactions_by_tag(
     goto done;
   }
 
-  ret = ta_find_transactions_by_tag(service, obj, res);
+  char *req_tag = (char*)malloc((NUM_TRYTES_TAG + 1) * sizeof(char));
+  int obj_len = strlen(obj);
+
+  if (obj_len == NUM_TRYTES_TAG) {
+    strncpy(req_tag, obj, NUM_TRYTES_TAG);
+  } else if (obj_len < NUM_TRYTES_TAG) {
+    fill_nines(req_tag, obj, NUM_TRYTES_TAG);
+  } else {  // tag length > 27 trytes
+    ret = SC_TA_WRONG_REQUEST_OBJ;
+    goto done;
+  }
+
+  ret = ta_find_transactions_by_tag(service, req_tag, res);
   if (ret) {
     goto done;
   }

--- a/accelerator/errors.h
+++ b/accelerator/errors.h
@@ -42,6 +42,7 @@ extern "C" {
 #define SC_MODULE_MAM (0x05 << SC_MODULE_SHIFT)
 #define SC_MODULE_RES (0x06 << SC_MODULE_SHIFT)
 #define SC_MODULE_CONF (0x07 << SC_MODULE_SHIFT)
+#define SC_MODULE_UTILS (0x08 << SC_MODULE_SHIFT)
 /** @} */
 
 /** @name serverity code */
@@ -63,6 +64,8 @@ typedef enum {
   /**< Fail to create TA object */
   SC_TA_NULL = 0x02 | SC_MODULE_TA | SC_SEVERITY_FATAL,
   /**< NULL TA objects */
+  SC_TA_WRONG_REQUEST_OBJ = 0x03 | SC_MODULE_TA | SC_SEVERITY_FATAL,
+  /**< wrong TA request object */
 
   // CClient module
   SC_CCLIENT_OOM = 0x01 | SC_MODULE_CCLIENT | SC_SEVERITY_FATAL,
@@ -132,6 +135,10 @@ typedef enum {
   /**< No argument in CLI */
   SC_CONF_UNKNOWN_OPTION = 0x03 | SC_MODULE_CONF | SC_SEVERITY_FATAL,
   /**< undefined option in CLI */
+
+  SC_UTILS_NULL = 0x01 | SC_MODULE_UTILS | SC_SEVERITY_FATAL,
+  SC_UTILS_WRONG_REQUEST_OBJ = 0x02 | SC_MODULE_UTILS | SC_SEVERITY_FATAL,
+  /**< wrong TA request object */
 } status_t;
 
 typedef enum {

--- a/serializer/BUILD
+++ b/serializer/BUILD
@@ -9,6 +9,7 @@ cc_library(
         "//accelerator:ta_errors",
         "//request",
         "//response",
+        "//utils:fill_nines",
         "@cJSON",
         "@entangled//cclient/types",
         "@entangled//common/trinary:tryte_ascii",

--- a/serializer/serializer.c
+++ b/serializer/serializer.c
@@ -1,11 +1,5 @@
 #include "serializer.h"
 
-void fill_tag(char* new_tag, char* old_tag, size_t tag_len) {
-  char nines[NUM_TRYTES_TAG] = "999999999999999999999999999";
-  int pad_len = NUM_TRYTES_TAG - (int)tag_len;
-  sprintf(new_tag, "%s%*.*s", old_tag, pad_len, pad_len, nines);
-}
-
 static status_t ta_hash243_stack_to_json_array(hash243_stack_t stack,
                                                cJSON* const json_root,
                                                char const* const obj_name) {
@@ -322,7 +316,7 @@ status_t ta_send_transfer_req_deserialize(const char* const obj,
     if (tag_len < NUM_TRYTES_TAG) {
       char new_tag[NUM_TRYTES_TAG + 1];
       // Fill in '9' to get valid tag (27 trytes)
-      fill_tag(new_tag, json_result->valuestring, tag_len);
+      fill_nines(new_tag, json_result->valuestring, NUM_TRYTES_TAG);
       new_tag[NUM_TRYTES_TAG] = '\0';
       flex_trits_from_trytes(tag_trits, NUM_TRITS_TAG, (const tryte_t*)new_tag,
                              NUM_TRYTES_TAG, NUM_TRYTES_TAG);

--- a/serializer/serializer.h
+++ b/serializer/serializer.h
@@ -9,6 +9,7 @@
 #include "common/trinary/tryte_ascii.h"
 #include "request/request.h"
 #include "response/response.h"
+#include "utils/fill_nines.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/utils/BUILD
+++ b/utils/BUILD
@@ -24,3 +24,13 @@ cc_library(
         "@entangled//utils:time",
     ],
 )
+
+cc_library(
+    name = "fill_nines",
+    srcs = ["fill_nines.c"],
+    hdrs = ["fill_nines.h"],
+    deps = [
+        "//accelerator:ta_errors",
+        "@entangled//cclient/types",
+    ],
+)

--- a/utils/fill_nines.c
+++ b/utils/fill_nines.c
@@ -1,0 +1,21 @@
+#include "fill_nines.h"
+
+status_t fill_nines(char* new_str, const char* const old_str,
+                    size_t new_str_len) {
+  if (!new_str || !old_str || new_str_len != NUM_TRYTES_TAG) {
+    return SC_SERIALIZER_NULL;
+  }
+
+  int old_str_len = strlen(old_str);
+  strncpy(new_str, old_str, old_str_len);
+
+  int diff = new_str_len - old_str_len;
+  if (diff) {
+    memset((new_str + old_str_len), '9', diff);
+  } else {
+    return SC_UTILS_WRONG_REQUEST_OBJ;
+  }
+  new_str[new_str_len] = '\0';
+
+  return SC_OK;
+}

--- a/utils/fill_nines.h
+++ b/utils/fill_nines.h
@@ -1,0 +1,16 @@
+#include "accelerator/errors.h"
+#include "cclient/types/types.h"
+
+/**
+ * @brief Patch input string with nines into assigned length.
+ *
+ * @param[out] new_str Output patched string
+ * @param[in] old_str Input string which needs to be patched
+ * @param[in] new_str_len assigned output string length
+ *
+ * @return
+ * - SC_OK on success
+ * - non-zero on error
+ */
+status_t fill_nines(char* new_str, const char* const old_str,
+                    size_t new_str_len);


### PR DESCRIPTION
The input tag length needs to be in 27 trytes for `ta_find_transactions_by_tag()`. Therefore `fill_nines()` needs to be called if tag's length is under 27. At the same time, `api_find_transactions_by_tag()` would return error if the length of tag is more than 27 trytes.

Fixes #195 