### PR TITLE
fix(server): Check request body in POST api callback functions

### DIFF
--- a/accelerator/http.c
+++ b/accelerator/http.c
@@ -157,6 +157,13 @@ static inline int process_invalid_path_request(char **const out) {
   return MHD_HTTP_BAD_REQUEST;
 }
 
+static inline int process_method_not_allowed_request(char **const out) {
+  cJSON *json_obj = cJSON_CreateObject();
+  cJSON_AddStringToObject(json_obj, "message", "Method not allowed");
+  *out = cJSON_PrintUnformatted(json_obj);
+  return MHD_HTTP_METHOD_NOT_ALLOWED;
+}
+
 static inline int process_options_request(char **const out) {
   cJSON *json_obj = cJSON_CreateObject();
   cJSON_AddStringToObject(json_obj, "message", "OPTIONS request");
@@ -173,21 +180,41 @@ static int ta_http_process_request(ta_http_t *const http, char const *const url,
   if (ta_http_url_matcher(url, "/address") == SC_OK) {
     return process_generate_address_request(http, out);
   } else if (ta_http_url_matcher(url, "/transaction/hash") == SC_OK) {
-    return process_find_txn_hash_request(http, payload, out);
+    if (payload != NULL) {
+      return process_find_txn_hash_request(http, payload, out);
+    } else {
+      return process_method_not_allowed_request(out);
+    }
   } else if (ta_http_url_matcher(url, "/transaction/object") == SC_OK) {
-    return process_find_txn_obj_request(http, payload, out);
+    if (payload != NULL) {
+      return process_find_txn_obj_request(http, payload, out);
+    } else {
+      return process_method_not_allowed_request(out);
+    }
   } else if (ta_http_url_matcher(url, "/tips/pair") == SC_OK) {
     return process_get_tips_pair_request(http, out);
   } else if (ta_http_url_matcher(url, "/tips") == SC_OK) {
     return process_get_tips_request(http, out);
   } else if (ta_http_url_matcher(url, "/transaction") == SC_OK) {
-    return process_send_transfer_request(http, payload, out);
+    if (payload != NULL) {
+      return process_send_transfer_request(http, payload, out);
+    } else {
+      return process_method_not_allowed_request(out);
+    }
   } else if (ta_http_url_matcher(url, "/mam/[A-Z9]{81}") == SC_OK) {
     return process_recv_mam_msg_request(http, url, out);
   } else if (ta_http_url_matcher(url, "/mam") == SC_OK) {
-    return process_mam_send_msg_request(http, payload, out);
+    if (payload != NULL) {
+      return process_mam_send_msg_request(http, payload, out);
+    } else {
+      return process_method_not_allowed_request(out);
+    }
   } else if (ta_http_url_matcher(url, "/tryte") == SC_OK) {
-    return process_send_trytes_request(http, payload, out);
+    if (payload != NULL) {
+      return process_send_trytes_request(http, payload, out);
+    } else {
+      return process_method_not_allowed_request(out);
+    }
   } else {
     return process_invalid_path_request(out);
   }


### PR DESCRIPTION
If the GET request has the same url with the POST apis, it should return
a method_not_allowed response. Thus we should check if body is empty or not
in the callback functions before execution.