### PR TITLE
fix: Fix Bazel rule coding style

### DIFF
--- a/accelerator/BUILD
+++ b/accelerator/BUILD
@@ -49,8 +49,8 @@ cc_image(
 
 container_push(
     name = "push_docker",
-    image = ":docker",
     format = "Docker",
+    image = ":docker",
     registry = "index.docker.io",
     repository = "dltcollab/tangle-accelerator",
     tag = "latest",


### PR DESCRIPTION
Because of the inconsistent Bazel rule coding style, CI check always
failed.