### PR TITLE
feat: Synchronize with entangled

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -3,13 +3,13 @@ load("//third_party:third_party.bzl", "third_party_deps")
 
 git_repository(
     name = "rules_iota",
-    commit = "4ea411a05b38633a8d6b13c2d4d520441aeda9dd",
+    commit = "8a302aaeba60b9eb38f6500d48249b8cbba16c73",
     remote = "https://github.com/iotaledger/rules_iota.git",
 )
 
 git_repository(
     name = "entangled",
-    commit = "4960865730640d23e75ffbce84d3f74264cfcd28",
+    commit = "6ad56514a8a13fb1bf01beb10934cb9e3fd1a8a4",
     remote = "https://github.com/iotaledger/entangled.git",
 )
 

--- a/accelerator/BUILD
+++ b/accelerator/BUILD
@@ -27,6 +27,7 @@ cc_library(
         ":common_core",
         ":ta_errors",
         "//serializer",
+        "@entangled//common/model:bundle",
         "@entangled//common/trinary:trit_tryte",
         "@entangled//mam/api",
     ],
@@ -62,7 +63,6 @@ cc_library(
         "//utils:cache",
         "//utils:pow",
         "@entangled//cclient/api",
-        "@entangled//cclient/types",
     ],
 )
 

--- a/accelerator/apis.c
+++ b/accelerator/apis.c
@@ -251,7 +251,7 @@ status_t api_mam_send_message(const iota_config_t* const tangle,
   }
 
   // Write header and packet
