### PR TITLE
refactor(api): Update the way to initialize logger

### DIFF
--- a/accelerator/main.c
+++ b/accelerator/main.c
@@ -21,15 +21,9 @@ int main(int argc, char* argv[]) {
   }
 
   // Initialize logger
-  if (LOGGER_VERSION != logger_version()) {
+  if (logger_helper_init(LOGGER_DEBUG) != RC_OK) {
     return EXIT_FAILURE;
   }
-
-  logger_init();
-  logger_color_prefix_enable();
-  logger_color_message_enable();
-  logger_output_register(stdout);
-  logger_output_level_set(stdout, LOGGER_DEBUG);
 
   logger_id = logger_helper_enable(MAIN_LOGGER, LOGGER_DEBUG, true);
 

--- a/accelerator/mqtt_interface.c
+++ b/accelerator/mqtt_interface.c
@@ -14,7 +14,10 @@ int main(int argc, char *argv[]) {
   struct mosquitto *mosq = NULL;
 
   // Initialize logger
-  logger_helper_init(LOGGER_DEBUG);
+  if (logger_helper_init(LOGGER_DEBUG) != RC_OK) {
+    return EXIT_FAILURE;
+  }
+
   mqtt_logger_id = logger_helper_enable(MQTT_INTERFACE_LOGGER, LOGGER_DEBUG, true);
 
   if (verbose_mode) {

--- a/accelerator/server.cc
+++ b/accelerator/server.cc
@@ -68,15 +68,10 @@ int main(int argc, char* argv[]) {
   mux.use_after(served::plugin::access_log);
 
   // Initialize logger
-  if (LOGGER_VERSION != logger_version()) {
+  if (logger_helper_init(LOGGER_DEBUG) != RC_OK) {
     return EXIT_FAILURE;
   }
 
-  logger_init();
-  logger_color_prefix_enable();
-  logger_color_message_enable();
-  logger_output_register(stdout);
-  logger_output_level_set(stdout, LOGGER_DEBUG);
   server_logger_id = logger_helper_enable(SERVER_LOGGER, LOGGER_DEBUG, true);
 
   // Initialize configurations with default value


### PR DESCRIPTION
With `logger_helper_init()` provided in newer version of
entangled(tag ="cclient-v1.0.0-beta"), codes that initialize logger
can be shortened.