### PR TITLE
 feat(accel): Refactor send mam API

### DIFF
--- a/accelerator/BUILD
+++ b/accelerator/BUILD
@@ -26,6 +26,7 @@ cc_library(
     deps = [
         ":common_core",
         ":ta_errors",
+        "//map:mode",
         "//serializer",
         "@entangled//common/model:bundle",
         "@entangled//common/trinary:trit_tryte",

--- a/accelerator/config.c
+++ b/accelerator/config.c
@@ -86,9 +86,6 @@ status_t ta_config_default_init(ta_config_t* const info, iota_config_t* const ta
 
   log_info(logger_id, "Initializing IRI configuration\n");
   tangle->milestone_depth = MILESTONE_DEPTH;
-  mkstemp(mss_tmp);
-  strncpy(tangle->mam_file, mss_tmp, FSIZE);
-  tangle->mss_depth = MSS_DEPTH;
   tangle->mwm = MWM;
   tangle->seed = SEED;
 

--- a/accelerator/config.h
+++ b/accelerator/config.h
@@ -26,7 +26,6 @@ extern "C" {
 #define IRI_PORT 14265
 #define MILESTONE_DEPTH 3
 #define FSIZE 11
-#define MSS_DEPTH 4
 #define MWM 14
 #define SEED                                                                   \
   "AMRWQP9BUMJALJHBXUCHOD9HFFD9LGTGEAWMJWWXSDVOF9PI9YGJAPBQLQUOMNYEQCZPGCTHGV" \
@@ -49,8 +48,6 @@ typedef struct ta_info_s {
 /** struct type of iota configuration */
 typedef struct ta_config_s {
   uint8_t milestone_depth; /**< Depth of API argument */
-  char mam_file[FSIZE];    /** Save file for mam struct like MSS, skn... */
-  uint8_t mss_depth;       /**< Depth of MSS layer merkle tree */
   uint8_t mwm;             /**< Minimum weight magnitude of API argument */
   /** Seed to generate address. This does not do any signature yet. */
   const char* seed;

--- a/map/BUILD
+++ b/map/BUILD
@@ -1,0 +1,11 @@
+package(default_visibility = ["//visibility:public"])
+
+cc_library(
+    name = "mode",
+    srcs = ["mode.c"],
+    hdrs = ["mode.h"],
+    deps = [
+        "@entangled//common/trinary:tryte_ascii",
+        "@entangled//mam/api",
+    ],
+)

--- a/map/mode.h
+++ b/map/mode.h
@@ -1,0 +1,98 @@
+#ifndef __MAP_MODE_H__
+#define __MAP_MODE_H__
+
+#include "mam/api/api.h"
+
+#define MSS_DEPTH 1
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * Creates a channel
+ *
+ * @param api - The API [in,out]
+ * @param channel_id - A known channel ID [out]
+ *
+ * @return return code
+ */
+retcode_t map_channel_create(mam_api_t* const api, tryte_t* const channel_id);
+
+/**
+ * Creates and announce a new channel on header
+ *
+ * @param api - The API [in,out]
+ * @param channel_id - A known channel ID [in]
+ * @param bundle - The bundle that the packet will be written into [out]
+ * @param msg_id - The msg_id [out]
+ * @param new_channel_id - The new channel ID [out]
+ *
+ * @return return code
+ */
+retcode_t map_announce_channel(mam_api_t* const api, tryte_t const* const channel_id,
+                               bundle_transactions_t* const bundle, trit_t* const msg_id,
+                               tryte_t* const new_channel_id);
+
+/**
+ * Creates and announce a new endpoint on header
+ *
+ * @param api - The API [in,out]
+ * @param channel_id - A known channel ID [in]
+ * @param bundle - The bundle that the packet will be written into [out]
+ * @param msg_id - The msg_id [out]
+ * @param new_endpoint - The new endpoint [out]
+ *
+ * @return return code
+ */
+retcode_t map_announce_endpoint(mam_api_t* const api, tryte_t const* const channel_id,
+                                bundle_transactions_t* const bundle, trit_t* const msg_id,
+                                tryte_t* const new_endpoint_id);
+
+/**
+ * Writes a header only bundle on a channel
+ *
+ * @param api - The API [in,out]
+ * @param channel_id - A known channel ID [in]
+ * @param bundle - The bundle that the packet will be written into [out]
+ * @param msg_id - The msg_id [out]
+ *
+ * @return return code
+ */
+retcode_t map_write_header_on_channel(mam_api_t* const api, tryte_t const* const channel_id,
+                                      bundle_transactions_t* const bundle, trit_t* const msg_id);
+
+/**
+ * Writes a header only bundle on an endpoint
+ *
+ * @param api - The API [in,out]
+ * @param channel_id - A known channel ID [in]
+ * @param endpoint_id - A known endpoint ID [in]
+ * @param bundle - The bundle that the packet will be written into [out]
+ * @param msg_id - The msg_id [out]
+ *
+ * @return return code
+ */
+retcode_t map_write_header_on_endpoint(mam_api_t* const api, tryte_t const* const channel_id,
+                                       tryte_t const* const endpoint_id, bundle_transactions_t* const bundle,
+                                       trit_t* const msg_id);
+
+/**
+ * Writes a packet on a bundle
+ *
+ * @param api - The API [in,out]
+ * @param bundle - The bundle that the packet will be written into [out]
+ * @param payload - The payload to write [in]
+ * @param msg_id - The msg_id [in]
+ * @param is_last_packet - True if this is the last packet to be written [in]
+ *
+ * @return return code
+ */
+retcode_t map_write_packet(mam_api_t* const api, bundle_transactions_t* const bundle, char const* const payload,
+                           trit_t const* const msg_id, bool is_last_packet);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // __MAP_MODE_H__

--- a/request/ta_send_mam.c
+++ b/request/ta_send_mam.c
@@ -3,38 +3,23 @@
 ta_send_mam_req_t* send_mam_req_new() {
   ta_send_mam_req_t* req = (ta_send_mam_req_t*)malloc(sizeof(ta_send_mam_req_t));
   if (req) {
-    req->payload_trytes = NULL;
+    req->payload = NULL;
+    req->channel_ord = 0;
   }
 
   return req;
-}
-
-status_t send_mam_req_set_payload(ta_send_mam_req_t* req, const tryte_t* payload) {
-  status_t ret = SC_OK;
-  size_t payload_size = sizeof(payload) / sizeof(tryte_t);
-
-  if ((!payload) || (payload_size == 0) || ((payload_size * 3) > SIZE_MAX)) {
-    return SC_MAM_OOM;
-  }
-
-  req->payload_trytes = (tryte_t*)malloc(payload_size * sizeof(tryte_t));
-  if (!req->payload_trytes) {
-    return SC_MAM_OOM;
-  }
-  memcpy(req->payload_trytes, payload, payload_size);
-  req->payload_trytes_size = payload_size;
-
-  return ret;
 }
 
 void send_mam_req_free(ta_send_mam_req_t** req) {
   if (!req || !(*req)) {
     return;
   }
-  if ((*req)->payload_trytes) {
-    free((*req)->payload_trytes);
-    (*req)->payload_trytes = NULL;
+
+  if ((*req)->payload) {
+    free((*req)->payload);
+    (*req)->payload = NULL;
   }
+
   free(*req);
   *req = NULL;
 }

--- a/request/ta_send_mam.h
+++ b/request/ta_send_mam.h
@@ -16,8 +16,8 @@ extern "C" {
 
 /** struct of ta_send_transfer_req_t */
 typedef struct send_mam_req_s {
-  tryte_t* payload_trytes;
-  size_t payload_trytes_size;
+  char* payload;
+  uint8_t channel_ord;
 } ta_send_mam_req_t;
 
 /**
@@ -28,16 +28,6 @@ typedef struct send_mam_req_s {
  * - NULL on error
  */
 ta_send_mam_req_t* send_mam_req_new();
-
-/**
- * Set payload of ta_send_mam_req_t object
- *
- * @param req Data type of ta_send_transfer_req_t
- * @param payload Tryte data going to send with mam
- *
- * @return NULL
- */
-status_t send_mam_req_set_payload(ta_send_mam_req_t* req, const tryte_t* payload);
 
 /**
  * Free memory of ta_send_mam_req_t

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -82,6 +82,17 @@ cc_test(
     ],
 )
 
+cc_test(
+    name = "test_map_mode",
+    srcs = [
+        "test_map_mode.c",
+    ],
+    deps = [
+        ":test_define",
+        "//map:mode",
+    ],
+)
+
 cc_library(
     name = "test_define",
     hdrs = ["test_define.h"],

--- a/tests/test_map_mode.c
+++ b/tests/test_map_mode.c
@@ -1,0 +1,82 @@
+#include "map/mode.h"
+#include "test_define.h"
+
+#define CHID "UANFAVTSAXZMYUWRECNAOJDAQVTTORVGJCCISMZYAFFU9EYLBMZKEJ9VNXVFFGUTCHONEYVWVUTBTDJLO"
+#define NEW_CHID "ONMTPDICUWBGEGODWKGBGMLNAZFXNHCJITSSTBTGMXCXBXJFBPOPXFPOJTXKOOSAJOZAYANZZBFKYHJ9N"
+#define EPID "KI99YKKLFALYRUVRXKKRJCPVFISPMNCQQSMB9BGUWIHZTYFQOBZWYSVRNKVFJLSPPLPSFNBNREJWOR99U"
+
+void test_channel_create(void) {
+  mam_api_t mam;
+  tryte_t channel_id[MAM_CHANNEL_ID_TRYTE_SIZE + 1];
+  mam_api_init(&mam, (tryte_t *)TRYTES_81_1);
+
+  map_channel_create(&mam, channel_id);
+  channel_id[MAM_CHANNEL_ID_TRYTE_SIZE] = '\0';
+  TEST_ASSERT_EQUAL_STRING(CHID, channel_id);
+
+  mam_api_destroy(&mam);
+}
+
+void test_announce_channel(void) {
+  mam_api_t mam;
+  bundle_transactions_t *bundle = NULL;
+  bundle_transactions_new(&bundle);
+  tryte_t channel_id[MAM_CHANNEL_ID_TRYTE_SIZE + 1];
+  trit_t msg_id[MAM_MSG_ID_SIZE];
+  mam_api_init(&mam, (tryte_t *)TRYTES_81_1);
+
+  map_channel_create(&mam, channel_id);
+  map_announce_channel(&mam, channel_id, bundle, msg_id, channel_id);
+  channel_id[MAM_CHANNEL_ID_TRYTE_SIZE] = '\0';
+  TEST_ASSERT_EQUAL_STRING(NEW_CHID, channel_id);
+
+  bundle_transactions_free(&bundle);
+  mam_api_destroy(&mam);
+}
+
+void test_announce_endpoint(void) {
+  mam_api_t mam;
+  bundle_transactions_t *bundle = NULL;
+  bundle_transactions_new(&bundle);
+  tryte_t channel_id[MAM_CHANNEL_ID_TRYTE_SIZE + 1];
+  trit_t msg_id[MAM_MSG_ID_SIZE];
+  mam_api_init(&mam, (tryte_t *)TRYTES_81_1);
+
+  map_channel_create(&mam, channel_id);
+  // Channel_id is actually the new endpoint id
+  map_announce_endpoint(&mam, channel_id, bundle, msg_id, channel_id);
+  channel_id[MAM_CHANNEL_ID_TRYTE_SIZE] = '\0';
+  TEST_ASSERT_EQUAL_STRING(EPID, channel_id);
+
+  bundle_transactions_free(&bundle);
+  mam_api_destroy(&mam);
+}
+
+void test_write_message(void) {
+  mam_api_t mam;
+  bundle_transactions_t *bundle = NULL;
+  bundle_transactions_new(&bundle);
+  tryte_t channel_id[MAM_CHANNEL_ID_TRYTE_SIZE + 1];
+  trit_t msg_id[MAM_MSG_ID_SIZE];
+  mam_api_init(&mam, (tryte_t *)TRYTES_81_1);
+  retcode_t ret = RC_ERROR;
+
+  map_channel_create(&mam, channel_id);
+  ret = map_write_header_on_channel(&mam, channel_id, bundle, msg_id);
+  TEST_ASSERT_EQUAL(RC_OK, ret);
+
+  ret = map_write_packet(&mam, bundle, TEST_PAYLOAD, msg_id, true);
+  TEST_ASSERT_EQUAL(RC_OK, ret);
+
+  bundle_transactions_free(&bundle);
+  mam_api_destroy(&mam);
+}
+
+int main(void) {
+  UNITY_BEGIN();
+  RUN_TEST(test_channel_create);
+  RUN_TEST(test_announce_channel);
+  RUN_TEST(test_announce_endpoint);
+  RUN_TEST(test_write_message);
+  return UNITY_END();
+}

--- a/tests/test_serializer.c
+++ b/tests/test_serializer.c
@@ -236,19 +236,15 @@ void test_deserialize_send_mam_message_response(void) {
 }
 
 void test_deserialize_send_mam_message(void) {
-  const char* json = "{\"message\":\"" TEST_PAYLOAD "\"}";
+  const char* json = "{\"message\":\"" TEST_PAYLOAD
+                     "\","
+                     "\"order\":2}";
   ta_send_mam_req_t* req = send_mam_req_new();
 
   send_mam_req_deserialize(json, req);
+  TEST_ASSERT_EQUAL_STRING(TEST_PAYLOAD, req->payload);
+  TEST_ASSERT_EQUAL_INT(2, req->channel_ord);
 
-  size_t payload_size = strlen(TEST_PAYLOAD) * 2;
-  tryte_t* payload_trytes = (tryte_t*)malloc(payload_size * sizeof(tryte_t));
-  ascii_to_trytes(TEST_PAYLOAD, payload_trytes);
-
-  TEST_ASSERT_EQUAL_UINT(payload_size, req->payload_trytes_size);
-  TEST_ASSERT_EQUAL_MEMORY(payload_trytes, req->payload_trytes, payload_size);
-
-  free(payload_trytes);
   send_mam_req_free(&req);
 }
 


### PR DESCRIPTION
Move basic mam api into wrapper called map/mode. The wrapper is also moved
under the map directory which is stand for Mask Authenticated Privacy. It
will be a seperate binary to implement mam utility in the future.

Add a new argument "order" to specific channel order.  Functions are now
from map target and add test case for it. Type of send mam request is alos
refactored.