### PR TITLE
refactor(serialize): Reorder serialize functions arguements

### DIFF
--- a/accelerator/apis.c
+++ b/accelerator/apis.c
@@ -41,7 +41,7 @@ status_t api_get_tips(const iota_client_service_t* const service, char** json_re
     goto done;
   }
 
-  ret = ta_get_tips_res_serialize(json_result, res);
+  ret = ta_get_tips_res_serialize(res, json_result);
   if (ret != SC_OK) {
     ret = SC_CCLIENT_JSON_PARSE;
     log_error(apis_logger_id, "[%s:%d:%s]\n", __func__, __LINE__, "SC_CCLIENT_JSON_PARSE");
@@ -109,7 +109,7 @@ status_t api_generate_address(const iota_config_t* const tangle, const iota_clie
     goto done;
   }
 
-  ret = ta_generate_address_res_serialize(json_result, res);
+  ret = ta_generate_address_res_serialize(res, json_result);
 
 done:
   ta_generate_address_res_free(&res);
@@ -180,7 +180,7 @@ status_t api_find_transaction_object_single(const iota_client_service_t* const s
     goto done;
   }
 
-  ret = ta_find_transaction_object_single_res_serialize(json_result, res);
+  ret = ta_find_transaction_object_single_res_serialize(res, json_result);
 
 done:
   ta_find_transaction_objects_req_free(&req);
@@ -211,7 +211,7 @@ status_t api_find_transaction_objects(const iota_client_service_t* const service
     goto done;
   }
 
-  ret = ta_find_transaction_objects_res_serialize(json_result, res);
+  ret = ta_find_transaction_objects_res_serialize(res, json_result);
 
 done:
   ta_find_transaction_objects_req_free(&req);
@@ -244,7 +244,7 @@ status_t api_find_transactions_by_tag(const iota_client_service_t* const service
     goto done;
   }
 
-  ret = ta_find_transactions_res_serialize(json_result, (ta_find_transactions_res_t*)res);
+  ret = ta_find_transactions_by_tag_res_serialize((ta_find_transactions_by_tag_res_t*)res, json_result);
 
 done:
   find_transactions_req_free(&req);
@@ -277,7 +277,7 @@ status_t api_find_transactions_obj_by_tag(const iota_client_service_t* const ser
     goto done;
   }
 
-  ret = ta_find_transaction_objects_res_serialize(json_result, res);
+  ret = ta_find_transaction_objects_res_serialize(res, json_result);
 
 done:
   find_transactions_req_free(&req);
@@ -314,7 +314,7 @@ status_t api_receive_mam_message(const iota_client_service_t* const service, con
     goto done;
   }
 
-  ret = receive_mam_message_serialize(json_result, &payload);
+  ret = receive_mam_message_res_serialize(payload, json_result);
 
 done:
   // Destroying MAM API
@@ -398,7 +398,7 @@ status_t api_mam_send_message(const iota_config_t* const tangle, const iota_clie
   }
   send_mam_res_set_bundle_hash(res, transaction_bundle((iota_transaction_t*)utarray_front(bundle)));
 
-  ret = send_mam_res_serialize(json_result, res);
+  ret = send_mam_res_serialize(res, json_result);
 
 done:
   // Destroying MAM API
@@ -446,7 +446,7 @@ status_t api_send_transfer(const iota_config_t* const tangle, const iota_client_
     goto done;
   }
 
-  ret = ta_send_transfer_res_serialize(json_result, res_txn_array);
+  ret = ta_send_transfer_res_serialize(res_txn_array, json_result);
 
 done:
   ta_send_transfer_req_free(&req);

--- a/accelerator/common_core.h
+++ b/accelerator/common_core.h
@@ -122,19 +122,19 @@ status_t ta_send_trytes(const iota_config_t* const tangle, const iota_client_ser
  * @brief Return list of transaction hash with given tag.
  *
  * Retreive all transactions that have same given tag. The result is a list of
- * transaction hash in ta_find_transactions_res_t.
+ * transaction hash in ta_find_transactions_by_tag_res_t.
  *
  * @param[in] service IRI node end point service
  * @param[in] req tag in trytes
  * @param[out] res Result containing a list of transaction hash in
- *             ta_find_transactions_res_t
+ *             ta_find_transactions_by_tag_res_t
  *
  * @return
  * - SC_OK on success
  * - non-zero on error
  */
 status_t ta_find_transactions_by_tag(const iota_client_service_t* const service, const char* const req,
-                                     ta_find_transactions_res_t* const res);
+                                     ta_find_transactions_by_tag_res_t* const res);
 
 /**
  * @brief Return list of transaction object with given tag.

--- a/response/ta_find_transactions.c
+++ b/response/ta_find_transactions.c
@@ -8,15 +8,16 @@
 
 #include "ta_find_transactions.h"
 
-ta_find_transactions_res_t* ta_find_transactions_res_new() {
-  ta_find_transactions_res_t* res = (ta_find_transactions_res_t*)malloc(sizeof(ta_find_transactions_res_t));
+ta_find_transactions_by_tag_res_t* ta_find_transactions_res_new() {
+  ta_find_transactions_by_tag_res_t* res =
+      (ta_find_transactions_by_tag_res_t*)malloc(sizeof(ta_find_transactions_by_tag_res_t));
   if (res) {
     res->hashes = NULL;
   }
   return res;
 }
 
-void ta_find_transactions_res_free(ta_find_transactions_res_t** res) {
+void ta_find_transactions_res_free(ta_find_transactions_by_tag_res_t** res) {
   if (!res || !(*res)) {
     return;
   }

--- a/response/ta_find_transactions.h
+++ b/response/ta_find_transactions.h
@@ -20,27 +20,27 @@ extern "C" {
  * @file response/ta_find_transactions.h
  */
 
-/** struct of ta_find_transactions_res_t */
+/** struct of ta_find_transactions_by_tag_res_t */
 typedef struct ta_find_transactions_res {
   /** Transaction hashes is a 243 long flex trits hash queue. */
   hash243_queue_t hashes;
-} ta_find_transactions_res_t;
+} ta_find_transactions_by_tag_res_t;
 
 /**
- * Allocate memory of ta_find_transactions_res_t
+ * Allocate memory of ta_find_transactions_by_tag_res_t
  *
  * @return
- * - struct of ta_find_transactions_res_t on success
+ * - struct of ta_find_transactions_by_tag_res_t on success
  * - NULL on error
  */
