### PR TITLE
fix(reg): Reslove regression port conflicts

### DIFF
--- a/tests/regression/1_run_TA.sh
+++ b/tests/regression/1_run_TA.sh
@@ -2,8 +2,7 @@ make
 
 redis-server &
 
-bazel run //accelerator &
-TA_pid=$!
+bazel run -- accelerator --ta_port=$1&
 sleep 5
 
 pip install --user -r tests/regression/requirements.txt


### PR DESCRIPTION
Using default port setting caused regression test failed during CI.
Now, we can assign whished port for CI as shell script argument.

CI result: https://buildkite.com/dltcollab/ta-regression-test-hojmay/builds/269

