### PR TITLE
refactor(api): Use entangled original APIs iota_client_get_tips and iota_client_get_transactions_to_approve

### DIFF
--- a/accelerator/common_core.c
+++ b/accelerator/common_core.c
@@ -39,30 +39,6 @@ done:
   return ret;
 }
 
-status_t cclient_get_tips(const iota_client_service_t* const service, ta_get_tips_res_t* res) {
-  if (res == NULL) {
-    return SC_TA_NULL;
-  }
-  status_t ret = SC_OK;
-  get_tips_res_t* get_tips_res = get_tips_res_new();
-  if (get_tips_res == NULL) {
-    ret = SC_CCLIENT_OOM;
-    goto done;
-  }
-
-  ret = iota_client_get_tips(service, get_tips_res);
-  if (ret) {
-    ret = SC_CCLIENT_FAILED_RESPONSE;
-    goto done;
-  }
-  res->tips = get_tips_res->hashes;
-  get_tips_res->hashes = NULL;
-
-done:
-  get_tips_res_free(&get_tips_res);
-  return ret;
-}
-
 status_t ta_attach_to_tangle(const attach_to_tangle_req_t* const req, attach_to_tangle_res_t* res) {
   status_t ret = SC_OK;
   bundle_transactions_t* bundle = NULL;

--- a/accelerator/common_core.h
+++ b/accelerator/common_core.h
@@ -41,21 +41,6 @@ status_t cclient_get_txn_to_approve(const iota_client_service_t* const service, 
                                     ta_get_tips_res_t* res);
 
 /**
- * @brief Get list of all tips from IRI node.
- *
- * Get list of all tips from IRI node which usually has thousands of tips in
- * its queue.
- *
- * @param[in] service IRI node end point service
- * @param[out] res Result containing list of all tips in ta_get_tips_res_t
- *
- * @return
- * - SC_OK on success
- * - non-zero on error
- */
-status_t cclient_get_tips(const iota_client_service_t* const service, ta_get_tips_res_t* res);
-
-/**
  * @brief Generate an unused address.
  *
  * Generate and return an unused address from the seed. An unused address means

--- a/serializer/BUILD
+++ b/serializer/BUILD
@@ -13,6 +13,7 @@ cc_library(
         "@cJSON",
         "@entangled//common/trinary:flex_trit",
         "@entangled//common/trinary:tryte_ascii",
+        "@entangled//utils:char_buffer",
         "@entangled//utils/containers/hash:hash_array",
     ],
 )

--- a/serializer/serializer.c
+++ b/serializer/serializer.c
@@ -233,25 +233,6 @@ status_t ta_generate_address_res_serialize(char** obj, const ta_generate_address
   return ret;
 }
 
-status_t ta_get_tips_res_serialize(char** obj, const ta_get_tips_res_t* const res) {
-  cJSON* json_root = cJSON_CreateObject();
-  status_t ret = SC_OK;
-  if (json_root == NULL) {
-    return SC_SERIALIZER_JSON_CREATE;
-  }
-  ret = ta_hash243_stack_to_json_array(res->tips, json_root, "tips");
-  if (ret) {
-    return ret;
-  }
-
-  *obj = cJSON_PrintUnformatted(json_root);
-  if (*obj == NULL) {
-    return SC_SERIALIZER_JSON_PARSE;
-  }
-  cJSON_Delete(json_root);
-  return ret;
-}
-
 status_t ta_send_transfer_req_deserialize(const char* const obj, ta_send_transfer_req_t* req) {
   if (obj == NULL) {
     return SC_SERIALIZER_NULL;

--- a/serializer/serializer.h
+++ b/serializer/serializer.h
@@ -5,6 +5,7 @@
 #include "common/trinary/tryte_ascii.h"
 #include "request/request.h"
 #include "response/response.h"
+#include "utils/char_buffer.h"
 #include "utils/containers/hash/hash_array.h"
 #include "utils/fill_nines.h"
 
@@ -43,18 +44,6 @@ extern "C" {
  * - non-zero on error
  */
 status_t ta_generate_address_res_serialize(char** obj, const ta_generate_address_res_t* const res);
-
-/**
- * @brief Serialze type of ta_get_tips_res_t to JSON string
- *
- * @param[out] obj List of tip hashes in JSON
- * @param[in] res Response data in type of ta_get_tips_res_t
- *
- * @return
- * - SC_OK on success
- * - non-zero on error
- */
-status_t ta_get_tips_res_serialize(char** obj, const ta_get_tips_res_t* const res);
 
 /**
  * @brief Deserialze JSON string to type of ta_send_transfer_req_t
@@ -176,6 +165,7 @@ status_t send_mam_res_deserialize(const char* const obj, ta_send_mam_res_t* cons
  * - non-zero on error
  */
 status_t send_mam_req_deserialize(const char* const obj, ta_send_mam_req_t* req);
+
 #ifdef __cplusplus
 }
 #endif