-ta_find_transactions_res_t* ta_find_transactions_res_new();
+ta_find_transactions_by_tag_res_t* ta_find_transactions_res_new();
 
 /**
- * Free memory of ta_find_transactions_res_t
+ * Free memory of ta_find_transactions_by_tag_res_t
  *
- * @param res Data type of ta_find_transactions_res_t
+ * @param res Data type of ta_find_transactions_by_tag_res_t
  */
-void ta_find_transactions_res_free(ta_find_transactions_res_t** res);
+void ta_find_transactions_res_free(ta_find_transactions_by_tag_res_t** res);
 
 #ifdef __cplusplus
 }

--- a/serializer/serializer.c
+++ b/serializer/serializer.c
@@ -281,7 +281,7 @@ static status_t transaction_array_to_json_array(cJSON* json_root, const transact
   return ret;
 }
 
-status_t ta_generate_address_res_serialize(char** obj, const ta_generate_address_res_t* const res) {
+status_t ta_generate_address_res_serialize(const ta_generate_address_res_t* const res, char** obj) {
   cJSON* json_root = cJSON_CreateArray();
   status_t ret = SC_OK;
   if (json_root == NULL) {
@@ -302,7 +302,7 @@ status_t ta_generate_address_res_serialize(char** obj, const ta_generate_address
   return ret;
 }
 
-status_t ta_get_tips_res_serialize(char** obj, const get_tips_res_t* const res) {
+status_t ta_get_tips_res_serialize(const get_tips_res_t* const res, char** obj) {
   status_t ret = SC_OK;
 
   cJSON* json_root = cJSON_CreateArray();
@@ -519,7 +519,7 @@ status_t ta_find_transaction_objects_req_deserialize(const char* const obj,
   return ret;
 }
 
-status_t ta_find_transaction_object_single_res_serialize(char** obj, transaction_array_t* res) {
+status_t ta_find_transaction_object_single_res_serialize(transaction_array_t* res, char** obj) {
   status_t ret = SC_OK;
   cJSON* json_root = cJSON_CreateObject();
   if (json_root == NULL) {
@@ -543,7 +543,7 @@ done:
   return ret;
 }
 
-status_t ta_find_transaction_objects_res_serialize(char** obj, const transaction_array_t* const res) {
+status_t ta_find_transaction_objects_res_serialize(const transaction_array_t* const res, char** obj) {
   status_t ret = SC_OK;
   cJSON* json_root = cJSON_CreateArray();
   if (json_root == NULL) {
@@ -567,7 +567,7 @@ done:
   return ret;
 }
 
-status_t ta_find_transactions_res_serialize(char** obj, const ta_find_transactions_res_t* const res) {
+status_t ta_find_transactions_by_tag_res_serialize(const ta_find_transactions_by_tag_res_t* const res, char** obj) {
   status_t ret = SC_OK;
   cJSON* json_root = cJSON_CreateArray();
   if (json_root == NULL) {
@@ -592,7 +592,7 @@ done:
   return ret;
 }
 
-status_t ta_send_transfer_res_serialize(char** obj, const transaction_array_t* const res) {
+status_t ta_send_transfer_res_serialize(transaction_array_t* res, char** obj) {
   status_t ret = SC_OK;
   cJSON* json_root = cJSON_CreateObject();
   if (json_root == NULL) {
@@ -618,33 +618,7 @@ done:
   return ret;
 }
 
-status_t ta_find_transactions_obj_res_serialize(char** obj, const ta_find_transactions_obj_res_t* const res) {
-  status_t ret = SC_OK;
-  cJSON* json_root = cJSON_CreateArray();
-  if (json_root == NULL) {
-    ret = SC_SERIALIZER_JSON_CREATE;
-    log_error(seri_logger_id, "[%s:%d:%s]\n", __func__, __LINE__, "SC_SERIALIZER_JSON_CREATE");
-    goto done;
-  }
-
-  ret = transaction_array_to_json_array(json_root, res->txn_obj);
-  if (ret != SC_OK) {
-    goto done;
-  }
-
-  *obj = cJSON_PrintUnformatted(json_root);
-  if (*obj == NULL) {
-    ret = SC_SERIALIZER_JSON_PARSE;
-    log_error(seri_logger_id, "[%s:%d:%s]\n", __func__, __LINE__, "SC_SERIALIZER_JSON_CREATE");
-    goto done;
-  }
-
-done:
-  cJSON_Delete(json_root);
-  return ret;
-}
-
-status_t receive_mam_message_serialize(char** obj, char** const res) {
+status_t receive_mam_message_res_serialize(char* const message, char** obj) {
   status_t ret = SC_OK;
   cJSON* json_root = cJSON_CreateObject();
   if (json_root == NULL) {
@@ -653,7 +627,7 @@ status_t receive_mam_message_serialize(char** obj, char** const res) {
     goto done;
   }
 
-  cJSON_AddStringToObject(json_root, "message", *res);
+  cJSON_AddStringToObject(json_root, "message", message);
 
   *obj = cJSON_PrintUnformatted(json_root);
   if (*obj == NULL) {
@@ -667,7 +641,7 @@ done:
   return ret;
 }
 
-status_t send_mam_res_serialize(char** obj, const ta_send_mam_res_t* const res) {
+status_t send_mam_res_serialize(const ta_send_mam_res_t* const res, char** obj) {
   status_t ret = SC_OK;
   cJSON* json_root = cJSON_CreateObject();
   if (json_root == NULL) {

--- a/serializer/serializer.h
+++ b/serializer/serializer.h
@@ -66,7 +66,7 @@ int serializer_logger_release();
  * - SC_OK on success
  * - non-zero on error
  */
-status_t ta_generate_address_res_serialize(char** obj, const ta_generate_address_res_t* const res);
+status_t ta_generate_address_res_serialize(const ta_generate_address_res_t* const res, char** obj);
 
 /**
  * @brief Serialze object `get_tips_res_t` into JSON
@@ -78,7 +78,7 @@ status_t ta_generate_address_res_serialize(char** obj, const ta_generate_address
  * - SC_OK on success
  * - non-zero on error
  */
-status_t ta_get_tips_res_serialize(char** obj, const get_tips_res_t* const res);
+status_t ta_get_tips_res_serialize(const get_tips_res_t* const res, char** obj);
 
 /**
  * @brief Deserialze JSON string to type of ta_send_transfer_req_t
@@ -102,7 +102,7 @@ status_t ta_send_transfer_req_deserialize(const char* const obj, ta_send_transfe
  * - SC_OK on success
  * - non-zero on error
  */
-status_t ta_send_transfer_res_serialize(char** obj, const transaction_array_t* const res);
+status_t ta_send_transfer_res_serialize(transaction_array_t* res, char** obj);
 
 /**
  * @brief Deserialze JSON string to hash8019_array_p
@@ -139,7 +139,7 @@ status_t ta_send_trytes_res_serialize(const hash8019_array_p trytes, char** obj)
  * - SC_OK on success
  * - non-zero on error
  */
-status_t ta_find_transaction_object_single_res_serialize(char** obj, transaction_array_t* res);
+status_t ta_find_transaction_object_single_res_serialize(transaction_array_t* res, char** obj);
 
 /**
  * @brief Deserialze type of ta_find_transaction_objects_req_t from JSON string
@@ -164,55 +164,43 @@ status_t ta_find_transaction_objects_req_deserialize(const char* const obj,
  * - SC_OK on success
  * - non-zero on error
  */
-status_t ta_find_transaction_objects_res_serialize(char** obj, const transaction_array_t* const res);
+status_t ta_find_transaction_objects_res_serialize(const transaction_array_t* const res, char** obj);
 
 /**
- * @brief Serialze type of ta_find_transactions_res_t to JSON string
+ * @brief Serialze type of ta_find_transactions_by_tag_res_t to JSON string
  *
  * @param[out] obj List of transaction hash in JSON
- * @param[in] res Response data in type of ta_find_transactions_res_t
+ * @param[in] res Response data in type of ta_find_transactions_by_tag_res_t
  *
  * @return
  * - SC_OK on success
  * - non-zero on error
  */
-status_t ta_find_transactions_res_serialize(char** obj, const ta_find_transactions_res_t* const res);
+status_t ta_find_transactions_by_tag_res_serialize(const ta_find_transactions_by_tag_res_t* const res, char** obj);
 
 /**
- * @brief Serialze type of ta_find_transactions_obj_res_t to JSON string
- *
- * @param[out] obj List of transaction object in JSON
- * @param[in] res Response data in type of ta_find_transactions_obj_res_t
- *
- * @return
- * - SC_OK on success
- * - non-zero on error
- */
-status_t ta_find_transactions_obj_res_serialize(char** obj, const ta_find_transactions_obj_res_t* const res);
-
-/**
- * @brief Serialize mam message
+ * @brief Serialize response of mam message
  *
  * @param[out] obj message formed in JSON
- * @param[in] res Response of payload message
+ * @param[in] message Response of payload message
  *
  * @return
  * - SC_OK on success
  * - non-zero on error
  */
-status_t receive_mam_message_serialize(char** obj, char** const res);
+status_t receive_mam_message_res_serialize(char* const message, char** obj);
 
 /**
- * @brief Serialze type of ta_send_mam_res_t to JSON string
+ * @brief Deserialze JSON string to type of ta_send_mam_req_t
  *
- * @param[out] obj send mam response object in JSON
- * @param[in] res Response data in type of ta_send_mam_res_t
+ * @param[in] obj Input values in JSON
+ * @param[out] req Request data in type of ta_send_mam_req_t
  *
  * @return
  * - SC_OK on success
  * - non-zero on error
  */
-status_t send_mam_res_serialize(char** obj, const ta_send_mam_res_t* const res);
+status_t send_mam_req_deserialize(const char* const obj, ta_send_mam_req_t* req);
 
 /**
  * @brief Deserialze JSON string to type of ta_send_mam_res_t
@@ -227,16 +215,16 @@ status_t send_mam_res_serialize(char** obj, const ta_send_mam_res_t* const res);
 status_t send_mam_res_deserialize(const char* const obj, ta_send_mam_res_t* const res);
 
 /**
- * @brief Deserialze JSON string to type of ta_send_mam_req_t
+ * @brief Serialze type of ta_send_mam_res_t to JSON string
  *
- * @param[in] obj Input values in JSON
- * @param[out] req Request data in type of ta_send_mam_req_t
+ * @param[out] obj send mam response object in JSON
+ * @param[in] res Response data in type of ta_send_mam_res_t
  *
  * @return
  * - SC_OK on success
  * - non-zero on error
  */
-status_t send_mam_req_deserialize(const char* const obj, ta_send_mam_req_t* req);
+status_t send_mam_res_serialize(const ta_send_mam_res_t* const res, char** obj);
 
 #ifdef __cplusplus
 }

--- a/tests/test_serializer.c
+++ b/tests/test_serializer.c
@@ -19,7 +19,7 @@ void test_serialize_ta_generate_address(void) {
   hash243_queue_push(&res->addresses, hash_trits_1);
   hash243_queue_push(&res->addresses, hash_trits_2);
 
-  ta_generate_address_res_serialize(&json_result, res);
+  ta_generate_address_res_serialize(res, &json_result);
   TEST_ASSERT_EQUAL_STRING(json, json_result);
   ta_generate_address_res_free(&res);
   free(json_result);
@@ -115,7 +115,7 @@ void test_serialize_ta_find_transaction_objects(void) {
   transaction_set_nonce(txn, tag_trits);
   transaction_array_push_back(res, txn);
 
-  ta_find_transaction_objects_res_serialize(&json_result, res);
+  ta_find_transaction_objects_res_serialize(res, &json_result);
 
   TEST_ASSERT_EQUAL_STRING(json, json_result);
   transaction_array_free(res);
@@ -126,7 +126,7 @@ void test_serialize_ta_find_transaction_objects(void) {
 void test_serialize_ta_find_transactions_by_tag(void) {
   const char* json = "[\"" TRYTES_81_1 "\",\"" TRYTES_81_2 "\"]";
   char* json_result;
-  ta_find_transactions_res_t* res = ta_find_transactions_res_new();
+  ta_find_transactions_by_tag_res_t* res = ta_find_transactions_res_new();
   flex_trit_t hash_trits_1[FLEX_TRIT_SIZE_243], hash_trits_2[FLEX_TRIT_SIZE_243];
   flex_trits_from_trytes(hash_trits_1, NUM_TRITS_HASH, (const tryte_t*)TRYTES_81_1, NUM_TRYTES_HASH, NUM_TRYTES_HASH);
   flex_trits_from_trytes(hash_trits_2, NUM_TRITS_HASH, (const tryte_t*)TRYTES_81_2, NUM_TRYTES_HASH, NUM_TRYTES_HASH);
@@ -134,7 +134,7 @@ void test_serialize_ta_find_transactions_by_tag(void) {
   hash243_queue_push(&res->hashes, hash_trits_1);
   hash243_queue_push(&res->hashes, hash_trits_2);
 
-  ta_find_transactions_res_serialize(&json_result, res);
+  ta_find_transactions_by_tag_res_serialize(res, &json_result);
 
   TEST_ASSERT_EQUAL_STRING(json, json_result);
   ta_find_transactions_res_free(&res);
@@ -206,7 +206,7 @@ void test_serialize_ta_find_transactions_obj_by_tag(void) {
   transaction_set_nonce(txn, tag_trits);
 
   utarray_push_back(res->txn_obj, txn);
-  ta_find_transactions_obj_res_serialize(&json_result, res);
+  ta_find_transaction_objects_res_serialize(res->txn_obj, &json_result);
 
   TEST_ASSERT_EQUAL_STRING(json, json_result);
   ta_find_transactions_obj_res_free(&res);
@@ -224,7 +224,7 @@ void test_serialize_send_mam_message(void) {
   send_mam_res_set_bundle_hash(res, (tryte_t*)TRYTES_81_2);
   send_mam_res_set_channel_id(res, (tryte_t*)TRYTES_81_1);
 
-  send_mam_res_serialize(&json_result, res);
+  send_mam_res_serialize(res, &json_result);
   TEST_ASSERT_EQUAL_STRING(json, json_result);
 
   free(json_result);


### PR DESCRIPTION
Reorder serializing functions into `serialize(*source, *dest)`.
This ordering would makes these functions more clear and
at the same time, it is following the same ordering entangled using.