### PR TITLE
fix: Enforce Bazel to use Python 2

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -12,6 +12,12 @@ coverage --instrumentation_filter="-/tests[/:]"
 
 test --copt='-ggdb3'
 
+# enforce using python2
+# see also: https://github.com/bazelbuild/rules_docker#known-issues
+build --host_force_python=PY2
+test --host_force_python=PY2
+run --host_force_python=PY2
+
 # --config asan: Address sanitizer
 build:asan --strip=never
 build:asan --copt -DADDRESS_SANITIZER


### PR DESCRIPTION
Because the container_push rule from rules_docker is written in
Python and its depend on the Python 2 packages, we need to enforce the
Bazel to use Python 2 with this rule.

These settings can be removed after the rules_docker migrate this rule
with go.

See also:
 - https://github.com/bazelbuild/rules_docker#known-issues
 - https://github.com/bazelbuild/rules_docker/issues/842