### PR TITLE
feat(api): Add lock to avoid race condition

### DIFF
--- a/accelerator/apis.h
+++ b/accelerator/apis.h
@@ -59,6 +59,24 @@ status_t api_get_ta_info(char** json_result, ta_config_t* const info, iota_confi
                          ta_cache_t* const cache, iota_client_service_t* const service);
 
 /**
+ * Initialize lock
+ *
+ * @return
+ * - zero on success
+ * - SC_CONF_LOCK_INIT on error
+ */
+status_t apis_lock_init();
+
+/**
+ * Destroy lock
+ *
+ * @return
+ * - zero on success
+ * - SC_CONF_LOCK_DESTROY on error
+ */
+status_t apis_lock_destroy();
+
+/**
  * @brief Generate an unused address.
  *
  * Generate and return an unused address from the seed. An unused address means

--- a/accelerator/errors.h
+++ b/accelerator/errors.h
@@ -152,6 +152,10 @@ typedef enum {
   /**< No argument in CLI */
   SC_CONF_UNKNOWN_OPTION = 0x03 | SC_MODULE_CONF | SC_SEVERITY_FATAL,
   /**< undefined option in CLI */
+  SC_CONF_LOCK_INIT = 0x04 | SC_MODULE_CONF | SC_SEVERITY_FATAL,
+  /**< fail to init lock */
+  SC_CONF_LOCK_DESTROY = 0x05 | SC_MODULE_CONF | SC_SEVERITY_FATAL,
+  /**< fail to destroy lock */
 
   // UTILS module
   SC_UTILS_NULL = 0x01 | SC_MODULE_UTILS | SC_SEVERITY_FATAL,

--- a/accelerator/main.c
+++ b/accelerator/main.c
@@ -42,6 +42,12 @@ int main(int argc, char* argv[]) {
     return EXIT_FAILURE;
   }
 
+  // Initialize apis cJSON lock
+  if (apis_lock_init() != SC_OK) {
+    log_critical(logger_id, "[%s:%d] Lock initialization failed %s.\n", __func__, __LINE__, MAIN_LOGGER);
+    return EXIT_FAILURE;
+  }
+
   // Enable other loggers when verbose mode is on
   if (verbose_mode) {
     http_logger_init();
@@ -67,6 +73,11 @@ int main(int argc, char* argv[]) {
   }
 
 cleanup:
+  log_warning(logger_id, "Destroying API lock\n");
+  if (apis_lock_destroy() != SC_OK) {
+    log_critical(logger_id, "[%s:%d] Destroying api lock failed %s.\n", __func__, __LINE__, MAIN_LOGGER);
+    return EXIT_FAILURE;
+  }
   log_warning(logger_id, "Destroying TA configurations\n");
   ta_config_destroy(&ta_core.service);
 

--- a/accelerator/server.cc
+++ b/accelerator/server.cc
@@ -89,6 +89,12 @@ int main(int argc, char* argv[]) {
     return EXIT_FAILURE;
   }
 
+  // Initialize apis cJSON lock
+  if (apis_lock_init() != SC_OK) {
+    log_critical(server_logger_id, "[%s:%d] Lock initialization failed %s.\n", __func__, __LINE__, SERVER_LOGGER);
+    return EXIT_FAILURE;
+  }
+
   // Enable other loggers when verbose mode is on
   if (verbose_mode) {
     apis_logger_init();
@@ -417,6 +423,10 @@ int main(int argc, char* argv[]) {
   served::net::server server(ta_core.info.host, ta_core.info.port, mux);
   server.run(ta_core.info.thread_count);
 
+  if (apis_lock_destroy() != SC_OK) {
+    log_critical(server_logger_id, "[%s:%d] Destroying api lock failed %s.\n", __func__, __LINE__, SERVER_LOGGER);
+    return EXIT_FAILURE;
+  }
   ta_config_destroy(&ta_core.service);
 
   if (verbose_mode) {


### PR DESCRIPTION
Race condition happens when doing `cJSON_parse`, both cclient library and deserialization in TA would use the function, thus those are wrapped with mutex lock.

