### PR TITLE
feat(api): Enhance send mam API with length detection

### DIFF
--- a/map/mode.c
+++ b/map/mode.c
@@ -2,9 +2,9 @@
 #include "common/trinary/tryte_ascii.h"
 #include "mam/mam/mam_channel_t_set.h"
 
-retcode_t map_channel_create(mam_api_t *const api, tryte_t *const channel_id) {
+retcode_t map_channel_create(mam_api_t *const api, tryte_t *const channel_id, const size_t depth) {
   if (mam_channel_t_set_size(api->channels) == 0) {
-    mam_api_channel_create(api, MSS_DEPTH, channel_id);
+    mam_api_channel_create(api, depth, channel_id);
   } else {
     mam_channel_t *channel = &api->channels->value;
     trits_to_trytes(trits_begin(mam_channel_id(channel)), channel_id, NUM_TRITS_ADDRESS);

--- a/map/mode.h
+++ b/map/mode.h
@@ -14,10 +14,11 @@ extern "C" {
  *
  * @param api - The API [in,out]
  * @param channel_id - A known channel ID [out]
+ * @param depth - depth of merkle tree going to generate [in]
  *
  * @return return code
  */
-retcode_t map_channel_create(mam_api_t* const api, tryte_t* const channel_id);
+retcode_t map_channel_create(mam_api_t* const api, tryte_t* const channel_id, const size_t depth);
 
 /**
  * Creates and announce a new channel on header

--- a/request/BUILD
+++ b/request/BUILD
@@ -11,6 +11,7 @@ cc_library(
     deps = [
         "//accelerator:ta_errors",
         "@entangled//common:errors",
+        "@entangled//common/model:transaction",
         "@entangled//common/trinary:tryte",
         "@entangled//utils/containers/hash:hash243_queue",
         "@entangled//utils/containers/hash:hash81_queue",

--- a/request/ta_send_mam.c
+++ b/request/ta_send_mam.c
@@ -3,6 +3,7 @@
 ta_send_mam_req_t* send_mam_req_new() {
   ta_send_mam_req_t* req = (ta_send_mam_req_t*)malloc(sizeof(ta_send_mam_req_t));
   if (req) {
+    req->prng[0] = 0;
     req->payload = NULL;
     req->channel_ord = 0;
   }

--- a/request/ta_send_mam.h
+++ b/request/ta_send_mam.h
@@ -4,6 +4,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include "accelerator/errors.h"
+#include "common/model/transaction.h"
 #include "common/trinary/tryte.h"
 
 #ifdef __cplusplus
@@ -16,6 +17,7 @@ extern "C" {
 
 /** struct of ta_send_transfer_req_t */
 typedef struct send_mam_req_s {
+  tryte_t prng[NUM_TRYTES_ADDRESS + 1];
   char* payload;
   uint8_t channel_ord;
 } ta_send_mam_req_t;

--- a/serializer/serializer.c
+++ b/serializer/serializer.c
@@ -550,6 +550,17 @@ status_t send_mam_req_deserialize(const char* const obj, ta_send_mam_req_t* req)
     goto done;
   }
 
+  json_result = cJSON_GetObjectItemCaseSensitive(json_obj, "prng");
+  if (json_result != NULL) {
+    size_t prng_size = strlen(json_result->valuestring);
+
+    if (prng_size != NUM_TRYTES_HASH) {
+      ret = SC_SERIALIZER_INVALID_REQ;
+      goto done;
+    }
+    snprintf(req->prng, prng_size + 1, "%s", json_result->valuestring);
+  }
+
   json_result = cJSON_GetObjectItemCaseSensitive(json_obj, "message");
   if (json_result != NULL) {
     size_t payload_size = strlen(json_result->valuestring);

--- a/tests/test_map_mode.c
+++ b/tests/test_map_mode.c
@@ -10,7 +10,7 @@ void test_channel_create(void) {
   tryte_t channel_id[MAM_CHANNEL_ID_TRYTE_SIZE + 1];
   mam_api_init(&mam, (tryte_t *)TRYTES_81_1);
 
-  map_channel_create(&mam, channel_id);
+  map_channel_create(&mam, channel_id, 1);
   channel_id[MAM_CHANNEL_ID_TRYTE_SIZE] = '\0';
   TEST_ASSERT_EQUAL_STRING(CHID, channel_id);
 
@@ -25,7 +25,7 @@ void test_announce_channel(void) {
   trit_t msg_id[MAM_MSG_ID_SIZE];
   mam_api_init(&mam, (tryte_t *)TRYTES_81_1);
 
-  map_channel_create(&mam, channel_id);
+  map_channel_create(&mam, channel_id, 1);
   map_announce_channel(&mam, channel_id, bundle, msg_id, channel_id);
   channel_id[MAM_CHANNEL_ID_TRYTE_SIZE] = '\0';
   TEST_ASSERT_EQUAL_STRING(NEW_CHID, channel_id);
@@ -42,7 +42,7 @@ void test_announce_endpoint(void) {
   trit_t msg_id[MAM_MSG_ID_SIZE];
   mam_api_init(&mam, (tryte_t *)TRYTES_81_1);
 
-  map_channel_create(&mam, channel_id);
+  map_channel_create(&mam, channel_id, 1);
   // Channel_id is actually the new endpoint id
   map_announce_endpoint(&mam, channel_id, bundle, msg_id, channel_id);
   channel_id[MAM_CHANNEL_ID_TRYTE_SIZE] = '\0';
@@ -61,7 +61,7 @@ void test_write_message(void) {
   mam_api_init(&mam, (tryte_t *)TRYTES_81_1);
   retcode_t ret = RC_ERROR;
 
-  map_channel_create(&mam, channel_id);
+  map_channel_create(&mam, channel_id, 1);
   ret = map_write_header_on_channel(&mam, channel_id, bundle, msg_id);
   TEST_ASSERT_EQUAL(RC_OK, ret);
 

--- a/tests/test_serializer.c
+++ b/tests/test_serializer.c
@@ -236,12 +236,11 @@ void test_deserialize_send_mam_message_response(void) {
 }
 
 void test_deserialize_send_mam_message(void) {
-  const char* json = "{\"message\":\"" TEST_PAYLOAD
-                     "\","
-                     "\"order\":2}";
+  const char* json = "{\"prng\":\"" TRYTES_81_1 "\",\"message\":\"" TEST_PAYLOAD "\",\"order\":2}";
   ta_send_mam_req_t* req = send_mam_req_new();
 
   send_mam_req_deserialize(json, req);
+  TEST_ASSERT_EQUAL_STRING(TRYTES_81_1, req->prng);
   TEST_ASSERT_EQUAL_STRING(TEST_PAYLOAD, req->payload);
   TEST_ASSERT_EQUAL_INT(2, req->channel_ord);
 


### PR DESCRIPTION
- Make send mam API able to check length of message and create exact sufficient mam channel depth. 
- Add optional parameter prng to make client able to create unique channel id.