-  if (mam_api_bundle_write_header_on_channel(&mam, channel_id, NULL, NULL, 0,
+  if (mam_api_bundle_write_header_on_channel(&mam, channel_id, NULL, NULL,
                                              bundle, msg_id) != RC_OK) {
     ret = SC_MAM_FAILED_WRITE;
     goto done;

--- a/accelerator/apis.c
+++ b/accelerator/apis.c
@@ -221,8 +221,8 @@ status_t api_mam_send_message(const iota_config_t* const tangle,
   bundle_transactions_new(&bundle);
   tryte_t channel_id[MAM_CHANNEL_ID_SIZE];
   trit_t msg_id[MAM_MSG_ID_SIZE];
-  send_mam_req_t* req = send_mam_req_new();
-  send_mam_res_t* res = send_mam_res_new();
+  ta_send_mam_req_t* req = send_mam_req_new();
+  ta_send_mam_res_t* res = send_mam_res_new();
 
   // Loading and creating MAM API
   if ((rc = mam_api_load(tangle->mam_file, &mam)) ==

--- a/accelerator/apis.h
+++ b/accelerator/apis.h
@@ -2,8 +2,6 @@
 #define ACCELERATOR_APIS_H_
 
 #include "accelerator/common_core.h"
-#include "accelerator/errors.h"
-#include "common/model/bundle.h"
 #include "common/trinary/trit_tryte.h"
 #include "mam/api/api.h"
 #include "mam/mam/mam_channel_t_set.h"

--- a/accelerator/apis.h
+++ b/accelerator/apis.h
@@ -3,7 +3,7 @@
 
 #include "accelerator/common_core.h"
 #include "accelerator/errors.h"
-#include "cclient/types/types.h"
+#include "common/model/bundle.h"
 #include "common/trinary/trit_tryte.h"
 #include "mam/api/api.h"
 #include "mam/mam/mam_channel_t_set.h"

--- a/accelerator/common_core.h
+++ b/accelerator/common_core.h
@@ -2,7 +2,6 @@
 #define ACCELERATOR_COMMON_CORE_H_
 
 #include "accelerator/config.h"
-#include "common/model/bundle.h"
 #include "common/model/transfer.h"
 #include "request/request.h"
 #include "response/response.h"

--- a/accelerator/config.h
+++ b/accelerator/config.h
@@ -3,7 +3,6 @@
 
 #include <getopt.h>
 
-#include "accelerator/errors.h"
 #include "accelerator/message.h"
 #include "cclient/api/core/core_api.h"
 #include "cclient/api/extended/extended_api.h"

--- a/accelerator/config.h
+++ b/accelerator/config.h
@@ -7,7 +7,6 @@
 #include "accelerator/message.h"
 #include "cclient/api/core/core_api.h"
 #include "cclient/api/extended/extended_api.h"
-#include "cclient/types/types.h"
 #include "utils/cache.h"
 #include "utils/pow.h"
 

--- a/accelerator/message.h
+++ b/accelerator/message.h
@@ -5,6 +5,11 @@
 extern "C" {
 #endif
 
+/**
+ * @file accelerator/message.h
+ * @brief Message and options for tangled-accelerator configures
+ */
+
 typedef enum ta_cli_arg_value_e {
   /** TA */
   TA_HOST_CLI = 127,

--- a/request/BUILD
+++ b/request/BUILD
@@ -11,10 +11,8 @@ cc_library(
     deps = [
         "//accelerator:ta_errors",
         "@entangled//common:errors",
-        "@entangled//common/model:transaction",
         "@entangled//common/trinary:tryte",
         "@entangled//utils/containers/hash:hash243_queue",
         "@entangled//utils/containers/hash:hash81_queue",
-        "@entangled//utils/containers/hash:hash_array",
     ],
 )

--- a/request/BUILD
+++ b/request/BUILD
@@ -10,6 +10,11 @@ cc_library(
     visibility = ["//visibility:public"],
     deps = [
         "//accelerator:ta_errors",
-        "@entangled//cclient/types",
+        "@entangled//common:errors",
+        "@entangled//common/model:transaction",
+        "@entangled//common/trinary:tryte",
+        "@entangled//utils/containers/hash:hash243_queue",
+        "@entangled//utils/containers/hash:hash81_queue",
+        "@entangled//utils/containers/hash:hash_array",
     ],
 )

--- a/request/ta_send_mam.c
+++ b/request/ta_send_mam.c
@@ -1,7 +1,8 @@
 #include "ta_send_mam.h"
 
 ta_send_mam_req_t* send_mam_req_new() {
-  ta_send_mam_req_t* req = (ta_send_mam_req_t*)malloc(sizeof(ta_send_mam_req_t));
+  ta_send_mam_req_t* req =
+      (ta_send_mam_req_t*)malloc(sizeof(ta_send_mam_req_t));
   if (req) {
     req->payload_trytes = NULL;
   }
@@ -9,7 +10,8 @@ ta_send_mam_req_t* send_mam_req_new() {
   return req;
 }
 
-status_t send_mam_req_set_payload(ta_send_mam_req_t* req, const tryte_t* payload) {
+status_t send_mam_req_set_payload(ta_send_mam_req_t* req,
+                                  const tryte_t* payload) {
   status_t ret = SC_OK;
   size_t payload_size = sizeof(payload) / sizeof(tryte_t);
 

--- a/request/ta_send_mam.c
+++ b/request/ta_send_mam.c
@@ -1,7 +1,7 @@
 #include "ta_send_mam.h"
 
-send_mam_req_t* send_mam_req_new() {
-  send_mam_req_t* req = (send_mam_req_t*)malloc(sizeof(send_mam_req_t));
+ta_send_mam_req_t* send_mam_req_new() {
+  ta_send_mam_req_t* req = (ta_send_mam_req_t*)malloc(sizeof(ta_send_mam_req_t));
   if (req) {
     req->payload_trytes = NULL;
   }
@@ -9,7 +9,7 @@ send_mam_req_t* send_mam_req_new() {
   return req;
 }
 
-status_t send_mam_req_set_payload(send_mam_req_t* req, const tryte_t* payload) {
+status_t send_mam_req_set_payload(ta_send_mam_req_t* req, const tryte_t* payload) {
   status_t ret = SC_OK;
   size_t payload_size = sizeof(payload) / sizeof(tryte_t);
 
@@ -27,7 +27,7 @@ status_t send_mam_req_set_payload(send_mam_req_t* req, const tryte_t* payload) {
   return ret;
 }
 
-void send_mam_req_free(send_mam_req_t** req) {
+void send_mam_req_free(ta_send_mam_req_t** req) {
   if (!req || !(*req)) {
     return;
   }

--- a/request/ta_send_mam.h
+++ b/request/ta_send_mam.h
@@ -11,11 +11,11 @@ extern "C" {
 typedef struct send_mam_req_s {
   tryte_t* payload_trytes;
   size_t payload_trytes_size;
-} send_mam_req_t;
+} ta_send_mam_req_t;
 
-send_mam_req_t* send_mam_req_new();
-status_t send_mam_req_set_payload(send_mam_req_t* req, const tryte_t* payload);
-void send_mam_req_free(send_mam_req_t** req);
+ta_send_mam_req_t* send_mam_req_new();
+status_t send_mam_req_set_payload(ta_send_mam_req_t* req, const tryte_t* payload);
+void send_mam_req_free(ta_send_mam_req_t** req);
 
 #ifdef __cplusplus
 }

--- a/request/ta_send_mam.h
+++ b/request/ta_send_mam.h
@@ -8,13 +8,43 @@
 extern "C" {
 #endif
 
+/**
+ * @file request/ta_send_mam.h
+ */
+
+/** struct of ta_send_transfer_req_t */
 typedef struct send_mam_req_s {
   tryte_t* payload_trytes;
   size_t payload_trytes_size;
 } ta_send_mam_req_t;
 
+/**
+ * Allocate memory of ta_send_mam_req_t
+ *
+ * @return
+ * - struct of ta_send_mam_req_t on success
+ * - NULL on error
+ */
 ta_send_mam_req_t* send_mam_req_new();
-status_t send_mam_req_set_payload(ta_send_mam_req_t* req, const tryte_t* payload);
+
+/**
+ * Set payload of ta_send_mam_req_t object
+ *
+ * @param req Data type of ta_send_transfer_req_t
+ * @param payload Tryte data going to send with mam
+ *
+ * @return NULL
+ */
+status_t send_mam_req_set_payload(ta_send_mam_req_t* req,
+                                  const tryte_t* payload);
+
+/**
+ * Free memory of ta_send_mam_req_t
+ *
+ * @param req Data type of ta_send_mam_req_t
+ *
+ * @return NULL
+ */
 void send_mam_req_free(ta_send_mam_req_t** req);
 
 #ifdef __cplusplus

--- a/request/ta_send_mam.h
+++ b/request/ta_send_mam.h
@@ -1,8 +1,10 @@
 #ifndef REQUEST_TA_SEND_MAM_H_
 #define REQUEST_TA_SEND_MAM_H_
 
+#include <stdlib.h>
+#include <string.h>
 #include "accelerator/errors.h"
-#include "cclient/types/types.h"
+#include "common/trinary/tryte.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/request/ta_send_transfer.h
+++ b/request/ta_send_transfer.h
@@ -1,7 +1,10 @@
 #ifndef REQUEST_TA_SEND_TRANSFER_H_
 #define REQUEST_TA_SEND_TRANSFER_H_
 
-#include "cclient/types/types.h"
+#include <stdlib.h>
+#include "common/trinary/flex_trit.h"
+#include "utils/containers/hash/hash243_queue.h"
+#include "utils/containers/hash/hash81_queue.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/response/BUILD
+++ b/response/BUILD
@@ -10,7 +10,11 @@ cc_library(
     visibility = ["//visibility:public"],
     deps = [
         "//accelerator:ta_errors",
-        "@entangled//cclient/types",
+        "@entangled//common:errors",
         "@entangled//common/model:transaction",
+        "@entangled//utils/containers/hash:hash243_queue",
+        "@entangled//utils/containers/hash:hash243_stack",
+        "@entangled//utils/containers/hash:hash8019_queue",
+        "@entangled//utils/containers/hash:hash_array",
     ],
 )

--- a/response/BUILD
+++ b/response/BUILD
@@ -14,7 +14,5 @@ cc_library(
         "@entangled//common/model:transaction",
         "@entangled//utils/containers/hash:hash243_queue",
         "@entangled//utils/containers/hash:hash243_stack",
-        "@entangled//utils/containers/hash:hash8019_queue",
-        "@entangled//utils/containers/hash:hash_array",
     ],
 )

--- a/response/ta_find_transactions.h
+++ b/response/ta_find_transactions.h
@@ -1,7 +1,8 @@
 #ifndef RESPONSE_TA_FIND_TRANSACTIONS_H_
 #define RESPONSE_TA_FIND_TRANSACTIONS_H_
 
-#include "cclient/types/types.h"
+#include <stdlib.h>
+#include "utils/containers/hash/hash243_queue.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/response/ta_find_transactions_obj.h
+++ b/response/ta_find_transactions_obj.h
@@ -1,7 +1,8 @@
 #ifndef RESPONSE_TA_FIND_TRANSACTIONS_OBJ_H_
 #define RESPONSE_TA_FIND_TRANSACTIONS_OBJ_H_
 
-#include "cclient/types/types.h"
+#include "./utarray.h"
+#include "common/model/transaction.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/response/ta_generate_address.h
+++ b/response/ta_generate_address.h
@@ -1,7 +1,8 @@
 #ifndef RESPONSE_TA_GENERATE_ADDRESS_H_
 #define RESPONSE_TA_GENERATE_ADDRESS_H_
 
-#include "cclient/types/types.h"
+#include <stdlib.h>
+#include "utils/containers/hash/hash243_queue.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/response/ta_get_tips.h
+++ b/response/ta_get_tips.h
@@ -1,7 +1,8 @@
 #ifndef RESPONSE_TA_GET_TIPS_H_
 #define RESPONSE_TA_GET_TIPS_H_
 
-#include "cclient/types/types.h"
+#include <stdlib.h>
+#include "utils/containers/hash/hash243_stack.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/response/ta_get_transaction_object.h
+++ b/response/ta_get_transaction_object.h
@@ -1,7 +1,7 @@
 #ifndef RESPONSE_TA_GET_TRANSACTION_OBJECT_H_
 #define RESPONSE_TA_GET_TRANSACTION_OBJECT_H_
 
-#include "cclient/types/types.h"
+#include "common/model/transaction.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/response/ta_send_mam.c
+++ b/response/ta_send_mam.c
@@ -1,7 +1,8 @@
 #include "ta_send_mam.h"
 
 ta_send_mam_res_t* send_mam_res_new() {
-  ta_send_mam_res_t* res = (ta_send_mam_res_t*)malloc(sizeof(ta_send_mam_res_t));
+  ta_send_mam_res_t* res =
+      (ta_send_mam_res_t*)malloc(sizeof(ta_send_mam_res_t));
 
   return res;
 }

--- a/response/ta_send_mam.c
+++ b/response/ta_send_mam.c
@@ -1,12 +1,12 @@
 #include "ta_send_mam.h"
 
-send_mam_res_t* send_mam_res_new() {
-  send_mam_res_t* res = (send_mam_res_t*)malloc(sizeof(send_mam_res_t));
+ta_send_mam_res_t* send_mam_res_new() {
+  ta_send_mam_res_t* res = (ta_send_mam_res_t*)malloc(sizeof(ta_send_mam_res_t));
 
   return res;
 }
 
-status_t send_mam_res_set_bundle_hash(send_mam_res_t* res,
+status_t send_mam_res_set_bundle_hash(ta_send_mam_res_t* res,
                                       const tryte_t* bundle_hash) {
   if (!bundle_hash || !res) {
     return SC_RES_NULL;
@@ -17,7 +17,7 @@ status_t send_mam_res_set_bundle_hash(send_mam_res_t* res,
   return SC_OK;
 }
 
-status_t send_mam_res_set_channel_id(send_mam_res_t* res,
+status_t send_mam_res_set_channel_id(ta_send_mam_res_t* res,
                                      const tryte_t* channel_id) {
   if (!channel_id || !res) {
     return SC_RES_NULL;
@@ -28,7 +28,7 @@ status_t send_mam_res_set_channel_id(send_mam_res_t* res,
   return SC_OK;
 }
 
-void send_mam_res_free(send_mam_res_t** res) {
+void send_mam_res_free(ta_send_mam_res_t** res) {
   if (!res || !(*res)) {
     return;
   }

--- a/response/ta_send_mam.h
+++ b/response/ta_send_mam.h
@@ -3,6 +3,7 @@
 
 #include "accelerator/errors.h"
 #include "common/model/transaction.h"
+#include "common/trinary/tryte.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/response/ta_send_mam.h
+++ b/response/ta_send_mam.h
@@ -18,16 +18,16 @@ typedef struct send_mam_res_s {
   char bundle_hash[NUM_TRYTES_HASH + 1];
   /** ascii string channel id */
   char channel_id[NUM_TRYTES_HASH + 1];
-} send_mam_res_t;
+} ta_send_mam_res_t;
 
 /**
- * Allocate memory of send_mam_res_t
+ * Allocate memory of ta_send_mam_res_t
  *
  * @return
- * - struct of send_mam_res_t on success
+ * - struct of ta_send_mam_res_t on success
  * - NULL on error
  */
-send_mam_res_t* send_mam_res_new();
+ta_send_mam_res_t* send_mam_res_new();
 
 /**
  * @brief Set the bundle_hash field of send_mam_res object.
@@ -36,14 +36,14 @@ send_mam_res_t* send_mam_res_new();
  * and convert (instead of decoding) the received bundle hash to ascii string.
  * After conversion, set the  bundle_hash field of send_mam_res object.
  *
- * @param[in] res send_mam_res_t struct object
+ * @param[in] res ta_send_mam_res_t struct object
  * @param[in] bundle_hash bundle hash decoded in trytes string
  *
  * @return
  * - SC_OK on success
  * - non-zero on error
  */
-status_t send_mam_res_set_bundle_hash(send_mam_res_t* res,
+status_t send_mam_res_set_bundle_hash(ta_send_mam_res_t* res,
                                       const tryte_t* bundle_hash);
 
 /**
@@ -53,24 +53,24 @@ status_t send_mam_res_set_bundle_hash(send_mam_res_t* res,
  * and convert (instead of decoding) the received channel id to ascii string.
  * After conversion, set the  channel_id field of send_mam_res object.
  *
- * @param[in] res send_mam_res_t struct object
+ * @param[in] res ta_send_mam_res_t struct object
  * @param[in] channel_id channel id decoded in trytes string
  *
  * @return
  * - SC_OK on success
  * - non-zero on error
  */
-status_t send_mam_res_set_channel_id(send_mam_res_t* res,
+status_t send_mam_res_set_channel_id(ta_send_mam_res_t* res,
                                      const tryte_t* channel_id);
 
 /**
- * Free memory of send_mam_res_t
+ * Free memory of ta_send_mam_res_t
  *
- * @param req Data type of send_mam_res_t
+ * @param req Data type of ta_send_mam_res_t
  *
  * @return NULL
  */
-void send_mam_res_free(send_mam_res_t** res);
+void send_mam_res_free(ta_send_mam_res_t** res);
 
 #ifdef __cplusplus
 }

--- a/response/ta_send_mam.h
+++ b/response/ta_send_mam.h
@@ -9,7 +9,7 @@ extern "C" {
 #endif
 
 /**
- * @file response/ta_send_mam_res.h
+ * @file response/ta_send_mam.h
  */
 
 /** struct of ta_send_mam_res_t */

--- a/response/ta_send_transfer.h
+++ b/response/ta_send_transfer.h
@@ -1,7 +1,8 @@
 #ifndef RESPONSE_TA_SEND_TRANSFER_H_
 #define RESPONSE_TA_SEND_TRANSFER_H_
 
-#include "cclient/types/types.h"
+#include <stdlib.h>
+#include "utils/containers/hash/hash243_queue.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/serializer/BUILD
+++ b/serializer/BUILD
@@ -13,9 +13,6 @@ cc_library(
         "@cJSON",
         "@entangled//common/trinary:flex_trit",
         "@entangled//common/trinary:tryte_ascii",
-        "@entangled//utils/containers/hash:hash243_queue",
-        "@entangled//utils/containers/hash:hash243_stack",
-        "@entangled//utils/containers/hash:hash81_queue",
         "@entangled//utils/containers/hash:hash_array",
     ],
 )

--- a/serializer/BUILD
+++ b/serializer/BUILD
@@ -11,7 +11,11 @@ cc_library(
         "//response",
         "//utils:fill_nines",
         "@cJSON",
-        "@entangled//cclient/types",
+        "@entangled//common/trinary:flex_trit",
         "@entangled//common/trinary:tryte_ascii",
+        "@entangled//utils/containers/hash:hash243_queue",
+        "@entangled//utils/containers/hash:hash243_stack",
+        "@entangled//utils/containers/hash:hash81_queue",
+        "@entangled//utils/containers/hash:hash_array",
     ],
 )

--- a/serializer/serializer.c
+++ b/serializer/serializer.c
@@ -556,7 +556,8 @@ done:
   return ret;
 }
 
-status_t send_mam_res_serialize(char** obj, const ta_send_mam_res_t* const res) {
+status_t send_mam_res_serialize(char** obj,
+                                const ta_send_mam_res_t* const res) {
   status_t ret = SC_OK;
   cJSON* json_root = cJSON_CreateObject();
   if (json_root == NULL) {
@@ -610,7 +611,8 @@ done:
   return ret;
 }
 
-status_t send_mam_req_deserialize(const char* const obj, ta_send_mam_req_t* req) {
+status_t send_mam_req_deserialize(const char* const obj,
+                                  ta_send_mam_req_t* req) {
   if (obj == NULL) {
     return SC_SERIALIZER_NULL;
   }

--- a/serializer/serializer.c
+++ b/serializer/serializer.c
@@ -556,7 +556,7 @@ done:
   return ret;
 }
 
-status_t send_mam_res_serialize(char** obj, const send_mam_res_t* const res) {
+status_t send_mam_res_serialize(char** obj, const ta_send_mam_res_t* const res) {
   status_t ret = SC_OK;
   cJSON* json_root = cJSON_CreateObject();
   if (json_root == NULL) {
@@ -580,7 +580,7 @@ done:
 }
 
 status_t send_mam_res_deserialize(const char* const obj,
-                                  send_mam_res_t* const res) {
+                                  ta_send_mam_res_t* const res) {
   if (obj == NULL) {
     return SC_SERIALIZER_NULL;
   }
@@ -610,7 +610,7 @@ done:
   return ret;
 }
 
-status_t send_mam_req_deserialize(const char* const obj, send_mam_req_t* req) {
+status_t send_mam_req_deserialize(const char* const obj, ta_send_mam_req_t* req) {
   if (obj == NULL) {
     return SC_SERIALIZER_NULL;
   }

--- a/serializer/serializer.h
+++ b/serializer/serializer.h
@@ -187,7 +187,8 @@ status_t send_mam_res_deserialize(const char* const obj,
  * - SC_OK on success
  * - non-zero on error
  */
-status_t send_mam_req_deserialize(const char* const obj, ta_send_mam_req_t* req);
+status_t send_mam_req_deserialize(const char* const obj,
+                                  ta_send_mam_req_t* req);
 #ifdef __cplusplus
 }
 #endif

--- a/serializer/serializer.h
+++ b/serializer/serializer.h
@@ -1,18 +1,10 @@
 #ifndef SERIALIZER_SERIALIZER_H_
 #define SERIALIZER_SERIALIZER_H_
 
-#include <stdlib.h>
-
-#include "accelerator/errors.h"
 #include "cJSON.h"
-#include "common/trinary/flex_trit.h"
 #include "common/trinary/tryte_ascii.h"
 #include "request/request.h"
 #include "response/response.h"
-#include "utarray.h"
-#include "utils/containers/hash/hash243_queue.h"
-#include "utils/containers/hash/hash243_stack.h"
-#include "utils/containers/hash/hash81_queue.h"
 #include "utils/containers/hash/hash_array.h"
 #include "utils/fill_nines.h"
 

--- a/serializer/serializer.h
+++ b/serializer/serializer.h
@@ -5,10 +5,15 @@
 
 #include "accelerator/errors.h"
 #include "cJSON.h"
-#include "cclient/types/types.h"
+#include "common/trinary/flex_trit.h"
 #include "common/trinary/tryte_ascii.h"
 #include "request/request.h"
 #include "response/response.h"
+#include "utarray.h"
+#include "utils/containers/hash/hash243_queue.h"
+#include "utils/containers/hash/hash243_stack.h"
+#include "utils/containers/hash/hash81_queue.h"
+#include "utils/containers/hash/hash_array.h"
 #include "utils/fill_nines.h"
 
 #ifdef __cplusplus

--- a/serializer/serializer.h
+++ b/serializer/serializer.h
@@ -153,41 +153,41 @@ status_t ta_find_transactions_obj_res_serialize(
 status_t receive_mam_message_serialize(char** obj, char** const res);
 
 /**
- * @brief Serialze type of send_mam_res_t to JSON string
+ * @brief Serialze type of ta_send_mam_res_t to JSON string
  *
  * @param[out] obj send mam response object in JSON
- * @param[in] res Response data in type of send_mam_res_t
+ * @param[in] res Response data in type of ta_send_mam_res_t
  *
  * @return
  * - SC_OK on success
  * - non-zero on error
  */
-status_t send_mam_res_serialize(char** obj, const send_mam_res_t* const res);
+status_t send_mam_res_serialize(char** obj, const ta_send_mam_res_t* const res);
 
 /**
- * @brief Deserialze JSON string to type of send_mam_res_t
+ * @brief Deserialze JSON string to type of ta_send_mam_res_t
  *
  * @param[in] obj Input values in JSON
- * @param[out] res Response data in type of send_mam_res_t
+ * @param[out] res Response data in type of ta_send_mam_res_t
  *
  * @return
  * - SC_OK on success
  * - non-zero on error
  */
 status_t send_mam_res_deserialize(const char* const obj,
-                                  send_mam_res_t* const res);
+                                  ta_send_mam_res_t* const res);
 
 /**
- * @brief Deserialze JSON string to type of send_mam_req_t
+ * @brief Deserialze JSON string to type of ta_send_mam_req_t
  *
  * @param[in] obj Input values in JSON
- * @param[out] req Request data in type of send_mam_req_t
+ * @param[out] req Request data in type of ta_send_mam_req_t
  *
  * @return
  * - SC_OK on success
  * - non-zero on error
  */
-status_t send_mam_req_deserialize(const char* const obj, send_mam_req_t* req);
+status_t send_mam_req_deserialize(const char* const obj, ta_send_mam_req_t* req);
 #ifdef __cplusplus
 }
 #endif

--- a/tests/driver.c
+++ b/tests/driver.c
@@ -6,7 +6,7 @@ static ta_core_t ta_core;
 struct timespec start_time, end_time;
 
 char driver_tag_msg[NUM_TRYTES_TAG];
-send_mam_res_t* res;
+ta_send_mam_res_t* res;
 
 #if defined(ENABLE_STAT)
 #define TEST_COUNT 100

--- a/tests/test_serializer.c
+++ b/tests/test_serializer.c
@@ -258,7 +258,7 @@ void test_serialize_send_mam_message(void) {
                      "\","
                      "\"bundle_hash\":\"" TRYTES_81_2 "\"}";
   char* json_result;
-  send_mam_res_t* res = send_mam_res_new();
+  ta_send_mam_res_t* res = send_mam_res_new();
 
   send_mam_res_set_bundle_hash(res, (tryte_t*)TRYTES_81_2);
   send_mam_res_set_channel_id(res, (tryte_t*)TRYTES_81_1);
@@ -274,7 +274,7 @@ void test_deserialize_send_mam_message_response(void) {
   const char* json = "{\"channel\":\"" TRYTES_81_1
                      "\","
                      "\"bundle_hash\":\"" TRYTES_81_2 "\"}";
-  send_mam_res_t* res = send_mam_res_new();
+  ta_send_mam_res_t* res = send_mam_res_new();
 
   send_mam_res_deserialize(json, res);
 
@@ -286,7 +286,7 @@ void test_deserialize_send_mam_message_response(void) {
 
 void test_deserialize_send_mam_message(void) {
   const char* json = "{\"message\":\"" TEST_PAYLOAD "\"}";
-  send_mam_req_t* req = send_mam_req_new();
+  ta_send_mam_req_t* req = send_mam_req_new();
 
   send_mam_req_deserialize(json, req);
 

--- a/utils/BUILD
+++ b/utils/BUILD
@@ -6,7 +6,7 @@ cc_library(
     hdrs = ["cache.h"],
     deps = [
         "//accelerator:ta_errors",
-        "@entangled//cclient/types",
+        "@entangled//common/trinary:flex_trit",
         "@hiredis",
     ],
 )
@@ -18,9 +18,10 @@ cc_library(
     deps = [
         "//accelerator:ta_errors",
         "//third_party:dcurl",
-        "@entangled//cclient/types",
+        "@com_github_uthash//:uthash",
         "@entangled//common/helpers:digest",
         "@entangled//common/model:bundle",
+        "@entangled//common/trinary:flex_trit",
         "@entangled//utils:time",
     ],
 )
@@ -31,6 +32,6 @@ cc_library(
     hdrs = ["fill_nines.h"],
     deps = [
         "//accelerator:ta_errors",
-        "@entangled//cclient/types",
+        "@entangled//common/model:transaction",
     ],
 )

--- a/utils/cache.h
+++ b/utils/cache.h
@@ -1,12 +1,14 @@
 #ifndef UTILS_CACHE_H_
 #define UTILS_CACHE_H_
 
+#include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
+#include "common/trinary/flex_trit.h"
+
 #include "accelerator/errors.h"
-#include "cclient/types/types.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/utils/cache.h
+++ b/utils/cache.h
@@ -5,10 +5,8 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-
-#include "common/trinary/flex_trit.h"
-
 #include "accelerator/errors.h"
+#include "common/trinary/flex_trit.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/utils/fill_nines.h
+++ b/utils/fill_nines.h
@@ -9,6 +9,10 @@ extern "C" {
 #endif
 
 /**
+ * @file utils/fill_nines.h
+ */
+
+/**
  * @brief Patch input string with nines into assigned length.
  *
  * @param[out] new_str Output patched string

--- a/utils/fill_nines.h
+++ b/utils/fill_nines.h
@@ -1,8 +1,11 @@
 #ifndef UTILS_FILL_NINES_H_
 #define UTILS_FILL_NINES_H_
 
+#include <stddef.h>
+#include <stdlib.h>
+#include <string.h>
 #include "accelerator/errors.h"
-#include "cclient/types/types.h"
+#include "common/model/transaction.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/utils/pow.h
+++ b/utils/pow.h
@@ -2,9 +2,10 @@
 #define UTILS_POW_H_
 
 #include <stdint.h>
+#include "./utarray.h"
 #include "accelerator/errors.h"
-#include "cclient/types/types.h"
 #include "common/model/bundle.h"
+#include "common/trinary/flex_trit.h"
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
Syncgronize entangled to latest commit, and replace our implementation of `cclient_prepare_transfer()` with entangled provided exteneded API `iota_client_prepare_transfers()`.

In the latest commit, the `entangled`'s own defined variable types should be included respectively (not like what we did before).

And `mam_api_bundle_write_header_on_channel()` has removed one argument (`trint9_t msg_type_id`).

Should be merged after #203 