### PR TITLE
api_get_transaction_object takes multiple hashes

### DIFF
--- a/accelerator/common_core.c
+++ b/accelerator/common_core.c
@@ -276,16 +276,16 @@ done:
   return ret;
 }
 
-status_t ta_get_transaction_object(const iota_client_service_t* const service, const char* const req,
+status_t ta_get_transaction_object(const iota_client_service_t* const service,
+                                   const ta_get_transaction_object_req_t* const req,
                                    ta_get_transaction_object_res_t* res) {
-  if (res == NULL) {
+  if (req == NULL || res == NULL) {
     return SC_TA_NULL;
   }
 
   status_t ret = SC_OK;
   flex_trit_t tx_trits[FLEX_TRIT_SIZE_8019];
   flex_trit_t hash_trits[NUM_TRITS_HASH];
-  flex_trits_from_trytes(hash_trits, NUM_TRITS_HASH, (const tryte_t*)req, NUM_TRYTES_HASH, NUM_TRYTES_HASH);
   char cache_value[FLEX_TRIT_SIZE_8019] = {0};
 
   // get raw transaction data of transaction hashes
@@ -296,45 +296,53 @@ status_t ta_get_transaction_object(const iota_client_service_t* const service, c
     goto done;
   }
 
-  // get in cache first, then get from full node if no result in cache
-  ret = cache_get(req, cache_value);
-  if (ret == SC_OK) {
-    flex_trits_from_trytes(tx_trits, NUM_TRITS_SERIALIZED_TRANSACTION, (const tryte_t*)cache_value,
-                           NUM_TRYTES_SERIALIZED_TRANSACTION, NUM_TRYTES_SERIALIZED_TRANSACTION);
-  } else {
-    ret = hash243_queue_push(&get_trytes_req->hashes, hash_trits);
-    if (ret) {
-      ret = SC_CCLIENT_HASH;
-      goto done;
+  
+  char** elt = NULL;
+  while ((elt = (char**)utarray_next(req->hashes, elt))) {
+    // get in cache first, then get from full node if no result in cache
+    printf("elt = %s \n", *elt);
+    ret = cache_get(*elt, cache_value);
+    if (ret == SC_OK) {
+      flex_trits_from_trytes(tx_trits, NUM_TRITS_SERIALIZED_TRANSACTION, (const tryte_t*)cache_value,
+                             NUM_TRYTES_SERIALIZED_TRANSACTION, NUM_TRYTES_SERIALIZED_TRANSACTION);
+    } else {
+      flex_trits_from_trytes(hash_trits, NUM_TRITS_HASH, (const tryte_t*)elt, NUM_TRYTES_HASH, NUM_TRYTES_HASH);
+      ret = hash243_queue_push(&get_trytes_req->hashes, hash_trits);
+      if (ret) {
+        ret = SC_CCLIENT_HASH;
+        goto done;
+      }
+
+      ret = iota_client_get_trytes(service, get_trytes_req, get_trytes_res);
+      if (ret) {
+        ret = SC_CCLIENT_FAILED_RESPONSE;
+        goto done;
+      }
+
+      memcpy(tx_trits, hash8019_queue_peek(get_trytes_res->trytes), FLEX_TRIT_SIZE_8019);
+
+      // set into cache if get_trytes response is not null trytes
+      if (!flex_trits_are_null(tx_trits, FLEX_TRIT_SIZE_8019)) {
+        flex_trits_to_trytes((tryte_t*)cache_value, NUM_TRYTES_SERIALIZED_TRANSACTION, tx_trits,
+                             NUM_TRITS_SERIALIZED_TRANSACTION, NUM_TRITS_SERIALIZED_TRANSACTION);
+        cache_set(elt, cache_value);
+      } else {
+        ret = SC_CCLIENT_NOT_FOUND;
+        goto done;
+      }
     }
 
-    ret = iota_client_get_trytes(service, get_trytes_req, get_trytes_res);
-    if (ret) {
+    // deserialize raw data to transaction object
+    iota_transaction_t *txn = transaction_deserialize(tx_trits, 0);
+    if (txn == NULL) {
       ret = SC_CCLIENT_FAILED_RESPONSE;
       goto done;
     }
-
-    memcpy(tx_trits, hash8019_queue_peek(get_trytes_res->trytes), FLEX_TRIT_SIZE_8019);
-
-    // set into cache if get_trytes response is not null trytes
-    if (!flex_trits_are_null(tx_trits, FLEX_TRIT_SIZE_8019)) {
-      flex_trits_to_trytes((tryte_t*)cache_value, NUM_TRYTES_SERIALIZED_TRANSACTION, tx_trits,
-                           NUM_TRITS_SERIALIZED_TRANSACTION, NUM_TRITS_SERIALIZED_TRANSACTION);
-      cache_set(req, cache_value);
-    } else {
-      ret = SC_CCLIENT_NOT_FOUND;
-      goto done;
-    }
+    transaction_set_hash(txn, hash_trits);
+    transaction_array_push_back(res->txn_array, txn);
   }
 
-  // deserialize raw data to transaction object
-  res->txn = transaction_deserialize(tx_trits, 0);
-  if (res->txn == NULL) {
-    ret = SC_CCLIENT_FAILED_RESPONSE;
-    goto done;
-  }
-  transaction_set_hash(res->txn, hash_trits);
-
+  
 done:
   get_trytes_req_free(&get_trytes_req);
   get_trytes_res_free(&get_trytes_res);
@@ -365,23 +373,24 @@ status_t ta_find_transactions_obj_by_tag(const iota_client_service_t* const serv
 
   // get transaction obj
   hash243_queue_entry_t* q_iter = NULL;
-  CDL_FOREACH(hash_res->hashes, q_iter) {
-    ta_get_transaction_object_res_t* obj_res = ta_get_transaction_object_res_new();
-    if (obj_res == NULL) {
+  ta_get_transaction_object_req_t* obj_req = ta_get_transaction_object_req_new();
+  ta_get_transaction_object_res_t* obj_res = ta_get_transaction_object_res_new();
+  if (obj_req == NULL || obj_res == NULL) {
       ret = SC_TA_OOM;
       goto done;
-    }
-    flex_trits_to_trytes((tryte_t*)hash_trytes, NUM_TRYTES_HASH, q_iter->hash, NUM_TRITS_HASH, NUM_TRITS_HASH);
-    hash_trytes[NUM_TRYTES_HASH] = '\0';
-
-    ret = ta_get_transaction_object(service, hash_trytes, obj_res);
-    if (ret != SC_OK) {
-      break;
-    }
-    ta_get_transaction_object_res_free(&obj_res);
   }
 
+  CDL_FOREACH(hash_res->hashes, q_iter) {  
+    flex_trits_to_trytes((tryte_t*)hash_trytes, NUM_TRYTES_HASH, q_iter->hash, NUM_TRITS_HASH, NUM_TRITS_HASH);
+    hash_trytes[NUM_TRYTES_HASH] = '\0';
+    ta_get_transaction_object_req_push_address(obj_req, hash_trytes);
+  }
+
+  ret = ta_get_transaction_object(service, obj_req, obj_res);
+  
 done:
+  ta_get_transaction_object_req_free(&obj_req);
+  ta_get_transaction_object_res_free(&obj_res);
   ta_find_transactions_res_free(&hash_res);
   return ret;
 }

--- a/accelerator/common_core.h
+++ b/accelerator/common_core.h
@@ -148,7 +148,7 @@ status_t ta_find_transactions_obj_by_tag(const iota_client_service_t* const serv
  * - SC_OK on success
  * - non-zero on error
  */
-status_t ta_get_transaction_object(const iota_client_service_t* const service, const char* const req,
+status_t ta_get_transaction_object(const iota_client_service_t* const service, const ta_get_transaction_object_req_t* const req,
                                    ta_get_transaction_object_res_t* res);
 
 /**

--- a/request/BUILD
+++ b/request/BUILD
@@ -12,6 +12,7 @@ cc_library(
         "//accelerator:ta_errors",
         "@entangled//common:errors",
         "@entangled//common/trinary:tryte",
+        "@entangled//common/model:transaction",
         "@entangled//utils/containers/hash:hash243_queue",
         "@entangled//utils/containers/hash:hash81_queue",
     ],

--- a/request/request.h
+++ b/request/request.h
@@ -3,6 +3,7 @@
 
 #include "request/ta_send_mam.h"
 #include "request/ta_send_transfer.h"
+#include "request/ta_get_transaction_object.h"
 
 /**
  * @file request.h

--- a/request/ta_get_transaction_object.c
+++ b/request/ta_get_transaction_object.c
@@ -1,0 +1,33 @@
+#include "ta_get_transaction_object.h"
+
+ta_get_transaction_object_req_t* ta_get_transaction_object_req_new() {
+    ta_get_transaction_object_req_t *req = (ta_get_transaction_object_req_t*) malloc(sizeof(ta_get_transaction_object_req_t));
+    if (req != NULL)
+    {
+        utarray_new(req->hashes, &ut_str_icd);
+        return req;
+    }
+    return NULL;
+}
+
+status_t ta_get_transaction_object_req_push_address(ta_get_transaction_object_req_t *req, const char* const addr) {
+    if (req ==NULL || addr == NULL) {
+        return SC_TA_NULL;
+    }
+
+    if (req->hashes == NULL) {
+        utarray_new(req->hashes, &ut_str_icd);
+        if (req->hashes == NULL) {
+            return SC_TA_OOM;
+        }
+    }
+    utarray_push_back(req->hashes, &addr);
+    
+    return SC_OK;
+}
+
+void ta_get_transaction_object_req_free(ta_get_transaction_object_req_t** req) {
+    utarray_free((*req)->hashes);
+    free((*req));
+    *req = NULL;
+}

--- a/request/ta_get_transaction_object.h
+++ b/request/ta_get_transaction_object.h
@@ -1,0 +1,24 @@
+#ifndef REQUEST_TA_GET_TRANSACTION_OBJECT_H_
+#define REQUEST_TA_GET_TRANSACTION_OBJECT_H_
+
+#include "utarray.h"
+#include "accelerator/errors.h"
+#include "common/model/transaction.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct{
+    UT_array* hashes;
+} ta_get_transaction_object_req_t;
+
+ta_get_transaction_object_req_t* ta_get_transaction_object_req_new();
+status_t ta_get_transaction_object_req_push_address(ta_get_transaction_object_req_t *req, const char* const addr);
+void ta_get_transaction_object_req_free(ta_get_transaction_object_req_t** req);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // REQUEST_TA_GET_TRANSACTION_OBJECT_H_

--- a/response/ta_find_transactions_obj.h
+++ b/response/ta_find_transactions_obj.h
@@ -14,8 +14,8 @@ extern "C" {
 
 /** struct of ta_find_transactions_obj_res_t */
 typedef struct ta_find_transactions_obj_res {
-  /** Transaction objects is a iota_transaction_t UT_array. */
-  UT_array* txn_obj;
+  /** Transaction objects is transaction_array_t. */
+  transaction_array_t* txn_obj;
 } ta_find_transactions_obj_res_t;
 
 /**

--- a/response/ta_get_transaction_object.c
+++ b/response/ta_get_transaction_object.c
@@ -4,7 +4,7 @@ ta_get_transaction_object_res_t* ta_get_transaction_object_res_new() {
   ta_get_transaction_object_res_t* res =
       (ta_get_transaction_object_res_t*)malloc(sizeof(ta_get_transaction_object_res_t));
   if (res) {
-    res->txn = NULL;
+    res->txn_array = transaction_array_new();
   }
   return res;
 }
@@ -14,8 +14,8 @@ void ta_get_transaction_object_res_free(ta_get_transaction_object_res_t** res) {
     return;
   }
 
-  if ((*res)->txn) {
-    transaction_free((*res)->txn);
+  if ((*res)->txn_array) {
+    transaction_array_free((*res)->txn_array);
   }
   free(*res);
   *res = NULL;

--- a/response/ta_get_transaction_object.h
+++ b/response/ta_get_transaction_object.h
@@ -14,7 +14,7 @@ extern "C" {
 /** struct of ta_get_transaction_object_res_t */
 typedef struct ta_get_transaction_object_res {
   /** Transaction is a iota_transaction_t list. */
-  iota_transaction_t* txn;
+  transaction_array_t* txn_array;
 } ta_get_transaction_object_res_t;
 
 /**

--- a/serializer/serializer.c
+++ b/serializer/serializer.c
@@ -382,19 +382,32 @@ done:
   return ret;
 }
 
+status_t ta_get_transaction_object_req_deserialize(char** obj, const ta_get_transaction_object_req_t* const req) {
+  status_t ret = SC_OK;
+  cJSON *json_obj = cJSON_Parse(obj);
+  
+  if (json_string_array_to_utarray(*obj, "hashes", req->hashes) != RC_OK){
+    ret = SC_SERIALIZER_JSON_PARSE;
+  }
+  
+  cJSON_Delete(json_obj);
+  return ret;
+}
+
 status_t ta_get_transaction_object_res_serialize(char** obj, const ta_get_transaction_object_res_t* const res) {
   status_t ret = SC_OK;
-  cJSON* json_root = NULL;
-
-  ret = iota_transaction_to_json_object(res->txn, &json_root);
-  if (ret) {
+  cJSON* json_root = cJSON_CreateObject();
+  
+  if (utarray_to_json_array(res->txn_array, json_root, "hashes") != RC_OK) {
+    ret = SC_SERIALIZER_JSON_PARSE;
     goto done;
   }
+
   *obj = cJSON_PrintUnformatted(json_root);
   if (*obj == NULL) {
     ret = SC_SERIALIZER_JSON_PARSE;
   }
-
+  
 done:
   cJSON_Delete(json_root);
   return ret;

--- a/serializer/serializer.h
+++ b/serializer/serializer.h
@@ -83,6 +83,18 @@ status_t ta_send_trytes_req_deserialize(const char* const obj, hash8019_array_p 
 status_t ta_send_trytes_res_serialize(const hash8019_array_p trytes, char** obj);
 
 /**
+ * @brief Deserialze type of ta_get_transaction_object_req_t from JSON string
+ *
+ * @param[in] obj List of transaction hash
+ * @param[out] res Response data in type of ta_get_transaction_object_req_t
+ *
+ * @return
+ * - SC_OK on success
+ * - non-zero on error
+ */
+status_t ta_get_transaction_object_req_deserialize(char** obj, const ta_get_transaction_object_req_t* const req);
+
+/**
  * @brief Serialze type of ta_get_transaction_object_res_t to JSON string
  *
  * @param[out] obj List of transaction object in JSON

--- a/tests/test_common.cc
+++ b/tests/test_common.cc
@@ -1,3 +1,4 @@
+#include "stdio.h"
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 #include "accelerator/common_core.h"
@@ -59,16 +60,19 @@ TEST(GenAdressTest, GetNewAddressTest) {
 }
 
 TEST(GetTxnObjTest, GetTrytesTest) {
-  const char req[FLEX_TRIT_SIZE_243] = {};
   flex_trit_t* txn_msg = NULL;
+  ta_get_transaction_object_req_t* req = ta_get_transaction_object_req_new();
   ta_get_transaction_object_res_t* res = ta_get_transaction_object_res_new();
   flex_trit_t msg_trits[FLEX_TRIT_SIZE_6561];
   flex_trits_from_trytes(msg_trits, NUM_TRITS_SIGNATURE, (const tryte_t*)TRYTES_2187_1, NUM_TRYTES_SIGNATURE,
                          NUM_TRYTES_SIGNATURE);
-
+                         
+  ta_get_transaction_object_req_push_address(req, TRYTES_81_1);
   EXPECT_CALL(APIMockObj, iota_client_get_trytes(_, _, _)).Times(AtLeast(0));
   EXPECT_EQ(ta_get_transaction_object(&service, req, res), 0);
-  txn_msg = transaction_message(res->txn);
+  
+  iota_transaction_t *txn = transaction_array_at(res->txn_array, 0);
+  txn_msg = transaction_message(txn);
   EXPECT_FALSE(memcmp(txn_msg, msg_trits, sizeof(flex_trit_t) * FLEX_TRIT_SIZE_6561));
   ta_get_transaction_object_res_free(&res);
 }

--- a/tests/test_serializer.c
+++ b/tests/test_serializer.c
@@ -60,51 +60,51 @@ void test_serialize_ta_get_transaction_object(void) {
   flex_trit_t msg_trits[FLEX_TRIT_SIZE_6561], tag_trits[FLEX_TRIT_SIZE_81], hash_trits_1[FLEX_TRIT_SIZE_243],
       hash_trits_2[FLEX_TRIT_SIZE_243];
   ta_get_transaction_object_res_t* res = ta_get_transaction_object_res_new();
-  res->txn = transaction_new();
+  //res->txn = transaction_new();
 
   flex_trits_from_trytes(hash_trits_1, NUM_TRITS_HASH, (const tryte_t*)TRYTES_81_1, NUM_TRYTES_HASH, NUM_TRYTES_HASH);
   flex_trits_from_trytes(hash_trits_2, NUM_TRITS_HASH, (const tryte_t*)TRYTES_81_2, NUM_TRYTES_HASH, NUM_TRYTES_HASH);
-
+  iota_transaction_t *txn = transaction_array_at(res->txn_array, 0);
   // set transaction hash
-  transaction_set_hash(res->txn, hash_trits_1);
+  transaction_set_hash(txn, hash_trits_1);
 
   // set message
   flex_trits_from_trytes(msg_trits, NUM_TRITS_SIGNATURE, (const tryte_t*)TRYTES_2187_1, NUM_TRYTES_SIGNATURE,
                          NUM_TRYTES_SIGNATURE);
-  transaction_set_signature(res->txn, msg_trits);
+  transaction_set_signature(txn, msg_trits);
 
   // set address
-  transaction_set_address(res->txn, hash_trits_1);
+  transaction_set_address(txn, hash_trits_1);
   // set value
-  transaction_set_value(res->txn, VALUE);
+  transaction_set_value(txn, VALUE);
 
   // set obsolete_tag
   flex_trits_from_trytes(tag_trits, NUM_TRITS_TAG, (const tryte_t*)TAG_MSG, NUM_TRYTES_TAG, NUM_TRYTES_TAG);
-  transaction_set_obsolete_tag(res->txn, tag_trits);
+  transaction_set_obsolete_tag(txn, tag_trits);
 
   // set timestamp
-  transaction_set_timestamp(res->txn, TIMESTAMP);
+  transaction_set_timestamp(txn, TIMESTAMP);
   // set current_index
-  transaction_set_current_index(res->txn, CURRENT_INDEX);
+  transaction_set_current_index(txn, CURRENT_INDEX);
   // set last_index
-  transaction_set_last_index(res->txn, LAST_INDEX);
+  transaction_set_last_index(txn, LAST_INDEX);
   // set bundle_hash
-  transaction_set_bundle(res->txn, hash_trits_2);
+  transaction_set_bundle(txn, hash_trits_2);
   // set trunk
-  transaction_set_trunk(res->txn, hash_trits_2);
+  transaction_set_trunk(txn, hash_trits_2);
   // set branch
-  transaction_set_branch(res->txn, hash_trits_1);
+  transaction_set_branch(txn, hash_trits_1);
   // set tag
-  transaction_set_tag(res->txn, tag_trits);
+  transaction_set_tag(txn, tag_trits);
   // set attachment_timestamp
-  transaction_set_attachment_timestamp(res->txn, TIMESTAMP);
+  transaction_set_attachment_timestamp(txn, TIMESTAMP);
   // set attachment_timestamp_lower_bound
-  transaction_set_attachment_timestamp_lower(res->txn, TIMESTAMP);
+  transaction_set_attachment_timestamp_lower(txn, TIMESTAMP);
   // set attachment_timestamp_upper_bound
-  transaction_set_attachment_timestamp_upper(res->txn, TIMESTAMP);
+  transaction_set_attachment_timestamp_upper(txn, TIMESTAMP);
   // set nonce
   flex_trits_from_trytes(tag_trits, NUM_TRITS_NONCE, (const tryte_t*)NONCE, NUM_TRYTES_NONCE, NUM_TRYTES_NONCE);
-  transaction_set_nonce(res->txn, tag_trits);
+  transaction_set_nonce(txn, tag_trits);
 
   ta_get_transaction_object_res_serialize(&json_result, res);
 


### PR DESCRIPTION
We defined some request/response objects for TA.  I removed the objects and replaced them with entangled orignal object.
Fixes #214 