### PR TITLE
fix(MAM): Wrong datatype for MAM function

### DIFF
--- a/accelerator/apis.c
+++ b/accelerator/apis.c
@@ -359,10 +359,8 @@ status_t api_receive_mam_message(const iota_client_service_t* const service, con
     goto done;
   }
 
-  flex_trit_t chid_trits[NUM_TRITS_HASH];
-  flex_trits_from_trytes(chid_trits, NUM_TRITS_HASH, (const tryte_t*)chid, NUM_TRYTES_HASH, NUM_TRYTES_HASH);
-  mam_api_add_trusted_channel_pk(&mam, chid_trits);
-  ret = ta_get_bundle_by_addr(service, chid_trits, bundle);
+  mam_api_add_trusted_channel_pk(&mam, chid);
+  ret = ta_get_bundle_by_addr(service, chid, bundle);
   if (ret != SC_OK) {
     goto done;
   }

--- a/accelerator/common_core.c
+++ b/accelerator/common_core.c
@@ -495,7 +495,7 @@ status_t ta_send_bundle(const iota_config_t* const tangle, const iota_client_ser
   return SC_OK;
 }
 
-status_t ta_get_bundle_by_addr(const iota_client_service_t* const service, flex_trit_t const* const addr,
+status_t ta_get_bundle_by_addr(const iota_client_service_t* const service, tryte_t const* const addr,
                                bundle_transactions_t* bundle) {
   status_t ret = SC_OK;
   tryte_t bundle_hash[NUM_TRYTES_BUNDLE];
@@ -509,7 +509,9 @@ status_t ta_get_bundle_by_addr(const iota_client_service_t* const service, flex_
     goto done;
   }
 
-  find_transactions_req_address_add(txn_req, addr);
+  flex_trit_t addr_trits[NUM_TRITS_HASH];
+  flex_trits_from_trytes(addr_trits, NUM_TRITS_HASH, (const tryte_t*)addr, NUM_TRYTES_HASH, NUM_TRYTES_HASH);
+  find_transactions_req_address_add(txn_req, addr_trits);
 
   if (iota_client_find_transactions(service, txn_req, txn_res) != RC_OK) {
     ret = SC_CCLIENT_FAILED_RESPONSE;

--- a/accelerator/common_core.h
+++ b/accelerator/common_core.h
@@ -214,14 +214,14 @@ status_t ta_send_bundle(const iota_config_t* const tangle, const iota_client_ser
  * of a transaction, we can use this function to search which bundle contains the message transaction we want to fetch.
  *
  * @param[in] service IRI node end point service
- * @param[in] addr searched address in flex_trit_t
+ * @param[in] addr searched address in tryte_t
  * @param[in] bundle pointer of bundle object that will contain the MAM transacitons
  *
  * @return
  * - SC_OK on success
  * - non-zero on error
  */
-status_t ta_get_bundle_by_addr(const iota_client_service_t* const service, flex_trit_t const* const addr,
+status_t ta_get_bundle_by_addr(const iota_client_service_t* const service, tryte_t const* const addr,
                                bundle_transactions_t* bundle);
 
 #ifdef __cplusplus


### PR DESCRIPTION
`mam_api_add_trusted_channel_pk` should take chid in `tryte_t`
instead of `flex_trit_t`.
Moreover, for simplicity of `apis.c`, `the tryte_t` to
`flex_trit_t` conversion is moved to `common_core.c`