### PR TITLE
refactor(api): Update the way to initialize logger

### DIFF
--- a/accelerator/main.c
+++ b/accelerator/main.c
@@ -21,16 +21,7 @@ int main(int argc, char* argv[]) {
   }
 
   // Initialize logger
-  if (LOGGER_VERSION != logger_version()) {
-    return EXIT_FAILURE;
-  }
-
-  logger_init();
-  logger_color_prefix_enable();
-  logger_color_message_enable();
-  logger_output_register(stdout);
-  logger_output_level_set(stdout, LOGGER_DEBUG);
-
+  logger_helper_init(LOGGER_DEBUG);
   logger_id = logger_helper_enable(MAIN_LOGGER, LOGGER_DEBUG, true);
 
   // Initialize configurations with default value

--- a/accelerator/server.cc
+++ b/accelerator/server.cc
@@ -68,15 +68,7 @@ int main(int argc, char* argv[]) {
   mux.use_after(served::plugin::access_log);
 
   // Initialize logger
-  if (LOGGER_VERSION != logger_version()) {
-    return EXIT_FAILURE;
-  }
-
-  logger_init();
-  logger_color_prefix_enable();
-  logger_color_message_enable();
-  logger_output_register(stdout);
-  logger_output_level_set(stdout, LOGGER_DEBUG);
+  logger_helper_init(LOGGER_DEBUG);
   server_logger_id = logger_helper_enable(SERVER_LOGGER, LOGGER_DEBUG, true);
 
   // Initialize configurations with default value

--- a/accelerator/server.cc
+++ b/accelerator/server.cc
@@ -98,6 +98,39 @@ int main(int argc, char* argv[]) {
     logger_helper_destroy();
   }
 
+  /**
+   * @method {get} / Show the information about a running accelerator
+   *
+   * @return {String[]} object Info of a running accelerator
+   */
+  mux.handle("/")
+      .method(served::method::OPTIONS,
+              [&](served::response& res, const served::request& req) { set_method_header(res, HTTP_METHOD_OPTIONS); })
+      .get([&](served::response& res, const served::request& req) {
+        status_t ret = SC_OK;
+        char* json_result = NULL;
+
+        cJSON* json_obj = cJSON_CreateObject();
+        cJSON_AddStringToObject(json_obj, "name", "tangle-accelerator");
+        cJSON_AddStringToObject(json_obj, "host", TA_HOST);
+        cJSON_AddStringToObject(json_obj, "version", TA_VERSION);
+        cJSON_AddStringToObject(json_obj, "port", TA_PORT);
+        cJSON_AddNumberToObject(json_obj, "thread", TA_THREAD_COUNT);
+        cJSON_AddStringToObject(json_obj, "iri_host", IRI_HOST);
+        cJSON_AddNumberToObject(json_obj, "iri_port", IRI_PORT);
+        cJSON_AddStringToObject(json_obj, "redis_host", REDIS_HOST);
+        cJSON_AddNumberToObject(json_obj, "redis_port", REDIS_PORT);
+        cJSON_AddNumberToObject(json_obj, "milestone_depth", MILESTONE_DEPTH);
+        cJSON_AddNumberToObject(json_obj, "mwm", MWM);
+        cJSON_AddBoolToObject(json_obj, "verbose", verbose_mode);
+        json_result = cJSON_Print(json_obj);
+        cJSON_Delete(json_obj);
+
+        set_method_header(res, HTTP_METHOD_GET);
+        res.set_status(ret);
+        res << json_result;
+      });
+
   mux.handle("/mam/{bundle:[A-Z9]{81}}")
       .method(served::method::OPTIONS,
               [&](served::response& res, const served::request& req) { set_method_header(res, HTTP_METHOD_OPTIONS); })


### PR DESCRIPTION
With `logger_helper_init()` provided in newer version of
entangled(tag ="cclient-v1.0.0-beta"), codes that initialize logger
can be shortened.