### PR TITLE
feat(api): Read setting from configuration file

### DIFF
--- a/accelerator/BUILD
+++ b/accelerator/BUILD
@@ -123,6 +123,7 @@ cc_library(
         "//utils:cache",
         "//utils:pow",
         "@entangled//cclient/api",
+        "@yaml",
     ],
 )
 

--- a/accelerator/config.h
+++ b/accelerator/config.h
@@ -9,6 +9,7 @@
 #ifndef ACCELERATOR_CONFIG_H_
 #define ACCELERATOR_CONFIG_H_
 
+#include <ctype.h>
 #include <getopt.h>
 
 #include "accelerator/message.h"
@@ -16,6 +17,8 @@
 #include "cclient/api/extended/extended_api.h"
 #include "utils/cache.h"
 #include "utils/pow.h"
+
+#define FILE_PATH_SIZE 128
 
 #ifdef __cplusplus
 extern "C" {
@@ -82,15 +85,28 @@ typedef struct ta_cache_s {
 
 /** struct type of accelerator core */
 typedef struct ta_core_s {
-  ta_config_t info;              /**< accelerator configiuration structure */
-  ta_cache_t cache;              /**< redis configiuration structure */
-  iota_config_t iconf;           /**< iota configuration structure */
-  iota_client_service_t service; /**< iota connection structure */
+  ta_config_t info;               /**< accelerator configiuration structure */
+  ta_cache_t cache;               /**< redis configiuration structure */
+  iota_config_t iconf;            /**< iota configuration structure */
+  iota_client_service_t service;  /**< iota connection structure */
+  char conf_file[FILE_PATH_SIZE]; /**< path to the configuration file */
 } ta_core_t;
 
 /**
+ * @brief Get corresponding key-value pair in ta_cli_arguments_g structure
+ * key : correspond to "name" in ta_cli_arguments_g structure
+ * value : correspond to "val" in ta_cli_arguments_g structure
+ *
+ * @param key[in] Key of the key-value pair in yaml file
+ *
+ * @return
+ * - ZERO on Parsing unknown key
+ * - non-zero Corresponding value of key
+ */
+int get_conf_key(char const* const key);
+
+/**
  * Initializes configurations with default values
- * Should be called first
  *
  * @param info[in] Tangle-accelerator configuration variables
  * @param tangle[in] iota configuration variables
@@ -105,11 +121,23 @@ status_t ta_config_default_init(ta_config_t* const info, iota_config_t* const ta
                                 iota_client_service_t* const service);
 
 /**
- * Initializes configurations with CLI values
- * Should be called third
+ * Initializes configurations with configuration file
  *
  * @param ta_conf[in] All configuration variables
- * @param argc[in] Number of argumentof CLI
+ * @param argc[in] Number of argument of CLI
+ * @param argv[in] Argument of CLI
+ *
+ * @return
+ * - SC_OK on success
+ * - non-zero on error
+ */
+status_t ta_config_file_init(ta_core_t* const ta_conf, int argc, char** argv);
+
+/**
+ * Initializes configurations with CLI values
+ *
+ * @param ta_conf[in] All configuration variables
+ * @param argc[in] Number of argument of CLI
  * @param argv[in] Argument of CLI
  *
  * @return

--- a/accelerator/errors.h
+++ b/accelerator/errors.h
@@ -158,6 +158,10 @@ typedef enum {
   /**< fail to init lock */
   SC_CONF_LOCK_DESTROY = 0x05 | SC_MODULE_CONF | SC_SEVERITY_FATAL,
   /**< fail to destroy lock */
+  SC_CONF_PARSER_ERROR = 0x06 | SC_MODULE_CONF | SC_SEVERITY_FATAL,
+  /**< fail to initialize yaml parser */
+  SC_CONF_FOPEN_ERROR = 0x07 | SC_MODULE_CONF | SC_SEVERITY_FATAL,
+  /**< fail to open file */
 
   // UTILS module
   SC_UTILS_NULL = 0x01 | SC_MODULE_UTILS | SC_SEVERITY_FATAL,

--- a/accelerator/main.c
+++ b/accelerator/main.c
@@ -32,6 +32,11 @@ int main(int argc, char* argv[]) {
     return EXIT_FAILURE;
   }
 
+  // Initialize configurations with file value
+  if (ta_config_file_init(&ta_core, argc, argv) != SC_OK) {
+    return EXIT_FAILURE;
+  }
+
   // Initialize configurations with CLI value
   if (ta_config_cli_init(&ta_core, argc, argv) != SC_OK) {
     return EXIT_FAILURE;

--- a/accelerator/message.h
+++ b/accelerator/message.h
@@ -37,6 +37,7 @@ typedef enum ta_cli_arg_value_e {
   MWM_CLI,
   SEED_CLI,
   CACHE,
+  CONF_CLI,
 
   /** LOGGER */
   VERBOSE,
@@ -62,6 +63,7 @@ static struct ta_cli_argument_s {
                           {"mwm", MWM_CLI, "minimum weight magnitude", OPTIONAL_ARG},
                           {"seed", SEED_CLI, "IOTA seed", OPTIONAL_ARG},
                           {"cache", CACHE, "Enable cache server with Y", REQUIRED_ARG},
+                          {"config", CONF_CLI, "Read configuration file", REQUIRED_ARG},
                           {"verbose", VERBOSE, "Enable logger", NO_ARG}};
 
 static const int cli_cmd_num = sizeof(ta_cli_arguments_g) / sizeof(struct ta_cli_argument_s);

--- a/accelerator/server.cc
+++ b/accelerator/server.cc
@@ -80,6 +80,11 @@ int main(int argc, char* argv[]) {
     return EXIT_FAILURE;
   }
 
+  // Initialize configurations with file value
+  if (ta_config_file_init(&ta_core, argc, argv) != SC_OK) {
+    return EXIT_FAILURE;
+  }
+
   // Initialize configurations with CLI value
   if (ta_config_cli_init(&ta_core, argc, argv) != SC_OK) {
     return EXIT_FAILURE;


### PR DESCRIPTION
Fixes #268 

With this commit, tangle accelerator can read the configuration file using `--config` CLI. When `--config` and other CLI (e.g., `--ta_host`、`--ta_port`) are passed in command-line arguments together,  `--config` has lower precedence.