### PR TITLE
fix: Add the missing files to doxygen document

### DIFF
--- a/accelerator/apis.c
+++ b/accelerator/apis.c
@@ -221,8 +221,8 @@ status_t api_mam_send_message(const iota_config_t* const tangle,
   bundle_transactions_new(&bundle);
   tryte_t channel_id[MAM_CHANNEL_ID_SIZE];
   trit_t msg_id[MAM_MSG_ID_SIZE];
-  send_mam_req_t* req = send_mam_req_new();
-  send_mam_res_t* res = send_mam_res_new();
+  ta_send_mam_req_t* req = send_mam_req_new();
+  ta_send_mam_res_t* res = send_mam_res_new();
 
   // Loading and creating MAM API
   if ((rc = mam_api_load(tangle->mam_file, &mam)) ==

--- a/accelerator/message.h
+++ b/accelerator/message.h
@@ -5,6 +5,11 @@
 extern "C" {
 #endif
 
+/**
+ * @file accelerator/message.h
+ * @brief Message and options for tangled-accelerator configures
+ */
+
 typedef enum ta_cli_arg_value_e {
   /** TA */
   TA_HOST_CLI = 127,

--- a/request/ta_send_mam.c
+++ b/request/ta_send_mam.c
@@ -1,7 +1,8 @@
 #include "ta_send_mam.h"
 
 ta_send_mam_req_t* send_mam_req_new() {
-  ta_send_mam_req_t* req = (ta_send_mam_req_t*)malloc(sizeof(ta_send_mam_req_t));
+  ta_send_mam_req_t* req =
+      (ta_send_mam_req_t*)malloc(sizeof(ta_send_mam_req_t));
   if (req) {
     req->payload_trytes = NULL;
   }
@@ -9,7 +10,8 @@ ta_send_mam_req_t* send_mam_req_new() {
   return req;
 }
 
-status_t send_mam_req_set_payload(ta_send_mam_req_t* req, const tryte_t* payload) {
+status_t send_mam_req_set_payload(ta_send_mam_req_t* req,
+                                  const tryte_t* payload) {
   status_t ret = SC_OK;
   size_t payload_size = sizeof(payload) / sizeof(tryte_t);
 

--- a/request/ta_send_mam.c
+++ b/request/ta_send_mam.c
@@ -1,7 +1,7 @@
 #include "ta_send_mam.h"
 
-send_mam_req_t* send_mam_req_new() {
-  send_mam_req_t* req = (send_mam_req_t*)malloc(sizeof(send_mam_req_t));
+ta_send_mam_req_t* send_mam_req_new() {
+  ta_send_mam_req_t* req = (ta_send_mam_req_t*)malloc(sizeof(ta_send_mam_req_t));
   if (req) {
     req->payload_trytes = NULL;
   }
@@ -9,7 +9,7 @@ send_mam_req_t* send_mam_req_new() {
   return req;
 }
 
-status_t send_mam_req_set_payload(send_mam_req_t* req, const tryte_t* payload) {
+status_t send_mam_req_set_payload(ta_send_mam_req_t* req, const tryte_t* payload) {
   status_t ret = SC_OK;
   size_t payload_size = sizeof(payload) / sizeof(tryte_t);
 
@@ -27,7 +27,7 @@ status_t send_mam_req_set_payload(send_mam_req_t* req, const tryte_t* payload) {
   return ret;
 }
 
-void send_mam_req_free(send_mam_req_t** req) {
+void send_mam_req_free(ta_send_mam_req_t** req) {
   if (!req || !(*req)) {
     return;
   }

--- a/request/ta_send_mam.h
+++ b/request/ta_send_mam.h
@@ -11,11 +11,11 @@ extern "C" {
 typedef struct send_mam_req_s {
   tryte_t* payload_trytes;
   size_t payload_trytes_size;
-} send_mam_req_t;
+} ta_send_mam_req_t;
 
-send_mam_req_t* send_mam_req_new();
-status_t send_mam_req_set_payload(send_mam_req_t* req, const tryte_t* payload);
-void send_mam_req_free(send_mam_req_t** req);
+ta_send_mam_req_t* send_mam_req_new();
+status_t send_mam_req_set_payload(ta_send_mam_req_t* req, const tryte_t* payload);
+void send_mam_req_free(ta_send_mam_req_t** req);
 
 #ifdef __cplusplus
 }

--- a/request/ta_send_mam.h
+++ b/request/ta_send_mam.h
@@ -8,13 +8,43 @@
 extern "C" {
 #endif
 
+/**
+ * @file request/ta_send_mam.h
+ */
+
+/** struct of ta_send_transfer_req_t */
 typedef struct send_mam_req_s {
   tryte_t* payload_trytes;
   size_t payload_trytes_size;
 } ta_send_mam_req_t;
 
+/**
+ * Allocate memory of ta_send_mam_req_t
+ *
+ * @return
+ * - struct of ta_send_mam_req_t on success
+ * - NULL on error
+ */
 ta_send_mam_req_t* send_mam_req_new();
-status_t send_mam_req_set_payload(ta_send_mam_req_t* req, const tryte_t* payload);
+
+/**
+ * Set payload of ta_send_mam_req_t object
+ *
+ * @param req Data type of ta_send_transfer_req_t
+ * @param payload Tryte data going to send with mam
+ *
+ * @return NULL
+ */
+status_t send_mam_req_set_payload(ta_send_mam_req_t* req,
+                                  const tryte_t* payload);
+
+/**
+ * Free memory of ta_send_mam_req_t
+ *
+ * @param req Data type of ta_send_mam_req_t
+ *
+ * @return NULL
+ */
 void send_mam_req_free(ta_send_mam_req_t** req);
 
 #ifdef __cplusplus

--- a/response/ta_send_mam.c
+++ b/response/ta_send_mam.c
@@ -1,7 +1,8 @@
 #include "ta_send_mam.h"
 
 ta_send_mam_res_t* send_mam_res_new() {
-  ta_send_mam_res_t* res = (ta_send_mam_res_t*)malloc(sizeof(ta_send_mam_res_t));
+  ta_send_mam_res_t* res =
+      (ta_send_mam_res_t*)malloc(sizeof(ta_send_mam_res_t));
 
   return res;
 }

--- a/response/ta_send_mam.c
+++ b/response/ta_send_mam.c
@@ -1,12 +1,12 @@
 #include "ta_send_mam.h"
 
-send_mam_res_t* send_mam_res_new() {
-  send_mam_res_t* res = (send_mam_res_t*)malloc(sizeof(send_mam_res_t));
+ta_send_mam_res_t* send_mam_res_new() {
+  ta_send_mam_res_t* res = (ta_send_mam_res_t*)malloc(sizeof(ta_send_mam_res_t));
 
   return res;
 }
 
-status_t send_mam_res_set_bundle_hash(send_mam_res_t* res,
+status_t send_mam_res_set_bundle_hash(ta_send_mam_res_t* res,
                                       const tryte_t* bundle_hash) {
   if (!bundle_hash || !res) {
     return SC_RES_NULL;
@@ -17,7 +17,7 @@ status_t send_mam_res_set_bundle_hash(send_mam_res_t* res,
   return SC_OK;
 }
 
-status_t send_mam_res_set_channel_id(send_mam_res_t* res,
+status_t send_mam_res_set_channel_id(ta_send_mam_res_t* res,
                                      const tryte_t* channel_id) {
   if (!channel_id || !res) {
     return SC_RES_NULL;
@@ -28,7 +28,7 @@ status_t send_mam_res_set_channel_id(send_mam_res_t* res,
   return SC_OK;
 }
 
-void send_mam_res_free(send_mam_res_t** res) {
+void send_mam_res_free(ta_send_mam_res_t** res) {
   if (!res || !(*res)) {
     return;
   }

--- a/response/ta_send_mam.h
+++ b/response/ta_send_mam.h
@@ -18,16 +18,16 @@ typedef struct send_mam_res_s {
   char bundle_hash[NUM_TRYTES_HASH + 1];
   /** ascii string channel id */
   char channel_id[NUM_TRYTES_HASH + 1];
-} send_mam_res_t;
+} ta_send_mam_res_t;
 
 /**
- * Allocate memory of send_mam_res_t
+ * Allocate memory of ta_send_mam_res_t
  *
  * @return
- * - struct of send_mam_res_t on success
+ * - struct of ta_send_mam_res_t on success
  * - NULL on error
  */
-send_mam_res_t* send_mam_res_new();
+ta_send_mam_res_t* send_mam_res_new();
 
 /**
  * @brief Set the bundle_hash field of send_mam_res object.
@@ -36,14 +36,14 @@ send_mam_res_t* send_mam_res_new();
  * and convert (instead of decoding) the received bundle hash to ascii string.
  * After conversion, set the  bundle_hash field of send_mam_res object.
  *
- * @param[in] res send_mam_res_t struct object
+ * @param[in] res ta_send_mam_res_t struct object
  * @param[in] bundle_hash bundle hash decoded in trytes string
  *
  * @return
  * - SC_OK on success
  * - non-zero on error
  */
-status_t send_mam_res_set_bundle_hash(send_mam_res_t* res,
+status_t send_mam_res_set_bundle_hash(ta_send_mam_res_t* res,
                                       const tryte_t* bundle_hash);
 
 /**
@@ -53,24 +53,24 @@ status_t send_mam_res_set_bundle_hash(send_mam_res_t* res,
  * and convert (instead of decoding) the received channel id to ascii string.
  * After conversion, set the  channel_id field of send_mam_res object.
  *
- * @param[in] res send_mam_res_t struct object
+ * @param[in] res ta_send_mam_res_t struct object
  * @param[in] channel_id channel id decoded in trytes string
  *
  * @return
  * - SC_OK on success
  * - non-zero on error
  */
-status_t send_mam_res_set_channel_id(send_mam_res_t* res,
+status_t send_mam_res_set_channel_id(ta_send_mam_res_t* res,
                                      const tryte_t* channel_id);
 
 /**
- * Free memory of send_mam_res_t
+ * Free memory of ta_send_mam_res_t
  *
- * @param req Data type of send_mam_res_t
+ * @param req Data type of ta_send_mam_res_t
  *
  * @return NULL
  */
-void send_mam_res_free(send_mam_res_t** res);
+void send_mam_res_free(ta_send_mam_res_t** res);
 
 #ifdef __cplusplus
 }

--- a/response/ta_send_mam.h
+++ b/response/ta_send_mam.h
@@ -9,7 +9,7 @@ extern "C" {
 #endif
 
 /**
- * @file response/ta_send_mam_res.h
+ * @file response/ta_send_mam.h
  */
 
 /** struct of ta_send_mam_res_t */

--- a/serializer/serializer.c
+++ b/serializer/serializer.c
@@ -556,7 +556,8 @@ done:
   return ret;
 }
 
-status_t send_mam_res_serialize(char** obj, const ta_send_mam_res_t* const res) {
+status_t send_mam_res_serialize(char** obj,
+                                const ta_send_mam_res_t* const res) {
   status_t ret = SC_OK;
   cJSON* json_root = cJSON_CreateObject();
   if (json_root == NULL) {
@@ -610,7 +611,8 @@ done:
   return ret;
 }
 
-status_t send_mam_req_deserialize(const char* const obj, ta_send_mam_req_t* req) {
+status_t send_mam_req_deserialize(const char* const obj,
+                                  ta_send_mam_req_t* req) {
   if (obj == NULL) {
     return SC_SERIALIZER_NULL;
   }

--- a/serializer/serializer.c
+++ b/serializer/serializer.c
@@ -556,7 +556,7 @@ done:
   return ret;
 }
 
-status_t send_mam_res_serialize(char** obj, const send_mam_res_t* const res) {
+status_t send_mam_res_serialize(char** obj, const ta_send_mam_res_t* const res) {
   status_t ret = SC_OK;
   cJSON* json_root = cJSON_CreateObject();
   if (json_root == NULL) {
@@ -580,7 +580,7 @@ done:
 }
 
 status_t send_mam_res_deserialize(const char* const obj,
-                                  send_mam_res_t* const res) {
+                                  ta_send_mam_res_t* const res) {
   if (obj == NULL) {
     return SC_SERIALIZER_NULL;
   }
@@ -610,7 +610,7 @@ done:
   return ret;
 }
 
-status_t send_mam_req_deserialize(const char* const obj, send_mam_req_t* req) {
+status_t send_mam_req_deserialize(const char* const obj, ta_send_mam_req_t* req) {
   if (obj == NULL) {
     return SC_SERIALIZER_NULL;
   }

--- a/serializer/serializer.h
+++ b/serializer/serializer.h
@@ -187,7 +187,8 @@ status_t send_mam_res_deserialize(const char* const obj,
  * - SC_OK on success
  * - non-zero on error
  */
-status_t send_mam_req_deserialize(const char* const obj, ta_send_mam_req_t* req);
+status_t send_mam_req_deserialize(const char* const obj,
+                                  ta_send_mam_req_t* req);
 #ifdef __cplusplus
 }
 #endif

--- a/serializer/serializer.h
+++ b/serializer/serializer.h
@@ -153,41 +153,41 @@ status_t ta_find_transactions_obj_res_serialize(
 status_t receive_mam_message_serialize(char** obj, char** const res);
 
 /**
- * @brief Serialze type of send_mam_res_t to JSON string
+ * @brief Serialze type of ta_send_mam_res_t to JSON string
  *
  * @param[out] obj send mam response object in JSON
- * @param[in] res Response data in type of send_mam_res_t
+ * @param[in] res Response data in type of ta_send_mam_res_t
  *
  * @return
  * - SC_OK on success
  * - non-zero on error
  */
-status_t send_mam_res_serialize(char** obj, const send_mam_res_t* const res);
+status_t send_mam_res_serialize(char** obj, const ta_send_mam_res_t* const res);
 
 /**
- * @brief Deserialze JSON string to type of send_mam_res_t
+ * @brief Deserialze JSON string to type of ta_send_mam_res_t
  *
  * @param[in] obj Input values in JSON
- * @param[out] res Response data in type of send_mam_res_t
+ * @param[out] res Response data in type of ta_send_mam_res_t
  *
  * @return
  * - SC_OK on success
  * - non-zero on error
  */
 status_t send_mam_res_deserialize(const char* const obj,
-                                  send_mam_res_t* const res);
+                                  ta_send_mam_res_t* const res);
 
 /**
- * @brief Deserialze JSON string to type of send_mam_req_t
+ * @brief Deserialze JSON string to type of ta_send_mam_req_t
  *
  * @param[in] obj Input values in JSON
- * @param[out] req Request data in type of send_mam_req_t
+ * @param[out] req Request data in type of ta_send_mam_req_t
  *
  * @return
  * - SC_OK on success
  * - non-zero on error
  */
-status_t send_mam_req_deserialize(const char* const obj, send_mam_req_t* req);
+status_t send_mam_req_deserialize(const char* const obj, ta_send_mam_req_t* req);
 #ifdef __cplusplus
 }
 #endif

--- a/tests/driver.c
+++ b/tests/driver.c
@@ -6,7 +6,7 @@ static ta_core_t ta_core;
 struct timespec start_time, end_time;
 
 char driver_tag_msg[NUM_TRYTES_TAG];
-send_mam_res_t* res;
+ta_send_mam_res_t* res;
 
 #if defined(ENABLE_STAT)
 #define TEST_COUNT 100

--- a/tests/test_serializer.c
+++ b/tests/test_serializer.c
@@ -258,7 +258,7 @@ void test_serialize_send_mam_message(void) {
                      "\","
                      "\"bundle_hash\":\"" TRYTES_81_2 "\"}";
   char* json_result;
-  send_mam_res_t* res = send_mam_res_new();
+  ta_send_mam_res_t* res = send_mam_res_new();
 
   send_mam_res_set_bundle_hash(res, (tryte_t*)TRYTES_81_2);
   send_mam_res_set_channel_id(res, (tryte_t*)TRYTES_81_1);
@@ -274,7 +274,7 @@ void test_deserialize_send_mam_message_response(void) {
   const char* json = "{\"channel\":\"" TRYTES_81_1
                      "\","
                      "\"bundle_hash\":\"" TRYTES_81_2 "\"}";
-  send_mam_res_t* res = send_mam_res_new();
+  ta_send_mam_res_t* res = send_mam_res_new();
 
   send_mam_res_deserialize(json, res);
 
@@ -286,7 +286,7 @@ void test_deserialize_send_mam_message_response(void) {
 
 void test_deserialize_send_mam_message(void) {
   const char* json = "{\"message\":\"" TEST_PAYLOAD "\"}";
-  send_mam_req_t* req = send_mam_req_new();
+  ta_send_mam_req_t* req = send_mam_req_new();
 
   send_mam_req_deserialize(json, req);
 

--- a/utils/fill_nines.h
+++ b/utils/fill_nines.h
@@ -9,6 +9,10 @@ extern "C" {
 #endif
 
 /**
+ * @file utils/fill_nines.h
+ */
+
+/**
  * @brief Patch input string with nines into assigned length.
  *
  * @param[out] new_str Output patched string


### PR DESCRIPTION
Some files were not included in doxygen document. The missing files are added to doxygen produced documents in this PR. 
And in order to achieve consistency `send_mam` objects are renamed to `ta_send_mam` object.