### PR TITLE
docs: Update docker image name

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ $ make && bazel run //accelerator:ta_image
 There's also an easier option to pull image from docker hub then simply run with default configs. Please do remember a redis-server is still required in this way.
 
 ```
-$ docker run -d --net=host --name tangle-accelerator wusyong/tangel-accelerator:latest
+$ docker run -d --net=host --name tangle-accelerator dltcollab/tangle-accelerator
 ```
 
 ## Developing


### PR DESCRIPTION
Since we have a new image repository on the Docker Hub, update the
readme document to use image comes from that repository.

See also: https://hub.docker.com/r/dltcollab/tangle-accelerator