### PR TITLE
Interface for accessing transactions with ScyllaDB backend

### DIFF
--- a/accelerator/errors.h
+++ b/accelerator/errors.h
@@ -55,6 +55,7 @@ extern "C" {
 #define SC_MODULE_UTILS (0x08 << SC_MODULE_SHIFT)
 #define SC_MODULE_HTTP (0x09 << SC_MODULE_SHIFT)
 #define SC_MODULE_MQTT (0x0A << SC_MODULE_SHIFT)
+#define SC_MODULE_STORAGE (0x0B << SC_MODULE_SHIFT)
 /** @} */
 
 /** @name serverity code */
@@ -211,6 +212,19 @@ typedef enum {
   /**< Error in setting options of `struct mosquitto` object */
   SC_CLIENT_CONNTECT = 0x0A | SC_MODULE_MQTT | SC_SEVERITY_MAJOR,
   /**< Error in connecting to broker */
+
+  // STORAGE module
+  SC_STORAGE_OOM = 0x01 | SC_MODULE_STORAGE | SC_SEVERITY_FATAL,
+  /**< Fail to malloc space for transactions */
+  SC_STORAGE_CONNECT_FAIL = 0x02 | SC_MODULE_STORAGE | SC_SEVERITY_MAJOR,
+  /**< Fail to connect scylla node */
+  SC_STORAGE_INVAILD_INPUT = 0x03 | SC_MODULE_STORAGE | SC_SEVERITY_MAJOR,
+  /**< invaild input parameter, e.g., null pointer or   */
+  SC_STORAGE_CASSANDRA_QUREY_FAIL = 0x04 | SC_MODULE_STORAGE | SC_SEVERITY_MAJOR,
+  /**< Fail to execute Cassandra query   */
+  SC_STORAGE_SYNC_ERROR = 0x05 | SC_MODULE_STORAGE | SC_SEVERITY_MAJOR,
+  /**< ZeroMQ process error   */
+
 } status_t;
 
 typedef enum {

--- a/storage/BUILD
+++ b/storage/BUILD
@@ -1,0 +1,17 @@
+package(default_visibility = ["//visibility:public"])
+
+cc_library(
+    name = "storage",
+    srcs = ["scylla_api.c"],
+    hdrs = [
+        "scylla_api.h",
+    ],
+    copts = ["-DLOGGER_ENABLE"],
+    linkopts = [
+        "-lcassandra",
+    ],
+    deps = [
+        "//accelerator:common_core",
+        "//accelerator:ta_errors",
+    ],
+)

--- a/storage/scylla_api.c
+++ b/storage/scylla_api.c
@@ -1,0 +1,754 @@
+/*
+ * Copyright (C) 2019 BiiLabs Co., Ltd. and Contributors
+ * All Rights Reserved.
+ * This is free software; you can redistribute it and/or modify it under the
+ * terms of the MIT license. A copy of the license can be found in the file
+ * "LICENSE" at the root of this distribution.
+ */
+#include "scylla_api.h"
+
+#define SCYLLA_API_LOGGER "SCYLLA_API"
+
+static logger_id_t logger_id;
+
+void scylla_api_logger_init() { logger_id = logger_helper_enable(SCYLLA_API_LOGGER, LOGGER_DEBUG, true); }
+
+int scylla_api_logger_release() {
+  logger_helper_release(logger_id);
+  if (logger_helper_destroy() != RC_OK) {
+    log_critical(logger_id, "%s.\n", SCYLLA_API_LOGGER);
+    return EXIT_FAILURE;
+  }
+  return 0;
+}
+
+typedef struct select_where_s {
+  cass_byte_t* bundle;
+  cass_byte_t* address;
+} select_where_t;
+
+typedef enum { WITH_BUNDLE = 0, WITH_BUNDLE_AND_ADDRESS, NUM_OF_SELECT_METHODS } select_method_t;
+
+typedef struct select_query_s {
+  const char* query;
+} select_query_t;
+
+struct scylla_iota_transaction_s {
+  cass_byte_t bundle[NUM_FLEX_TRITS_BUNDLE];
+  cass_byte_t address[NUM_FLEX_TRITS_ADDRESS];
+  cass_byte_t hash[NUM_FLEX_TRITS_HASH];
+  cass_byte_t message[NUM_FLEX_TRITS_MESSAGE];
+  cass_int64_t value;
+  cass_int64_t timestamp;
+  cass_byte_t trunk[NUM_FLEX_TRITS_TRUNK];
+  cass_byte_t branch[NUM_FLEX_TRITS_BRANCH];
+};
+
+status_t new_scylla_iota_transaction(scylla_iota_transaction_t** obj) {
+  *obj = (scylla_iota_transaction_t*)malloc(sizeof(scylla_iota_transaction_t));
+  if (NULL == *obj) {
+    ta_log_error("%s\n", "SC_STORAGE_OOM");
+    return SC_STORAGE_OOM;
+  }
+  return SC_OK;
+}
+
+void free_scylla_iota_transaction(scylla_iota_transaction_t** obj) {
+  free(*obj);
+  obj = NULL;
+}
+
+status_t set_transaction_hash(scylla_iota_transaction_t* obj, cass_byte_t* hash, size_t length) {
+  if (obj == NULL || hash == NULL) {
+    ta_log_error("%s\n", "SC_TA_NULL");
+    return SC_TA_NULL;
+  }
+  if (length != NUM_FLEX_TRITS_HASH) {
+    ta_log_error("%s\n", "SC_STORAGE_INVAILD_INPUT");
+    return SC_STORAGE_INVAILD_INPUT;
+  }
+  memcpy(obj->hash, hash, NUM_FLEX_TRITS_HASH);
+  return SC_OK;
+}
+
+cass_byte_t* ret_transaction_hash(scylla_iota_transaction_t* obj) {
+  if (obj == NULL) {
+    ta_log_error("%s\n", "SC_TA_NULL");
+    return NULL;
+  }
+  return obj->hash;
+}
+
+status_t set_transaction_address(scylla_iota_transaction_t* obj, cass_byte_t* hash, size_t length) {
+  if (obj == NULL || hash == NULL) {
+    ta_log_error("%s\n", "SC_TA_NULL");
+    return SC_TA_NULL;
+  }
+  if (length != NUM_FLEX_TRITS_ADDRESS) {
+    ta_log_error("%s\n", "SC_STORAGE_INVAILD_INPUT");
+    return SC_STORAGE_INVAILD_INPUT;
+  }
+  memcpy(obj->address, hash, length);
+  return SC_OK;
+}
+
+cass_byte_t* ret_transaction_address(scylla_iota_transaction_t* obj) {
+  if (obj == NULL) {
+    ta_log_error("%s\n", "SC_TA_NULL");
+    return NULL;
+  }
+  return obj->address;
+}
+
+status_t set_transaction_bundle(scylla_iota_transaction_t* obj, cass_byte_t* hash, size_t length) {
+  if (obj == NULL || hash == NULL) {
+    ta_log_error("%s\n", "SC_TA_NULL");
+    return SC_TA_NULL;
+  }
+  if (length != NUM_FLEX_TRITS_BUNDLE) {
+    ta_log_error("%s\n", "SC_STORAGE_INVAILD_INPUT");
+    return SC_STORAGE_INVAILD_INPUT;
+  }
+  memcpy(obj->bundle, hash, length);
+  return SC_OK;
+}
+
+cass_byte_t* ret_transaction_bundle(scylla_iota_transaction_t* obj) {
+  if (obj == NULL) {
+    ta_log_error("%s\n", "SC_TA_NULL");
+    return NULL;
+  }
+  return obj->bundle;
+}
+
+status_t set_transaction_trunk(scylla_iota_transaction_t* obj, cass_byte_t* hash, size_t length) {
+  if (obj == NULL || hash == NULL) {
+    ta_log_error("%s\n", "SC_TA_NULL");
+    return SC_TA_NULL;
+  }
+  if (length != NUM_FLEX_TRITS_TRUNK) {
+    ta_log_error("%s\n", "SC_STORAGE_INVAILD_INPUT");
+    return SC_STORAGE_INVAILD_INPUT;
+  }
+  memcpy(obj->trunk, hash, length);
+  return SC_OK;
+}
+
+cass_byte_t* ret_transaction_trunk(scylla_iota_transaction_t* obj) {
+  if (obj == NULL) {
+    ta_log_error("%s\n", "SC_TA_NULL");
+    return NULL;
+  }
+  return obj->trunk;
+}
+
+status_t set_transaction_branch(scylla_iota_transaction_t* obj, cass_byte_t* hash, size_t length) {
+  if (obj == NULL || hash == NULL) {
+    ta_log_error("%s\n", "SC_TA_NULL");
+    return SC_TA_NULL;
+  }
+  if (length != NUM_FLEX_TRITS_BRANCH) {
+    ta_log_error("%s\n", "SC_STORAGE_INVAILD_INPUT");
+    return SC_STORAGE_INVAILD_INPUT;
+  }
+  memcpy(obj->branch, hash, length);
+  return SC_OK;
+}
+
+cass_byte_t* ret_transaction_branch(scylla_iota_transaction_t* obj) {
+  if (obj == NULL) {
+    ta_log_error("%s\n", "SC_TA_NULL");
+    return NULL;
+  }
+  return obj->branch;
+}
+
+status_t set_transaction_message(scylla_iota_transaction_t* obj, cass_byte_t* hash, size_t length) {
+  if (obj == NULL || hash == NULL) {
+    ta_log_error("%s\n", "SC_TA_NULL");
+    return SC_TA_NULL;
+  }
+  if (length != NUM_FLEX_TRITS_MESSAGE) {
+    ta_log_error("%s\n", "SC_STORAGE_INVAILD_INPUT");
+    return SC_STORAGE_INVAILD_INPUT;
+  }
+
+  memcpy(obj->message, hash, length);
+
+  return SC_OK;
+}
+
+cass_byte_t* ret_transaction_message(scylla_iota_transaction_t* obj) {
+  if (obj == NULL) {
+    ta_log_error("%s\n", "SC_TA_NULL");
+    return NULL;
+  }
+  return obj->message;
+}
+
+status_t set_transaction_value(scylla_iota_transaction_t* obj, int64_t value) {
+  if (obj == NULL) {
+    ta_log_error("%s\n", "SC_TA_NULL");
+    return SC_TA_NULL;
+  }
+  obj->value = value;
+  return SC_OK;
+}
+
+int64_t ret_transaction_value(scylla_iota_transaction_t* obj) {
+  if (obj == NULL) {
+    ta_log_error("%s\n", "SC_TA_NULL");
+    return 0;
+  }
+  return obj->value;
+}
+
+status_t set_transaction_timestamp(scylla_iota_transaction_t* obj, int64_t timestamp) {
+  if (obj == NULL) {
+    ta_log_error("%s\n", "SC_TA_NULL");
+    return SC_TA_NULL;
+  }
+  obj->timestamp = timestamp;
+  return SC_OK;
+}
+
+int64_t ret_transaction_timestamp(scylla_iota_transaction_t* obj) {
+  if (obj == NULL) {
+    ta_log_error("%s\n", "SC_TA_NULL");
+    return 0;
+  }
+  return obj->timestamp;
+}
+
+static const select_query_t select_query[NUM_OF_SELECT_METHODS] = {
+    {"SELECT * FROM permanent.bundleTable WHERE bundle = ?"},
+    {"SELECT * FROM permanent.bundleTable WHERE bundle = ? AND address = ?"}};
+
+static void print_error(CassFuture* future) {
+  const char* message;
+  size_t message_length;
+  cass_future_error_message(future, &message, &message_length);
+  ta_log_error("Error: %.*s\n", (int)message_length, message);
+}
+
+static CassCluster* create_cluster(const char* hosts) {
+  CassCluster* cluster = cass_cluster_new();
+  cass_cluster_set_contact_points(cluster, hosts);
+  return cluster;
+}
+
+static CassError connect_session(CassSession* session, const CassCluster* cluster) {
+  CassError rc = CASS_OK;
+  CassFuture* future = cass_session_connect(session, cluster);
+
+  cass_future_wait(future);
+  rc = cass_future_error_code(future);
+  if (rc != CASS_OK) {
+    print_error(future);
+  }
+  cass_future_free(future);
+
+  return rc;
+}
+
+static CassError execute_query(CassSession* session, const char* query) {
+  CassError rc = CASS_OK;
+  CassStatement* statement = cass_statement_new(query, 0);
+  CassFuture* future = cass_session_execute(session, statement);
+
+  cass_future_wait(future);
+
+  rc = cass_future_error_code(future);
+  if (rc != CASS_OK) {
+    print_error(future);
+  }
+
+  cass_future_free(future);
+  cass_statement_free(statement);
+
+  return rc;
+}
+
+static CassError prepare_query(CassSession* session, const char* query, const CassPrepared** prepared) {
+  CassError rc = CASS_OK;
+  CassFuture* future = NULL;
+
+  future = cass_session_prepare(session, query);
+  cass_future_wait(future);
+
+  rc = cass_future_error_code(future);
+  if (rc != CASS_OK) {
+    print_error(future);
+  } else {
+    *prepared = cass_future_get_prepared(future);
+  }
+
+  cass_future_free(future);
+
+  return rc;
+}
+
+static CassError execute_statement(CassSession* session, CassStatement* statement) {
+  CassError rc = CASS_OK;
+  CassFuture* future = NULL;
+  future = cass_session_execute(session, statement);
+
+  cass_future_wait(future);
+
+  rc = cass_future_error_code(future);
+  if (rc != CASS_OK) {
+    print_error(future);
+  }
+
+  cass_future_free(future);
+  cass_statement_free(statement);
+
+  return rc;
+}
+
+static status_t get_blob(const CassRow* row, cass_byte_t* target, const char* column) {
+  size_t len;
+  const cass_byte_t* buf;
+  status_t ret = SC_OK;
+  cass_value_get_bytes(cass_row_get_column_by_name(row, column), &buf, &len);
+  memcpy(target, buf, len);
+  return ret;
+}
+
+static status_t create_permanent_keyspace(CassSession* session) {
+  status_t ret = SC_OK;
+  if (execute_query(session, "DROP KEYSPACE IF EXISTS permanent;") != CASS_OK) {
+    ta_log_error("%s\n", "SC_STORAGE_CASSANDRA_QUREY_FAIL");
+    ret = SC_STORAGE_CASSANDRA_QUREY_FAIL;
+    goto exit;
+  }
+  if (execute_query(session,
+                    "CREATE KEYSPACE IF NOT EXISTS permanent WITH replication = {"
+                    "'class': 'SimpleStrategy', 'replication_factor': '2' };") != CASS_OK) {
+    ta_log_error("%s\n", "SC_STORAGE_CASSANDRA_QUREY_FAIL");
+    ret = SC_STORAGE_CASSANDRA_QUREY_FAIL;
+    goto exit;
+  }
+
+exit:
+  return ret;
+}
+
+static status_t create_bundle_table(CassSession* session) {
+  status_t ret = SC_OK;
+  if (execute_query(session, "DROP TABLE IF EXISTS permanent.bundleTable;") != CASS_OK) {
+    ta_log_error("%s\n", "SC_STORAGE_CASSANDRA_QUREY_FAIL");
+    ret = SC_STORAGE_CASSANDRA_QUREY_FAIL;
+    goto exit;
+  }
+  if (execute_query(session,
+                    "CREATE TABLE IF NOT EXISTS permanent.bundleTable ("
+                    "bundle blob,"
+                    "address blob,"
+                    "hash blob,"
+                    "message blob,"
+                    "value bigint,"
+                    "timestamp bigint,"
+                    "trunk blob,"
+                    "branch blob,"
+                    "PRIMARY KEY (bundle, address, hash));") != CASS_OK) {
+    ta_log_error("%s\n", "SC_STORAGE_CASSANDRA_QUREY_FAIL");
+    ret = SC_STORAGE_CASSANDRA_QUREY_FAIL;
+    goto exit;
+  }
+
+exit:
+  return ret;
+}
+
+static status_t create_edge_table(CassSession* session) {
+  status_t ret = SC_OK;
+  if (execute_query(session, "DROP TABLE IF EXISTS permanent.edgeTable;") != CASS_OK) {
+    ta_log_error("%s\n", "SC_STORAGE_CASSANDRA_QUREY_FAIL");
+    ret = SC_STORAGE_CASSANDRA_QUREY_FAIL;
+    goto exit;
+  }
+  if (execute_query(session,
+                    "CREATE TABLE IF NOT EXISTS permanent.edgeTable("
+                    "edge blob,"
+                    "bundle blob,"
+                    "address blob,"
+                    "hash blob,"
+                    "PRIMARY KEY (edge, bundle, address, hash));") != CASS_OK) {
+    ta_log_error("%s\n", "SC_STORAGE_CASSANDRA_QUREY_FAIL");
+    ret = SC_STORAGE_CASSANDRA_QUREY_FAIL;
+    goto exit;
+  }
+
+exit:
+  return ret;
+}
+status_t init_scylla(CassCluster** cluster, CassSession* session, char* hosts, bool is_need_create_table) {
+  status_t ret = SC_OK;
+  /* Add contact points */
+  *cluster = create_cluster(hosts);
+  if (connect_session(session, *cluster) != CASS_OK) {
+    ta_log_error("%s\n", "connect Scylla cluster fail");
+    ret = SC_STORAGE_CONNECT_FAIL;
+    goto exit;
+  }
+  if (is_need_create_table == true) {
+    if ((ret = create_permanent_keyspace(session)) != SC_OK) {
+      ta_log_error("%s\n", "create permanent keyspace fail");
+      goto exit;
+    }
+    if ((ret = create_bundle_table(session)) != SC_OK) {
+      ta_log_error("%s\n", "create bundle table fail");
+      goto exit;
+    }
+    if ((ret = create_edge_table(session)) != SC_OK) {
+      ta_log_error("%s\n", "create edge table fail");
+      goto exit;
+    }
+  }
+
+exit:
+  return ret;
+}
+static CassStatement* ret_insert_bundle_statement(const CassPrepared* prepared,
+                                                  const scylla_iota_transaction_t* transaction) {
+  CassStatement* statement = NULL;
+  statement = cass_prepared_bind(prepared);
+  cass_statement_bind_bytes_by_name(statement, "bundle", transaction->bundle, NUM_FLEX_TRITS_BUNDLE);
+  cass_statement_bind_bytes_by_name(statement, "address", transaction->address, NUM_FLEX_TRITS_ADDRESS);
+  cass_statement_bind_bytes_by_name(statement, "hash", transaction->hash, NUM_FLEX_TRITS_HASH);
+  cass_statement_bind_bytes_by_name(statement, "message", transaction->message, NUM_FLEX_TRITS_MESSAGE);
+  cass_statement_bind_int64_by_name(statement, "value", transaction->value);
+  cass_statement_bind_int64_by_name(statement, "timestamp", transaction->timestamp);
+  cass_statement_bind_bytes_by_name(statement, "trunk", transaction->trunk, NUM_FLEX_TRITS_TRUNK);
+  cass_statement_bind_bytes_by_name(statement, "branch", transaction->branch, NUM_FLEX_TRITS_BRANCH);
+  return statement;
+}
+
+static CassStatement* ret_insert_edge_statement(const CassPrepared* prepared,
+                                                const scylla_iota_transaction_t* transaction, const cass_byte_t* edge) {
+  CassStatement* statement = NULL;
+  statement = cass_prepared_bind(prepared);
+  cass_statement_bind_bytes_by_name(statement, "edge", edge, NUM_FLEX_TRITS_HASH);
+  cass_statement_bind_bytes_by_name(statement, "bundle", transaction->bundle, NUM_FLEX_TRITS_BUNDLE);
+  cass_statement_bind_bytes_by_name(statement, "address", transaction->address, NUM_FLEX_TRITS_ADDRESS);
+  cass_statement_bind_bytes_by_name(statement, "hash", transaction->hash, NUM_FLEX_TRITS_HASH);
+  return statement;
+}
+
+static CassStatement* ret_select_from_bundleTable_statement(const CassPrepared* parpared, select_method_t select_method,
+                                                            const select_where_t* select_where) {
+  CassStatement* statement;
+  statement = cass_prepared_bind(parpared);
+  if (select_method == WITH_BUNDLE) {
+    cass_statement_bind_bytes_by_name(statement, "bundle", select_where->bundle, NUM_FLEX_TRITS_BUNDLE);
+  } else if (select_method == WITH_BUNDLE_AND_ADDRESS) {
+    cass_statement_bind_bytes_by_name(statement, "bundle", select_where->bundle, NUM_FLEX_TRITS_BUNDLE);
+    cass_statement_bind_bytes_by_name(statement, "address", select_where->address, NUM_FLEX_TRITS_ADDRESS);
+  }
+  return statement;
+}
+
+status_t insert_transaction_into_bundleTable(CassSession* session, scylla_iota_transaction_t* transaction,
+                                             size_t trans_num) {
+  status_t ret = SC_OK;
+  const CassPrepared* insert_prepared = NULL;
+  CassStatement* statement = NULL;
+  const char* insert_query =
+      "INSERT INTO permanent.bundleTable (bundle, address, hash, message, value, timestamp, trunk, branch)"
+      "VALUES (?, ?, ?, ?, ?, ?, ?, ?);";
+  if (session == NULL || transaction == NULL) {
+    ta_log_error("%s\n", "SC_TA_NULL");
+    return SC_TA_NULL;
+  }
+
+  if (prepare_query(session, insert_query, &insert_prepared) != CASS_OK) {
+    ta_log_error("%s\n", "prepare INSERT query fail");
+    return SC_STORAGE_CASSANDRA_QUREY_FAIL;
+  }
+  for (size_t i = 0; i < trans_num; i++) {
+    statement = ret_insert_bundle_statement(insert_prepared, transaction + i);
+    if (execute_statement(session, statement) != CASS_OK) {
+      ret = SC_STORAGE_CASSANDRA_QUREY_FAIL;
+      goto exit;
+    }
+  }
+
+exit:
+  cass_prepared_free(insert_prepared);
+  return ret;
+}
+
+status_t insert_transaction_into_edgeTable(CassSession* session, scylla_iota_transaction_t* transaction,
+                                           size_t trans_num) {
+  status_t ret = SC_OK;
+  const CassPrepared* insert_prepared = NULL;
+  CassStatement* statement = NULL;
+  const char* insert_query =
+      "INSERT INTO permanent.edgeTable (edge, bundle, address, hash)"
+      "VALUES (?, ?, ?, ?);";
+
+  if (transaction == NULL) {
+    ta_log_error("%s\n", "SC_TA_NULL");
+    return SC_TA_NULL;
+  }
+
+  if (prepare_query(session, insert_query, &insert_prepared) != CASS_OK) {
+    ta_log_error("%s\n", "prepare INSERT query fail");
+    return SC_STORAGE_CASSANDRA_QUREY_FAIL;
+  }
+
+  for (size_t i = 0; i < trans_num; i++) {
+    statement = ret_insert_edge_statement(insert_prepared, transaction + i, (transaction + i)->address);
+    if (execute_statement(session, statement) != CASS_OK) {
+      ret = SC_STORAGE_CASSANDRA_QUREY_FAIL;
+      goto exit;
+    }
+    statement = ret_insert_edge_statement(insert_prepared, transaction + i, (transaction + i)->trunk);
+    if (execute_statement(session, statement) != CASS_OK) {
+      ret = SC_STORAGE_CASSANDRA_QUREY_FAIL;
+      goto exit;
+    }
+    statement = ret_insert_edge_statement(insert_prepared, transaction + i, (transaction + i)->branch);
+    if (execute_statement(session, statement) != CASS_OK) {
+      ret = SC_STORAGE_CASSANDRA_QUREY_FAIL;
+      goto exit;
+    }
+  }
+
+exit:
+  cass_prepared_free(insert_prepared);
+  return ret;
+}
+
+status_t select_from_bundleTable(CassSession* session, CassStatement* statement,
+                                 scylla_iota_transaction_t** transaction, size_t* transactionNum) {
+  int idx;
+  status_t ret = SC_OK;
+  CassFuture* future = NULL;
+  const CassResult* result;
+  CassIterator* iterator;
+
+  future = cass_session_execute(session, statement);
+  cass_future_wait(future);
+  if (cass_future_error_code(future) != CASS_OK) {
+    print_error(future);
+    ret = SC_STORAGE_CASSANDRA_QUREY_FAIL;
+    goto exit;
+  }
+
+  /* get transaction number */
+  result = cass_future_get_result(future);
+  iterator = cass_iterator_from_result(result);
+  *transactionNum = 0;
+  while (cass_iterator_next(iterator)) {
+    (*transactionNum)++;
+  }
+  *transaction = malloc((*transactionNum) * sizeof(scylla_iota_transaction_t));
+  if (*transaction == NULL) {
+    ta_log_error("%s\n", "SC_STORAGE_OOM");
+    ret = SC_STORAGE_OOM;
+    goto end_iterate;
+  }
+  /* get each transaction result */
+  idx = 0;
+  iterator = cass_iterator_from_result(result);
+  const CassRow* row;
+  while (cass_iterator_next(iterator)) {
+    row = cass_iterator_get_row(iterator);
+
+    if ((ret = get_blob(row, ((*transaction) + idx)->bundle, "bundle")) != SC_OK) {
+      goto end_iterate;
+    }
+    if ((ret = get_blob(row, ((*transaction) + idx)->address, "address")) != SC_OK) {
+      goto end_iterate;
+    }
+    if ((ret = get_blob(row, ((*transaction) + idx)->hash, "hash")) != SC_OK) {
+      goto end_iterate;
+    }
+    if ((ret = get_blob(row, ((*transaction) + idx)->message, "message")) != SC_OK) {
+      goto end_iterate;
+    }
+    if ((ret = get_blob(row, ((*transaction) + idx)->trunk, "trunk")) != SC_OK) {
+      goto end_iterate;
+    }
+    if ((ret = get_blob(row, ((*transaction) + idx)->branch, "branch")) != SC_OK) {
+      goto end_iterate;
+    }
+    cass_value_get_int64(cass_row_get_column_by_name(row, "value"), &(((*transaction) + idx)->value));
+    cass_value_get_int64(cass_row_get_column_by_name(row, "timestamp"), &(((*transaction) + idx)->timestamp));
+
+    idx++;
+  }
+
+end_iterate:
+  cass_result_free(result);
+  cass_iterator_free(iterator);
+
+exit:
+  cass_future_free(future);
+  cass_statement_free(statement);
+
+  return ret;
+}
+
+static status_t push_columns_into_queue(CassSession* session, CassStatement* statement,
+                                        hash243_queue_t* const res_queue, const char* column_name) {
+  status_t ret = SC_OK;
+  CassFuture* future = NULL;
+  const CassResult* result;
+  CassIterator* iterator;
+
+  future = cass_session_execute(session, statement);
+  cass_future_wait(future);
+
+  if (cass_future_error_code(future) != CASS_OK) {
+    print_error(future);
+    ret = SC_STORAGE_CASSANDRA_QUREY_FAIL;
+    goto exit;
+  }
+
+  result = cass_future_get_result(future);
+  iterator = cass_iterator_from_result(result);
+
+  while (cass_iterator_next(iterator)) {
+    const CassRow* row = cass_iterator_get_row(iterator);
+    size_t len;
+    const cass_byte_t* buf;
+    if (cass_value_get_bytes(cass_row_get_column_by_name(row, column_name), &buf, &len) != CASS_OK) {
+      ta_log_error("%s\n", "SC_STORAGE_CASSANDRA_QUREY_FAIL");
+      ret = SC_STORAGE_CASSANDRA_QUREY_FAIL;
+      goto end_iterate;
+    }
+    if (hash243_queue_push(res_queue, (flex_trit_t const* const)buf) != RC_OK) {
+      ta_log_error("%s\n", "SC_STORAGE_OOM");
+      ret = SC_STORAGE_OOM;
+      goto end_iterate;
+    }
+  }
+
+end_iterate:
+  cass_result_free(result);
+  cass_iterator_free(iterator);
+
+exit:
+  cass_future_free(future);
+  cass_statement_free(statement);
+
+  return ret;
+}
+
+status_t select_transactions_with_bundle(CassSession* session, const select_method_t select_method,
+                                         const select_where_t* select_where, const size_t select_num) {
+  status_t ret = SC_OK;
+  scylla_iota_transaction_t* output;
+  size_t outputNum = 0;
+  CassStatement* statement = NULL;
+  const CassPrepared* select_prepared = NULL;
+  if (select_where == NULL) {
+    ta_log_error("%s\n", "SC_TA_NULL");
+    return SC_TA_NULL;
+  }
+
+  if (prepare_query(session, select_query[select_method].query, &select_prepared) != CASS_OK) {
+    ta_log_error("%s\n", "prepare SELECT query fail");
+    return SC_STORAGE_CASSANDRA_QUREY_FAIL;
+  }
+  for (size_t i = 0; i < select_num; i++) {
+    statement = ret_select_from_bundleTable_statement(select_prepared, select_method, select_where + i);
+    select_from_bundleTable(session, statement, &output, &outputNum);
+    ta_log_debug("row = %d\n", outputNum);
+    for (size_t i = 0; i < outputNum; i++) {
+      ta_log_debug("%s %s %s %s %ld %ld %s %s\n", output[i].bundle, output[i].address, output[i].hash,
+                   output[i].message, output[i].value, output[i].timestamp, output[i].trunk, output[i].branch);
+    }
+    free_scylla_iota_transaction(&output);
+  }
+
+  cass_prepared_free(select_prepared);
+  return ret;
+}
+
+static status_t get_column_from_bundleTable(CassSession* session, hash243_queue_t* res_queue,
+                                            const select_method_t select_method, const select_where_t* select_where,
+                                            const char* column_name) {
+  status_t ret = SC_OK;
+  CassStatement* statement = NULL;
+  const CassPrepared* select_prepared = NULL;
+  if (select_where == NULL) {
+    ta_log_error("%s\n", "SC_TA_NULL");
+    return SC_TA_NULL;
+  }
+  if (prepare_query(session, select_query[select_method].query, &select_prepared) != CASS_OK) {
+    ta_log_error("%s\n", "prepare SELECT query fail");
+    return SC_STORAGE_CASSANDRA_QUREY_FAIL;
+  }
+
+  statement = ret_select_from_bundleTable_statement(select_prepared, select_method, select_where);
+  ret = push_columns_into_queue(session, statement, res_queue, column_name);
+
+  cass_prepared_free(select_prepared);
+  return ret;
+}
+status_t get_column_from_edgeTable(CassSession* session, hash243_queue_t* res_queue, cass_byte_t* edge,
+                                   const char* column_name) {
+  status_t ret = SC_OK;
+  static const char* query = "SELECT * FROM permanent.edgeTable WHERE edge = ?";
+  CassStatement* statement = NULL;
+  const CassPrepared* select_prepared = NULL;
+
+  if (prepare_query(session, query, &select_prepared) != CASS_OK) {
+    ta_log_error("%s\n", "prepare SELECT query fail");
+    return SC_STORAGE_CASSANDRA_QUREY_FAIL;
+  }
+
+  statement = cass_prepared_bind(select_prepared);
+  cass_statement_bind_bytes_by_name(statement, "edge", edge, FLEX_TRIT_SIZE_243);
+  ret = push_columns_into_queue(session, statement, res_queue, column_name);
+
+  cass_prepared_free(select_prepared);
+  return ret;
+}
+
+status_t get_transactions(CassSession* session, hash243_queue_t* res_queue, hash243_queue_t bundles,
+                          hash243_queue_t addresses, hash243_queue_t approves) {
+  status_t ret = SC_OK;
+  hash243_queue_t itr243 = NULL;
+  hash243_queue_t itr243_2 = NULL;
+  select_where_t select_where;
+
+  CDL_FOREACH(bundles, itr243) {
+    select_where.bundle = (cass_byte_t*)itr243->hash;
+    ret = get_column_from_bundleTable(session, res_queue, WITH_BUNDLE, &select_where, "hash");
+    if (ret != SC_OK) {
+      goto exit;
+    }
+  }
+  CDL_FOREACH(addresses, itr243) {
+    hash243_queue_t bundle_hashes = NULL;
+    ret = get_column_from_edgeTable(session, &bundle_hashes, (cass_byte_t*)itr243->hash, "bundle");
+    if (ret != SC_OK) {
+      hash243_queue_free(&bundle_hashes);
+      goto exit;
+    }
+    select_where.address = (cass_byte_t*)itr243->hash;
+    CDL_FOREACH(bundle_hashes, itr243_2) {
+      select_where.bundle = (cass_byte_t*)itr243_2->hash;
+      ret = get_column_from_bundleTable(session, res_queue, WITH_BUNDLE_AND_ADDRESS, &select_where, "hash");
+      if (ret != SC_OK) {
+        hash243_queue_free(&bundle_hashes);
+        goto exit;
+      }
+    }
+    hash243_queue_free(&bundle_hashes);
+  }
+  CDL_FOREACH(approves, itr243) {
+    ret = get_column_from_edgeTable(session, res_queue, (cass_byte_t*)itr243->hash, "hash");
+    if (ret != SC_OK) {
+      goto exit;
+    }
+  }
+
+exit:
+  return ret;
+}

--- a/storage/scylla_api.h
+++ b/storage/scylla_api.h
@@ -1,0 +1,313 @@
+/*
+ * Copyright (C) 2019 BiiLabs Co., Ltd. and Contributors
+ * All Rights Reserved.
+ * This is free software; you can redistribute it and/or modify it under the
+ * terms of the MIT license. A copy of the license can be found in the file
+ * "LICENSE" at the root of this distribution.
+ */
+#ifndef TA_SCYLLA_API_H_
+#define TA_SCYLLA_API_H_
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "accelerator/errors.h"
+#include "cassandra.h"
+#include "common/model/transaction.h"
+#include "utils/containers/hash/hash243_queue.h"
+#include "utils/logger_helper.h"
+
+typedef struct scylla_iota_transaction_s scylla_iota_transaction_t;
+
+/**
+ * @brief malloc memory space to *obj
+ *
+ * @param[in] obj pointer to pointer to scylla_iota_transaction_t
+ *
+ * @return
+ * - SC_OK on success
+ * - SC_STORAGE_OOM on error
+ */
+status_t new_scylla_iota_transaction(scylla_iota_transaction_t** obj);
+
+/**
+ * @brief release memory space to *obj
+ *
+ * @param[in] obj pointer to pointer to scylla_iota_transaction_t
+ */
+void free_scylla_iota_transaction(scylla_iota_transaction_t** obj);
+
+/**
+ * @brief set hash in scylla_iota_transaction_t
+ *
+ * @param[in] obj pointer to scylla_iota_transaction_t
+ * @param[in] hash input hash to be set to member of scylla_iota_transaction_t
+ * @param[in] length length of hash
+ * @return
+ * - SC_OK on success
+ * - SC_TA_NULL/SC_STORAGE_INVAILD_INPUT on error
+ */
+status_t set_transaction_hash(scylla_iota_transaction_t* obj, cass_byte_t* hash, size_t length);
+
+/**
+ * @brief set bundle in scylla_iota_transaction_t
+ *
+ * @param[in] obj pointer to scylla_iota_transaction_t
+ * @param[in] hash input hash to be set to member of scylla_iota_transaction_t
+ * @param[in] length length of hash
+ * @return
+ * - SC_OK on success
+ * - SC_TA_NULL/SC_STORAGE_INVAILD_INPUT on error
+ */
+status_t set_transaction_bundle(scylla_iota_transaction_t* obj, cass_byte_t* hash, size_t length);
+
+/**
+ * @brief set address in scylla_iota_transaction_t
+ *
+ * @param[in] obj pointer to scylla_iota_transaction_t
+ * @param[in] hash input hash to be set to member of scylla_iota_transaction_t
+ * @param[in] length length of hash
+ * @return
+ * - SC_OK on success
+ * - SC_TA_NULL/SC_STORAGE_INVAILD_INPUT on error
+ */
+status_t set_transaction_address(scylla_iota_transaction_t* obj, cass_byte_t* hash, size_t length);
+
+/**
+ * @brief set trunk in scylla_iota_transaction_t
+ *
+ * @param[in] obj pointer to scylla_iota_transaction_t
+ * @param[in] hash input hash to be set to member of scylla_iota_transaction_t
+ * @param[in] length length of hash
+ * @return
+ * - SC_OK on success
+ * - SC_TA_NULL/SC_STORAGE_INVAILD_INPUT on error
+ */
+status_t set_transaction_trunk(scylla_iota_transaction_t* obj, cass_byte_t* hash, size_t length);
+
+/**
+ * @brief set branch in scylla_iota_transaction_t
+ *
+ * @param[in] obj pointer to scylla_iota_transaction_t
+ * @param[in] hash input hash to be set to member of scylla_iota_transaction_t
+ * @param[in] length length of hash
+ * @return
+ * - SC_OK on success
+ * - SC_TA_NULL/SC_STORAGE_INVAILD_INPUT on error
+ */
+status_t set_transaction_branch(scylla_iota_transaction_t* obj, cass_byte_t* hash, size_t length);
+
+/**
+ * @brief set message in scylla_iota_transaction_t
+ *
+ * @param[in] obj pointer to scylla_iota_transaction_t
+ * @param[in] hash input hash to be set to member of scylla_iota_transaction_t
+ * @param[in] length length of hash
+ * @return
+ * - SC_OK on success
+ * - SC_TA_NULL/SC_STORAGE_INVAILD_INPUT on error
+ */
+status_t set_transaction_message(scylla_iota_transaction_t* obj, cass_byte_t* hash, size_t length);
+
+/**
+ * @brief set value of iota token in scylla_iota_transaction_t
+ *
+ * @param[in] obj pointer to scylla_iota_transaction_t
+ * @param[in] value input value to be set to member of scylla_iota_transaction_t
+ * @return
+ * - SC_OK on success
+ * - SC_TA_NULL/SC_STORAGE_INVAILD_INPUT on error
+ */
+status_t set_transaction_value(scylla_iota_transaction_t* obj, int64_t value);
+
+/**
+ * @brief set timestamp in scylla_iota_transaction_t
+ *
+ * @param[in] obj pointer to scylla_iota_transaction_t
+ * @param[in] timestamp input timestamp to be set to member of scylla_iota_transaction_t
+ * @return
+ * - SC_OK on success
+ * - SC_TA_NULL/SC_STORAGE_INVAILD_INPUT on error
+ */
+status_t set_transaction_timestamp(scylla_iota_transaction_t* obj, int64_t timestamp);
+
+/**
+ * @brief return hash in scylla_iota_transaction_t
+ *
+ * @param[in] obj pointer to scylla_iota_transaction_t
+ *
+ * @return
+ * - hash on success
+ * - NULL on error
+ */
+cass_byte_t* ret_transaction_hash(scylla_iota_transaction_t* obj);
+
+/**
+ * @brief return hash in scylla_iota_transaction_t
+ *
+ * @param[in] obj pointer to scylla_iota_transaction_t
+ *
+ * @return
+ * - hash on success
+ * - NULL on error
+ */
+cass_byte_t* ret_transaction_bundle(scylla_iota_transaction_t* obj);
+
+/**
+ * @brief return address in scylla_iota_transaction_t
+ *
+ * @param[in] obj pointer to scylla_iota_transaction_t
+ *
+ * @return
+ * - address on success
+ * - NULL on error
+ */
+cass_byte_t* ret_transaction_address(scylla_iota_transaction_t* obj);
+
+/**
+ * @brief return trunk in scylla_iota_transaction_t
+ *
+ * @param[in] obj pointer to scylla_iota_transaction_t
+ *
+ * @return
+ * - trunk on success
+ * - NULL on error
+ */
+cass_byte_t* ret_transaction_trunk(scylla_iota_transaction_t* obj);
+
+/**
+ * @brief return branch in scylla_iota_transaction_t
+ *
+ * @param[in] obj pointer to scylla_iota_transaction_t
+ *
+ * @return
+ * - branch on success
+ * - NULL on error
+ */
+cass_byte_t* ret_transaction_branch(scylla_iota_transaction_t* obj);
+
+/**
+ * @brief return message in scylla_iota_transaction_t
+ *
+ * @param[in] obj pointer to scylla_iota_transaction_t
+ *
+ * @return
+ * - message on success
+ * - NULL on error
+ */
+cass_byte_t* ret_transaction_message(scylla_iota_transaction_t* obj);
+
+/**
+ * @brief return value in scylla_iota_transaction_t
+ *
+ * @param[in] obj pointer to scylla_iota_transaction_t
+ *
+ * @return
+ * - value on success
+ * - NULL on error
+ */
+int64_t ret_transaction_value(scylla_iota_transaction_t* obj);
+
+/**
+ * @brief return timestamp in scylla_iota_transaction_t
+ *
+ * @param[in] obj pointer to scylla_iota_transaction_t
+ *
+ * @return
+ * - timestamp on success
+ * - NULL on error
+ */
+int64_t ret_transaction_timestamp(scylla_iota_transaction_t* obj);
+
+/**
+ * Initialize logger
+ */
+void scylla_api_logger_init();
+
+/**
+ * Release logger
+ *
+ * @return
+ * - zero on success
+ * - EXIT_FAILURE on error
+ */
+int scylla_api_logger_release();
+
+/**
+ * @brief connect to Scylla node and create table
+ *
+ * @param[out] cluster Scylla node cluster
+ * @param[out] session Scylla cluster session
+ * @param[in] hosts Scylla node ip
+ * @param[in] is_need_create_table true : create, false : not to create
+ *
+ * @return
+ * - SC_OK on success
+ * - non-zero on error
+ */
+status_t init_scylla(CassCluster** cluster, CassSession* session, char* hosts, bool is_need_create_table);
+
+/**
+ * @brief insert transactions into bundle table
+ *
+ * @param[in] session Scylla cluster session
+ * @param[in] transaction input transactions data
+ * @param[in] tran_num input transactions number
+ *
+ * @return
+ * - SC_OK on success
+ * - non-zero on error
+ */
+status_t insert_transaction_into_bundleTable(CassSession* session, scylla_iota_transaction_t* transaction,
+                                             size_t trans_num);
+
+/**
+ * @brief insert transactions into edge table
+ *
+ * @param[in] session Scylla cluster session
+ * @param[in] transaction input transactions data
+ * @param[in] tran_num input transactions number
+ *
+ * @return
+ * - SC_OK on success
+ * - non-zero on error
+ */
+status_t insert_transaction_into_edgeTable(CassSession* session, scylla_iota_transaction_t* transaction,
+                                           size_t trans_num);
+
+/**
+ * @brief get bundles from edge table by edge
+ *
+ * @param[in] session Scylla cluster session
+ * @param[in] edge primary key for select bundles
+ * @param[in] column_name the column we want to select
+ * @param[out] res_queue response transactions queue
+ *
+ * @return
+ * - SC_OK on success
+ * - non-zero on error
+ */
+status_t get_column_from_edgeTable(CassSession* session, hash243_queue_t* res_queue, cass_byte_t* edge,
+                                   const char* column_name);
+
+/**
+ * @brief get transactions by bundles, addresses or get approves
+ *
+ * @param[in] session Scylla cluster session
+ * @param[in] bundles query bundles queue
+ * @param[in] bundles query addresses queue
+ * @param[in] bundles query approves queue
+ * @param[out] res_queue response transactions queue
+ *
+ * @return
+ * - SC_OK on success
+ * - non-zero on error
+ */
+status_t get_transactions(CassSession* session, hash243_queue_t* res_queue, hash243_queue_t bundles,
+                          hash243_queue_t addresses, hash243_queue_t approves);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // TA_SCYLLA_API_H_

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -101,3 +101,14 @@ cc_library(
         "@unity",
     ],
 )
+
+cc_test(
+    name = "test_scylla",
+    srcs = [
+        "test_scylla.c",
+    ],
+    deps = [
+        ":test_define",
+        "//storage",
+    ],
+)

--- a/tests/test_define.h
+++ b/tests/test_define.h
@@ -263,6 +263,75 @@ extern "C" {
 #define TEST_CHANNEL_ORD 5
 #define DEVICE_ID "cb692268436743c9bbe17c1721741db1"
 
+#define BUNDLE_1                                                               \
+  "BUNDLE100000LIKCEJTTIQOTTAWSQCCQQ9A9VOKIWRBWVPXMCGUENWVVMQAMPEIVHEQ9JXLCNZ" \
+  "OORVZTA"
+#define BUNDLE_2                                                               \
+  "BUNDLE200000LIKCEJTTIQOTTAWSQCCQQ9A9VOKIWRBWVPXMCGUENWVVMQAMPEIVHEQ9JXLCNZ" \
+  "OORVZTA"
+#define BUNDLE_3                                                               \
+  "BUNDLE300000LIKCEJTTIQOTTAWSQCCQQ9A9VOKIWRBWVPXMCGUENWVVMQAMPEIVHEQ9JXLCNZ" \
+  "OORVZTA"
+
+#define ADDRESS_1                                                               \
+  "ADDRESS100000LIKCEJTTIQOTTAWSQCCQQ9A9VOKIWRBWVPXMCGUENWVVMQAMPEIVHEQ9JXLCNZ" \
+  "OORVZT"
+#define ADDRESS_2                                                               \
+  "ADDRESS200000LIKCEJTTIQOTTAWSQCCQQ9A9VOKIWRBWVPXMCGUENWVVMQAMPEIVHEQ9JXLCNZ" \
+  "OORVZT"
+#define ADDRESS_3                                                               \
+  "ADDRESS300000LIKCEJTTIQOTTAWSQCCQQ9A9VOKIWRBWVPXMCGUENWVVMQAMPEIVHEQ9JXLCNZ" \
+  "OORVZT"
+#define ADDRESS_4                                                               \
+  "ADDRESS400000LIKCEJTTIQOTTAWSQCCQQ9A9VOKIWRBWVPXMCGUENWVVMQAMPEIVHEQ9JXLCNZ" \
+  "OORVZT"
+#define ADDRESS_5                                                               \
+  "ADDRESS500000LIKCEJTTIQOTTAWSQCCQQ9A9VOKIWRBWVPXMCGUENWVVMQAMPEIVHEQ9JXLCNZ" \
+  "OORVZT"
+#define ADDRESS_6                                                               \
+  "ADDRESS600000LIKCEJTTIQOTTAWSQCCQQ9A9VOKIWRBWVPXMCGUENWVVMQAMPEIVHEQ9JXLCNZ" \
+  "OORVZT"
+
+#define TRANSACTION_1                                                               \
+  "TRANSACTION100000LIKCEJTTIQOTTAWSQCCQQ9A9VOKIWRBWVPXMCGUENWVVMQAMPEIVHEQ9JXLCNZ" \
+  "OO"
+#define TRANSACTION_2                                                               \
+  "TRANSACTION200000LIKCEJTTIQOTTAWSQCCQQ9A9VOKIWRBWVPXMCGUENWVVMQAMPEIVHEQ9JXLCNZ" \
+  "OO"
+#define TRANSACTION_3                                                               \
+  "TRANSACTION300000LIKCEJTTIQOTTAWSQCCQQ9A9VOKIWRBWVPXMCGUENWVVMQAMPEIVHEQ9JXLCNZ" \
+  "OO"
+#define TRANSACTION_4                                                               \
+  "TRANSACTION400000LIKCEJTTIQOTTAWSQCCQQ9A9VOKIWRBWVPXMCGUENWVVMQAMPEIVHEQ9JXLCNZ" \
+  "OO"
+#define TRANSACTION_5                                                               \
+  "TRANSACTION500000LIKCEJTTIQOTTAWSQCCQQ9A9VOKIWRBWVPXMCGUENWVVMQAMPEIVHEQ9JXLCNZ" \
+  "OO"
+#define TRANSACTION_6                                                               \
+  "TRANSACTION600000LIKCEJTTIQOTTAWSQCCQQ9A9VOKIWRBWVPXMCGUENWVVMQAMPEIVHEQ9JXLCNZ" \
+  "OO"
+#define TRANSACTION_7                                                               \
+  "TRANSACTION700000LIKCEJTTIQOTTAWSQCCQQ9A9VOKIWRBWVPXMCGUENWVVMQAMPEIVHEQ9JXLCNZ" \
+  "OO"
+#define TRANSACTION_8                                                               \
+  "TRANSACTION800000LIKCEJTTIQOTTAWSQCCQQ9A9VOKIWRBWVPXMCGUENWVVMQAMPEIVHEQ9JXLCNZ" \
+  "OO"
+#define TRANSACTION_9                                                               \
+  "TRANSACTION900000LIKCEJTTIQOTTAWSQCCQQ9A9VOKIWRBWVPXMCGUENWVVMQAMPEIVHEQ9JXLCNZ" \
+  "OO"
+
+#define TIMESTAMP_1 1
+#define TIMESTAMP_2 2
+#define TIMESTAMP_3 3
+
+#define MESSAGE_1 "MESSAGE1"
+#define MESSAGE_2 "MESSAGE2"
+#define MESSAGE_3 "MESSAGE3"
+#define MESSAGE_4 "MESSAGE4"
+#define MESSAGE_5 "MESSAGE5"
+#define MESSAGE_6 "MESSAGE6"
+
+
 #ifdef __cplusplus
 }
 #endif

--- a/tests/test_scylla.c
+++ b/tests/test_scylla.c
@@ -1,0 +1,184 @@
+/*
+ * Copyright (C) 2019 BiiLabs Co., Ltd. and Contributors
+ * All Rights Reserved.
+ * This is free software; you can redistribute it and/or modify it under the
+ * terms of the MIT license. A copy of the license can be found in the file
+ * "LICENSE" at the root of this distribution.
+ */
+
+#include "storage/scylla_api.h"
+#include "test_define.h"
+
+static char* host;
+
+void test_get_column_from_edgeTable(CassSession* session) {
+  char expected_result[][FLEX_TRIT_SIZE_243] = {
+      {BUNDLE_1},       // address_2
+      {BUNDLE_2},       // address_2
+      {BUNDLE_3},       // address_2
+      {BUNDLE_1},       // address_1
+      {TRANSACTION_4},  // approvees T7
+      {TRANSACTION_3},  // approvees T7
+      {TRANSACTION_6},  // approvees T7
+      {TRANSACTION_5}   // approvees T7
+  };
+  hash243_queue_t res_hash = NULL;
+  hash243_queue_entry_t* iter243 = NULL;
+  get_column_from_edgeTable(session, &res_hash, (cass_byte_t*)ADDRESS_2, "bundle");
+  get_column_from_edgeTable(session, &res_hash, (cass_byte_t*)ADDRESS_1, "bundle");
+  get_column_from_edgeTable(session, &res_hash, (cass_byte_t*)TRANSACTION_7, "hash");
+  size_t idx = 0;
+  CDL_FOREACH(res_hash, iter243) {
+    TEST_ASSERT_EQUAL_MEMORY(iter243->hash, (flex_trit_t*)expected_result[idx++],
+                             sizeof(flex_trit_t) * FLEX_TRIT_SIZE_243);
+  }
+  hash243_queue_free(&res_hash);
+  TEST_ASSERT_EQUAL_INT(idx, sizeof(expected_result) / (sizeof(char) * FLEX_TRIT_SIZE_243));
+}
+
+void test_get_transactions(CassSession* session) {
+  char expected_response_transactions[][NUM_FLEX_TRITS_HASH] = {
+      {TRANSACTION_1},  // bundle 1
+      {TRANSACTION_2},  // bundle 1
+      {TRANSACTION_4},  // bundle 2
+      {TRANSACTION_3},  // bundle 2
+      {TRANSACTION_1},  // address_1
+      {TRANSACTION_2},  // address_2
+      {TRANSACTION_4},  // address_2
+      {TRANSACTION_6},  // address_2
+      {TRANSACTION_5},  // approvees T6
+      {TRANSACTION_4},  // approvees T7
+      {TRANSACTION_3},  // approvees T7
+      {TRANSACTION_6},  // approvees T7
+      {TRANSACTION_5}   // approvees T7
+  };
+
+  hash243_queue_t transactions = NULL;
+  hash243_queue_entry_t* iter243 = NULL;
+  hash243_queue_t bundles = NULL;
+  hash243_queue_t addresses = NULL;
+  hash243_queue_t approvees = NULL;
+  hash243_queue_push(&bundles, (flex_trit_t const* const)BUNDLE_1);
+  hash243_queue_push(&bundles, (flex_trit_t const* const)BUNDLE_2);
+
+  hash243_queue_push(&addresses, (flex_trit_t const* const)ADDRESS_1);
+  hash243_queue_push(&addresses, (flex_trit_t const* const)ADDRESS_2);
+
+  hash243_queue_push(&approvees, (flex_trit_t const* const)TRANSACTION_6);
+  hash243_queue_push(&approvees, (flex_trit_t const* const)TRANSACTION_7);
+
+  get_transactions(session, &transactions, bundles, addresses, approvees);
+
+  size_t idx = 0;
+  CDL_FOREACH(transactions, iter243) {
+    TEST_ASSERT_EQUAL_MEMORY(iter243->hash, (flex_trit_t*)expected_response_transactions[idx++],
+                             sizeof(flex_trit_t) * NUM_FLEX_TRITS_HASH);
+  }
+  TEST_ASSERT_EQUAL_INT(idx, sizeof(expected_response_transactions) / (sizeof(char) * NUM_FLEX_TRITS_HASH));
+  hash243_queue_free(&bundles);
+  hash243_queue_free(&addresses);
+  hash243_queue_free(&approvees);
+  hash243_queue_free(&transactions);
+}
+
+void test_scylla(void) {
+  /* input_transactions' graph
+   * T1-T2 in BUNDLE 1 approved T3-T4 and T5-T6
+   * T3-T4 in BUNDLE 2 approved T7-T8 and T9
+   * T5-T6 in BUNDLE 3 approved T7-T8 and T9
+   *
+   *    T1-T2
+   *    | /  \
+   *    |/    \
+   *    T3-T4  T5-T6
+   *    | /__\_/__/
+   *    |/    \  /
+   *    T7-T8   T9
+   */
+
+  CassCluster* cluster = NULL;
+  CassSession* session = cass_session_new();
+  char hashes[][NUM_FLEX_TRITS_HASH] = {
+      {TRANSACTION_1}, {TRANSACTION_2}, {TRANSACTION_3}, {TRANSACTION_4}, {TRANSACTION_5}, {TRANSACTION_6},
+  };
+  char bundles[][NUM_FLEX_TRITS_BUNDLE] = {
+      {BUNDLE_1}, {BUNDLE_1}, {BUNDLE_2}, {BUNDLE_2}, {BUNDLE_3}, {BUNDLE_3},
+  };
+  char addresses[][NUM_FLEX_TRITS_ADDRESS] = {
+      {ADDRESS_1}, {ADDRESS_2}, {ADDRESS_3}, {ADDRESS_2}, {ADDRESS_4}, {ADDRESS_2},
+  };
+  char messages[][NUM_FLEX_TRITS_MESSAGE] = {
+      {MESSAGE_1}, {MESSAGE_2}, {MESSAGE_3}, {MESSAGE_4}, {MESSAGE_5}, {MESSAGE_6},
+  };
+  char timestamps[][NUM_FLEX_TRITS_TIMESTAMP] = {
+      {TIMESTAMP_1}, {TIMESTAMP_1}, {TIMESTAMP_2}, {TIMESTAMP_2}, {TIMESTAMP_3}, {TIMESTAMP_3},
+  };
+  char trunks[][NUM_FLEX_TRITS_TRUNK] = {
+      {TRANSACTION_2}, {TRANSACTION_3}, {TRANSACTION_4}, {TRANSACTION_7}, {TRANSACTION_6}, {TRANSACTION_7},
+  };
+  char branches[][NUM_FLEX_TRITS_BRANCH] = {
+      {TRANSACTION_3}, {TRANSACTION_5}, {TRANSACTION_7}, {TRANSACTION_9}, {TRANSACTION_7}, {TRANSACTION_9},
+  };
+
+  size_t tx_num = sizeof(hashes) / (NUM_FLEX_TRITS_HASH);
+  scylla_iota_transaction_t* transaction;
+  TEST_ASSERT_NOT_EQUAL(host, NULL);
+  TEST_ASSERT_EQUAL_INT(init_scylla(&cluster, session, host, true), SC_OK);
+  new_scylla_iota_transaction(&transaction);
+
+  for (size_t i = 0; i < tx_num; i++) {
+    set_transaction_hash(transaction, (cass_byte_t*)hashes[i], NUM_FLEX_TRITS_HASH);
+    set_transaction_bundle(transaction, (cass_byte_t*)bundles[i], NUM_FLEX_TRITS_BUNDLE);
+    set_transaction_address(transaction, (cass_byte_t*)addresses[i], NUM_FLEX_TRITS_ADDRESS);
+    set_transaction_message(transaction, (cass_byte_t*)messages[i], NUM_FLEX_TRITS_MESSAGE);
+    set_transaction_trunk(transaction, (cass_byte_t*)trunks[i], NUM_FLEX_TRITS_TRUNK);
+    set_transaction_branch(transaction, (cass_byte_t*)branches[i], NUM_FLEX_TRITS_BRANCH);
+    set_transaction_timestamp(transaction, (int64_t)timestamps[i]);
+    set_transaction_value(transaction, (int64_t)i);
+    /* insert test input transactions to ScyllyDB */
+    insert_transaction_into_bundleTable(session, transaction, 1);
+    insert_transaction_into_edgeTable(session, transaction, 1);
+  }
+
+  /* test select bundles by edge in edge table */
+  test_get_column_from_edgeTable(session);
+  /* test find transactions by bundles or addresses */
+  test_get_transactions(session);
+
+  free_scylla_iota_transaction(&transaction);
+  cass_cluster_free(cluster);
+  cass_session_free(session);
+}
+
+int main(int argc, char** argv) {
+  int cmdOpt;
+  int optIdx;
+  const struct option longOpt[] = {{"host", required_argument, NULL, 'h'}, {NULL, 0, NULL, 0}};
+
+  host = NULL;
+
+  /* Parse the command line options */
+  /* TODO: Support macOS since getopt_long() is GNU extension */
+  while (1) {
+    cmdOpt = getopt_long(argc, argv, "b:", longOpt, &optIdx);
+    if (cmdOpt == -1) break;
+
+    /* Invalid option */
+    if (cmdOpt == '?') break;
+
+    if (cmdOpt == 'h') {
+      host = optarg;
+    }
+  }
+  UNITY_BEGIN();
+
+  if (logger_helper_init(LOGGER_ERR) != RC_OK) {
+    return EXIT_FAILURE;
+  }
+  scylla_api_logger_init();
+
+  RUN_TEST(test_scylla);
+  scylla_api_logger_release();
+
+  return UNITY_END();
+}


### PR DESCRIPTION
Why: for Permanode to store transactions with scyllaDB
How: add storage folder with Bazel BUILD
          @storage/scylla_api.c - insert_transaction_into_bundleTable => insert transaction
                                 - select_transactions_with_bundle => show all transaction in specific bundle
