### PR TITLE
fix(WORKSPACE): Bump bazel rules docker to 0.7.0

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -28,10 +28,14 @@ git_repository(
 git_repository(
     name = "io_bazel_rules_docker",
     remote = "https://github.com/bazelbuild/rules_docker.git",
-    tag = "v0.6.0",
+    tag = "v0.7.0",
 )
 
 load("@rules_iota//:defs.bzl", "iota_deps")
+load("@io_bazel_rules_docker//repositories:repositories.bzl", container_repositories = "repositories")
+
+container_repositories()
+
 load("@io_bazel_rules_docker//cc:image.bzl", _cc_image_repos = "repositories")
 
 iota_deps()


### PR DESCRIPTION
Fix #229 