--- a/tests/test_common.cc
+++ b/tests/test_common.cc
@@ -26,21 +26,6 @@ TEST(GetTxnToApproveTest, TrunkBranchHashTest) {
   ta_get_tips_res_free(&res);
 }
 
-TEST(GetTipsTest, TipsHashTest) {
-  ta_get_tips_res_t* res = ta_get_tips_res_new();
-  flex_trit_t hash_trits_1[FLEX_TRIT_SIZE_243];
-  flex_trits_from_trytes(hash_trits_1, NUM_TRITS_HASH, (const tryte_t*)TRYTES_81_1, NUM_TRYTES_HASH, NUM_TRYTES_HASH);
-
-  EXPECT_CALL(APIMockObj, iota_client_get_tips(_, _)).Times(AtLeast(1));
-
-  EXPECT_EQ(cclient_get_tips(&service, res), 0);
-  hash243_stack_entry_t* s_iter = NULL;
-  LL_FOREACH(res->tips, s_iter) {
-    EXPECT_FALSE(memcmp(s_iter->hash, hash_trits_1, sizeof(flex_trit_t) * FLEX_TRIT_SIZE_243));
-  }
-  ta_get_tips_res_free(&res);
-}
-
 TEST(FindTxnTest, TxnHashTest) {
   const char req[NUM_TRYTES_TAG] = {};
   ta_find_transactions_res_t* res = ta_find_transactions_res_new();

--- a/tests/test_serializer.c
+++ b/tests/test_serializer.c
@@ -1,23 +1,6 @@
 #include "serializer/serializer.h"
 #include "test_define.h"
 
-void test_serialize_ta_get_tips(void) {
-  const char* json = "{\"tips\":[\"" TRYTES_81_1 "\",\"" TRYTES_81_2 "\"]}";
-  char* json_result;
-  ta_get_tips_res_t* res = ta_get_tips_res_new();
-  flex_trit_t hash_trits_1[FLEX_TRIT_SIZE_243], hash_trits_2[FLEX_TRIT_SIZE_243];
-  flex_trits_from_trytes(hash_trits_1, NUM_TRITS_HASH, (const tryte_t*)TRYTES_81_1, NUM_TRYTES_HASH, NUM_TRYTES_HASH);
-  flex_trits_from_trytes(hash_trits_2, NUM_TRITS_HASH, (const tryte_t*)TRYTES_81_2, NUM_TRYTES_HASH, NUM_TRYTES_HASH);
-
-  hash243_stack_push(&res->tips, hash_trits_2);
-  hash243_stack_push(&res->tips, hash_trits_1);
-
-  ta_get_tips_res_serialize(&json_result, res);
-  TEST_ASSERT_EQUAL_STRING(json, json_result);
-  ta_get_tips_res_free(&res);
-  free(json_result);
-}
-
 void test_serialize_ta_generate_address(void) {
   const char* json = "{\"address\":[\"" TRYTES_81_1 "\",\"" TRYTES_81_2 "\"]}";
   char* json_result;
@@ -311,7 +294,6 @@ void test_serialize_ta_send_trytes_res(void) {
 int main(void) {
   UNITY_BEGIN();
 
-  RUN_TEST(test_serialize_ta_get_tips);
   RUN_TEST(test_serialize_ta_generate_address);
   RUN_TEST(test_deserialize_ta_send_transfer);
   RUN_TEST(test_serialize_ta_get_transaction_object);


### PR DESCRIPTION
Discard our own implemeneted `cclient_get_tips()` and use etangled original function `iota_client_get_tips()`. The related functions in serializer.[c, h] have been removed as well.

In `api_get_tips_pair()`, we discard our own implemented `cclient_get_txn_to_approve()`, and
use entangled original function `iota_client_get_transactions_to_approve()`.