### PR TITLE
fix: Fix regression and common core errors

### DIFF
--- a/accelerator/apis.c
+++ b/accelerator/apis.c
@@ -21,11 +21,11 @@ status_t api_get_tips(const iota_client_service_t* const service, char** json_re
     goto done;
   }
 
-  *json_result = (char*)malloc(res_buff->length * sizeof(char));
+  *json_result = (char*)malloc((res_buff->length + 1) * sizeof(char));
   if (*json_result == NULL) {
     goto done;
   }
-  memcpy(*json_result, res_buff->data, res_buff->length);
+  snprintf(*json_result, (res_buff->length + 1), "%s", res_buff->data);
 
 done:
   get_tips_res_free(&res);
@@ -56,11 +56,11 @@ status_t api_get_tips_pair(const iota_config_t* const tangle, const iota_client_
     goto done;
   }
 
-  *json_result = (char*)malloc(res_buff->length * sizeof(char));
+  *json_result = (char*)malloc((res_buff->length + 1) * sizeof(char));
   if (*json_result == NULL) {
     goto done;
   }
-  memcpy(*json_result, res_buff->data, res_buff->length);
+  snprintf(*json_result, (res_buff->length + 1), "%s", res_buff->data);
 
 done:
   get_transactions_to_approve_req_free(&req);

--- a/accelerator/common_core.c
+++ b/accelerator/common_core.c
@@ -378,6 +378,8 @@ status_t ta_find_transactions_obj_by_tag(const iota_client_service_t* const serv
     if (ret != SC_OK) {
       break;
     }
+
+    utarray_push_back(res->txn_obj, obj_res->txn);
     ta_get_transaction_object_res_free(&obj_res);
   }
 

--- a/tests/regression/1_close_TA.sh
+++ b/tests/regression/1_close_TA.sh
@@ -1,8 +1,0 @@
-#!/usr/bin/env bash
-
-wait $(ps aux | grep '[r]unner.py' | awk '{print $2}')
-wait $(kill $(ps aux | grep '[r]edis' | awk '{print $2}'))
-wait $(kill $(ps aux | grep '[.]/accelerator' | awk '{print $2}'))
-
-trap 'exit 0' SIGTERM
-

--- a/tests/regression/1_run_TA.sh
+++ b/tests/regression/1_run_TA.sh
@@ -1,9 +1,0 @@
-make
-
-redis-server &
-
-bazel run -- accelerator --ta_port=$1&
-sleep 5
-
-pip install --user -r tests/regression/requirements.txt
-

--- a/tests/regression/1_run_TA_API.sh
+++ b/tests/regression/1_run_TA_API.sh
@@ -1,0 +1,16 @@
+make
+
+redis-server &
+
+bazel run -- accelerator --ta_port=$1&
+TA=$!
+sleep $2 # TA takes time to be built
+
+pip install --user -r tests/regression/requirements.txt
+python3 tests/regression/runner.py $3 $4 $5
+rc=$?
+
+if [[ $rc != 0 ]]; then exit -1 $rc; fi
+
+wait $(kill -9 $TA)
+trap 'exit 0' SIGTERM

--- a/tests/regression/runner.py
+++ b/tests/regression/runner.py
@@ -593,7 +593,7 @@ class Regression_Test(unittest.TestCase):
         for i in range(len(response)):
             if i in pass_case:
                 res_json = json.loads(response[i]["content"])
-                tips_hashes_array = res_json["tips"]
+                tips_hashes_array = res_json["hashes"]
 
                 for tx_hashes in tips_hashes_array:
                     self.assertTrue(valid_trytes(tx_hashes, LEN_ADDR))
@@ -635,11 +635,11 @@ class Regression_Test(unittest.TestCase):
         for i in range(len(response)):
             if i in pass_case:
                 res_json = json.loads(response[i]["content"])
-                tips_hashes_array = res_json["tips"]
 
-                self.assertTrue(2, len(tips_hashes_array))
-                for tx_hashes in tips_hashes_array:
-                    self.assertTrue(valid_trytes(tx_hashes, LEN_ADDR))
+                self.assertTrue(
+                    valid_trytes(res_json["trunkTransaction"], LEN_ADDR))
+                self.assertTrue(
+                    valid_trytes(res_json["branchTransaction"], LEN_ADDR))
             else:
                 # At this moment, api get_tips allow whatever string follow after /tips/pair
                 self.assertEqual(STATUS_CODE_200, response[i]["status_code"])
@@ -711,9 +711,9 @@ class Regression_Test(unittest.TestCase):
             all_9_context = fill_nines("", 2673 - 81 * 3)
             tips_response = API("/tips/pair/", get_data="")
             res_json = json.loads(tips_response["content"])
-            tips = res_json["tips"]
 
-            rand_trytes.append(all_9_context + tips[0] + tips[1] +
+            rand_trytes.append(all_9_context + res_json["trunkTransaction"] +
+                               res_json["branchTransaction"] +
                                fill_nines("", 81))
 
         query_string = [[rand_trytes[0]], [rand_trytes[0], rand_trytes[1]],


### PR DESCRIPTION
After TA was synchronized to the closer entagled commit, some of TA's response
fields were renamed, because we used entangled original serialzers.

To meet the different naming in the response of TA, the testing response's json key
have to be changed to cooperate with TA's response json key.

And the last cleanup causes empty response error of `ta_find_transactions_obj_by_tag`.
We fix that here.

Furthermore, the CI failures were resulted from bazel didn't have enough time
to build TA which makes no TA to process request sent from runner.py.
The problem can be solve easily by giving more time for bazel to build TA.
But in some situations, if the agent is parallelly executing other task (other CIs), then it may take more time for bazel to build TA or even causes failure.

CI result: https://buildkite.com/dltcollab/ta-regression-test-hojmay/builds/330