### PR TITLE
feat(reg): Fix regression test API format

### DIFF
--- a/accelerator/apis.c
+++ b/accelerator/apis.c
@@ -367,8 +367,8 @@ status_t api_receive_mam_message(const iota_config_t* const iconf, const iota_cl
     goto done;
   }
 
-  mam_api_add_trusted_channel_pk(&mam, chid);
-  ret = ta_get_bundle_by_addr(service, chid, bundle);
+  mam_api_add_trusted_channel_pk(&mam, (tryte_t*)chid);
+  ret = ta_get_bundle_by_addr(service, (tryte_t*)chid, bundle);
   if (ret != SC_OK) {
     goto done;
   }

--- a/accelerator/common_core.c
+++ b/accelerator/common_core.c
@@ -505,6 +505,7 @@ status_t ta_get_bundle_by_addr(const iota_client_service_t* const service, tryte
   transaction_array_t* obj_res = transaction_array_new();
 
   if (txn_req == NULL || txn_res == NULL || obj_req == NULL || obj_res == NULL) {
+    log_error(cc_logger_id, "[%s:%d:%s]\n", __func__, __LINE__, "SC_TA_OOM");
     ret = SC_TA_OOM;
     goto done;
   }
@@ -514,6 +515,7 @@ status_t ta_get_bundle_by_addr(const iota_client_service_t* const service, tryte
   find_transactions_req_address_add(txn_req, addr_trits);
 
   if (iota_client_find_transactions(service, txn_req, txn_res) != RC_OK) {
+    log_error(cc_logger_id, "[%s:%d:%s]\n", __func__, __LINE__, "SC_CCLIENT_FAILED_RESPONSE");
     ret = SC_CCLIENT_FAILED_RESPONSE;
     goto done;
   }
@@ -529,6 +531,7 @@ status_t ta_get_bundle_by_addr(const iota_client_service_t* const service, tryte
 
   ret = ta_find_transaction_objects(service, obj_req, obj_res);
   if (ret != SC_OK) {
+    log_error(cc_logger_id, "[%s:%d:%d]\n", __func__, __LINE__, ret);
     goto done;
   }
 
@@ -536,6 +539,7 @@ status_t ta_get_bundle_by_addr(const iota_client_service_t* const service, tryte
   flex_trits_to_trytes(bundle_hash, NUM_TRYTES_BUNDLE, transaction_bundle(curr_tx), NUM_TRITS_BUNDLE, NUM_TRITS_BUNDLE);
   ret = ta_get_bundle(service, bundle_hash, bundle);
   if (ret != SC_OK) {
+    log_error(cc_logger_id, "[%s:%d:%d]\n", __func__, __LINE__, ret);
     goto done;
   }
 

--- a/accelerator/common_core.c
+++ b/accelerator/common_core.c
@@ -518,7 +518,15 @@ status_t ta_get_bundle_by_addr(const iota_client_service_t* const service, tryte
     goto done;
   }
 
-  hash243_queue_push(&obj_req->hashes, find_transactions_res_hashes_get(txn_res, 0));
+  // In case the requested transction hashes is an empty one
+  if (hash243_queue_count(txn_res->hashes) > 0) {
+    hash243_queue_push(&obj_req->hashes, find_transactions_res_hashes_get(txn_res, 0));
+  } else {
+    log_error(cc_logger_id, "[%s:%d:%s]\n", __func__, __LINE__, "SC_MAM_NOT_FOUND");
+    ret = SC_MAM_NOT_FOUND;
+    goto done;
+  }
+
   ret = ta_find_transaction_objects(service, obj_req, obj_res);
   if (ret != SC_OK) {
     goto done;


### PR DESCRIPTION
The tests in regression test are still using the deprecated API
format. We should correct it to accommodate the current using
API format.

In order to avoid some possible crashes, we block unicode messages.
Now, both tag and message are not allowed to be unicode string.
CI result: https://buildkite.com/dltcollab/ta-regression-test-hojmay/builds/474