### PR TITLE
refactor(logger): Wrap log_xxx() into macro

### DIFF
--- a/accelerator/common_core.c
+++ b/accelerator/common_core.c
@@ -11,14 +11,14 @@
 
 #define CC_LOGGER "common_core"
 
-static logger_id_t cc_logger_id;
+static logger_id_t logger_id;
 
-void cc_logger_init() { cc_logger_id = logger_helper_enable(CC_LOGGER, LOGGER_DEBUG, true); }
+void cc_logger_init() { logger_id = logger_helper_enable(CC_LOGGER, LOGGER_DEBUG, true); }
 
 int cc_logger_release() {
-  logger_helper_release(cc_logger_id);
+  logger_helper_release(logger_id);
   if (logger_helper_destroy() != RC_OK) {
-    log_critical(cc_logger_id, "[%s:%d] Destroying logger failed %s.\n", __func__, __LINE__, CC_LOGGER);
+    ta_log_critical("Destroying logger failed %s.\n", CC_LOGGER);
     return EXIT_FAILURE;
   }
 
@@ -28,7 +28,7 @@ int cc_logger_release() {
 status_t cclient_get_txn_to_approve(const iota_client_service_t* const service, uint8_t const depth,
                                     ta_get_tips_res_t* res) {
   if (res == NULL) {
-    log_error(cc_logger_id, "[%s:%d:%s]\n", __func__, __LINE__, "SC_TA_NULL");
+    ta_log_error("%s\n", "SC_TA_NULL");
     return SC_TA_NULL;
   }
 
@@ -37,7 +37,7 @@ status_t cclient_get_txn_to_approve(const iota_client_service_t* const service, 
   get_transactions_to_approve_res_t* get_txn_res = get_transactions_to_approve_res_new();
   if (get_txn_req == NULL || get_txn_res == NULL) {
     ret = SC_CCLIENT_OOM;
-    log_error(cc_logger_id, "[%s:%d:%s]\n", __func__, __LINE__, "SC_CCLIENT_OOM");
+    ta_log_error("%s\n", "SC_CCLIENT_OOM");
     goto done;
   }
   // The depth at which Random Walk starts. Mininal is 3, and max is 15.
@@ -46,20 +46,20 @@ status_t cclient_get_txn_to_approve(const iota_client_service_t* const service, 
   ret = iota_client_get_transactions_to_approve(service, get_txn_req, get_txn_res);
   if (ret) {
     ret = SC_CCLIENT_FAILED_RESPONSE;
-    log_error(cc_logger_id, "[%s:%d:%s]\n", __func__, __LINE__, "SC_CCLIENT_FAILED_RESPONSE");
+    ta_log_error("%s\n", "SC_CCLIENT_FAILED_RESPONSE");
     goto done;
   }
 
   ret = hash243_stack_push(&res->tips, get_txn_res->branch);
   if (ret) {
     ret = SC_CCLIENT_HASH;
-    log_error(cc_logger_id, "[%s:%d:%s]\n", __func__, __LINE__, "SC_CCLIENT_HASH");
+    ta_log_error("%s\n", "SC_CCLIENT_HASH");
     goto done;
   }
   ret = hash243_stack_push(&res->tips, get_txn_res->trunk);
   if (ret) {
     ret = SC_CCLIENT_HASH;
-    log_error(cc_logger_id, "[%s:%d:%s]\n", __func__, __LINE__, "SC_CCLIENT_HASH");
+    ta_log_error("%s\n", "SC_CCLIENT_HASH");
   }
 
 done:
@@ -108,7 +108,7 @@ status_t ta_attach_to_tangle(const attach_to_tangle_req_t* const req, attach_to_
       tx_trytes = NULL;
     } else {
       ret = SC_CCLIENT_FAILED_RESPONSE;
-      log_error(cc_logger_id, "[%s:%d:%s]\n", __func__, __LINE__, "SC_CCLIENT_FAILED_RESPONSE");
+      ta_log_error("%s\n", "SC_CCLIENT_FAILED_RESPONSE");
       goto done;
     }
   }
@@ -127,14 +127,14 @@ status_t ta_send_trytes(const iota_config_t* const iconf, const iota_client_serv
   attach_to_tangle_res_t* attach_res = attach_to_tangle_res_new();
   if (!tx_approve_req || !tx_approve_res || !attach_req || !attach_res) {
     ret = SC_CCLIENT_OOM;
-    log_error(cc_logger_id, "[%s:%d:%s]\n", __func__, __LINE__, "SC_CCLIENT_OOM");
+    ta_log_error("%s\n", "SC_CCLIENT_OOM");
     goto done;
   }
 
   get_transactions_to_approve_req_set_depth(tx_approve_req, iconf->milestone_depth);
   if (iota_client_get_transactions_to_approve(service, tx_approve_req, tx_approve_res)) {
     ret = SC_CCLIENT_FAILED_RESPONSE;
-    log_error(cc_logger_id, "[%s:%d:%s]\n", __func__, __LINE__, "SC_CCLIENT_FAILED_RESPONSE");
+    ta_log_error("%s\n", "SC_CCLIENT_FAILED_RESPONSE");
     goto done;
   }
 
@@ -150,7 +150,7 @@ status_t ta_send_trytes(const iota_config_t* const iconf, const iota_client_serv
   // store and broadcast
   if (iota_client_store_and_broadcast(service, (store_transactions_req_t*)attach_res) != RC_OK) {
     ret = SC_CCLIENT_FAILED_RESPONSE;
-    log_error(cc_logger_id, "[%s:%d:%s]\n", __func__, __LINE__, "SC_CCLIENT_FAILED_RESPONSE");
+    ta_log_error("%s\n", "SC_CCLIENT_FAILED_RESPONSE");
     goto done;
   }
 
@@ -168,7 +168,7 @@ done:
 status_t ta_generate_address(const iota_config_t* const iconf, const iota_client_service_t* const service,
                              ta_generate_address_res_t* res) {
   if (res == NULL) {
-    log_error(cc_logger_id, "[%s:%d:%s]\n", __func__, __LINE__, "SC_TA_NULL");
+    ta_log_error("%s\n", "SC_TA_NULL");
     return SC_TA_NULL;
   }
 
@@ -182,7 +182,7 @@ status_t ta_generate_address(const iota_config_t* const iconf, const iota_client
 
   if (ret) {
     ret = SC_CCLIENT_FAILED_RESPONSE;
-    log_error(cc_logger_id, "[%s:%d:%s]\n", __func__, __LINE__, "SC_CCLIENT_FAILED_RESPONSE");
+    ta_log_error("%s\n", "SC_CCLIENT_FAILED_RESPONSE");
   } else {
     res->addresses = out_address;
   }
@@ -192,7 +192,7 @@ status_t ta_generate_address(const iota_config_t* const iconf, const iota_client
 status_t ta_send_transfer(const iota_config_t* const iconf, const iota_client_service_t* const service,
                           const ta_send_transfer_req_t* const req, ta_send_transfer_res_t* res) {
   if (req == NULL || res == NULL) {
-    log_error(cc_logger_id, "[%s:%d:%s]\n", __func__, __LINE__, "SC_TA_NULL");
+    ta_log_error("%s\n", "SC_TA_NULL");
     return SC_TA_NULL;
   }
 
@@ -207,7 +207,7 @@ status_t ta_send_transfer(const iota_config_t* const iconf, const iota_client_se
   transfer_array_t* transfers = transfer_array_new();
   if (find_tx_req == NULL || find_tx_res == NULL || transfers == NULL) {
     ret = SC_CCLIENT_OOM;
-    log_error(cc_logger_id, "[%s:%d:%s]\n", __func__, __LINE__, "SC_CCLIENT_OOM");
+    ta_log_error("%s\n", "SC_CCLIENT_OOM");
     goto done;
   }
 
@@ -220,7 +220,7 @@ status_t ta_send_transfer(const iota_config_t* const iconf, const iota_client_se
 
   if (transfer_message_set_trytes(&transfer, msg_tryte, transfer.msg_len) != RC_OK) {
     ret = SC_CCLIENT_OOM;
-    log_error(cc_logger_id, "[%s:%d:%s]\n", __func__, __LINE__, "SC_CCLIENT_OOM");
+    ta_log_error("%s\n", "SC_CCLIENT_OOM");
     goto done;
   }
   memcpy(transfer.address, hash243_queue_peek(req->address), FLEX_TRIT_SIZE_243);
@@ -234,7 +234,7 @@ status_t ta_send_transfer(const iota_config_t* const iconf, const iota_client_se
   if (iota_client_prepare_transfers(service, seed, 2, transfers, NULL, NULL, false, current_timestamp_ms(),
                                     out_bundle) != RC_OK) {
     ret = SC_CCLIENT_FAILED_RESPONSE;
-    log_error(cc_logger_id, "[%s:%d:%s]\n", __func__, __LINE__, "SC_CCLIENT_FAILED_RESPONSE");
+    ta_log_error("%s\n", "SC_CCLIENT_FAILED_RESPONSE");
     goto done;
   }
 
@@ -242,7 +242,7 @@ status_t ta_send_transfer(const iota_config_t* const iconf, const iota_client_se
     serialized_txn = transaction_serialize(txn);
     if (serialized_txn == NULL) {
       ret = SC_CCLIENT_FAILED_RESPONSE;
-      log_error(cc_logger_id, "[%s:%d:%s]\n", __func__, __LINE__, "SC_CCLIENT_FAILED_RESPONSE");
+      ta_log_error("%s\n", "SC_CCLIENT_FAILED_RESPONSE");
       goto done;
     }
     hash_array_push(raw_tx, serialized_txn);
@@ -258,14 +258,14 @@ status_t ta_send_transfer(const iota_config_t* const iconf, const iota_client_se
   ret = hash243_queue_push(&find_tx_req->bundles, transaction_bundle(txn));
   if (ret) {
     ret = SC_CCLIENT_HASH;
-    log_error(cc_logger_id, "[%s:%d:%s]\n", __func__, __LINE__, "SC_CCLIENT_HASH");
+    ta_log_error("%s\n", "SC_CCLIENT_HASH");
     goto done;
   }
 
   ret = iota_client_find_transactions(service, find_tx_req, find_tx_res);
   if (ret) {
     ret = SC_CCLIENT_FAILED_RESPONSE;
-    log_error(cc_logger_id, "[%s:%d:%s]\n", __func__, __LINE__, "SC_CCLIENT_FAILED_RESPONSE");
+    ta_log_error("%s\n", "SC_CCLIENT_FAILED_RESPONSE");
     goto done;
   }
 
@@ -285,7 +285,7 @@ done:
 status_t ta_find_transactions_obj_by_tag(const iota_client_service_t* const service,
                                          const find_transactions_req_t* const req, transaction_array_t* res) {
   if (req == NULL || res == NULL) {
-    log_error(cc_logger_id, "[%s:%d]\n", __func__, __LINE__);
+    ta_log_error("%s\n", "SC_TA_NULL");
     return SC_TA_NULL;
   }
 
@@ -293,14 +293,14 @@ status_t ta_find_transactions_obj_by_tag(const iota_client_service_t* const serv
   find_transactions_res_t* txn_res = find_transactions_res_new();
   ta_find_transaction_objects_req_t* obj_req = ta_find_transaction_objects_req_new();
   if (txn_res == NULL || obj_req == NULL) {
-    log_error(cc_logger_id, "[%s:%d:%s]\n", __func__, __LINE__, "SC_TA_OOM");
+    ta_log_error("%s\n", "SC_TA_OOM");
     goto done;
   }
 
   // get transaction hash
   if (iota_client_find_transactions(service, req, txn_res) != RC_OK) {
     ret = SC_CCLIENT_FAILED_RESPONSE;
-    log_error(cc_logger_id, "[%s:%d]\n", __func__, __LINE__);
+    ta_log_error("%s\n", "SC_CCLIENT_FAILED_RESPONSE");
     goto done;
   }
 
@@ -308,7 +308,7 @@ status_t ta_find_transactions_obj_by_tag(const iota_client_service_t* const serv
 
   ret = ta_find_transaction_objects(service, obj_req, res);
   if (ret) {
-    log_error(cc_logger_id, "[%s:%d]\n", __func__, __LINE__);
+    ta_log_error("%d\n", ret);
     goto done;
   }
 
@@ -327,7 +327,7 @@ status_t ta_find_transaction_objects(const iota_client_service_t* const service,
   transaction_array_t* uncached_txn_array = transaction_array_new();
   if (req == NULL || res == NULL || req_get_trytes == NULL || uncached_txn_array == NULL) {
     ret = SC_TA_NULL;
-    log_error(cc_logger_id, "[%s:%d:%s]\n", __func__, __LINE__, "SC_TA_NULL");
+    ta_log_error("%s\n", "SC_TA_NULL");
     goto done;
   }
   char txn_hash[NUM_TRYTES_HASH + 1] = {0};
@@ -350,7 +350,7 @@ status_t ta_find_transaction_objects(const iota_client_service_t* const service,
       temp = transaction_deserialize(tx_trits, true);
       if (temp == NULL) {
         ret = SC_CCLIENT_OOM;
-        log_error(cc_logger_id, "[%s:%d:%s]\n", __func__, __LINE__, "SC_CCLIENT_OOM");
+        ta_log_error("%s\n", "SC_CCLIENT_OOM");
         goto done;
       }
 
@@ -362,7 +362,7 @@ status_t ta_find_transaction_objects(const iota_client_service_t* const service,
     } else {
       if (hash243_queue_push(&req_get_trytes->hashes, q_iter->hash) != RC_OK) {
         ret = SC_CCLIENT_HASH;
-        log_error(cc_logger_id, "[%s:%d:%s]\n", __func__, __LINE__, "SC_CCLIENT_HASH");
+        ta_log_error("%s\n", "SC_CCLIENT_HASH");
         goto done;
       }
       ret = SC_OK;
@@ -372,7 +372,7 @@ status_t ta_find_transaction_objects(const iota_client_service_t* const service,
   if (req_get_trytes->hashes != NULL) {
     if (iota_client_get_transaction_objects(service, req_get_trytes, uncached_txn_array) != RC_OK) {
       ret = SC_CCLIENT_FAILED_RESPONSE;
-      log_error(cc_logger_id, "[%s:%d:%s]\n", __func__, __LINE__, "SC_CCLIENT_FAILED_RESPONSE");
+      ta_log_error("%s\n", "SC_CCLIENT_FAILED_RESPONSE");
       goto done;
     }
   }
@@ -398,7 +398,7 @@ status_t ta_find_transaction_objects(const iota_client_service_t* const service,
       transaction_free(append_txn);
     } else {
       ret = SC_CCLIENT_NOT_FOUND;
-      log_error(cc_logger_id, "[%s:%d:%s]\n", __func__, __LINE__, "SC_CCLIENT_NOT_FOUND");
+      ta_log_error("%s\n", "SC_CCLIENT_NOT_FOUND");
       goto done;
     }
     free(temp_txn_trits);
@@ -449,7 +449,7 @@ status_t ta_get_bundle(const iota_client_service_t* const service, tryte_t const
   find_transactions_req_t* find_tx_req = find_transactions_req_new();
   if (find_tx_req == NULL) {
     ret = SC_CCLIENT_OOM;
-    log_error(cc_logger_id, "[%s:%d:%s]\n", __func__, __LINE__, "SC_CCLIENT_OOM");
+    ta_log_error("%s\n", "SC_CCLIENT_OOM");
     goto done;
   }
 
@@ -459,7 +459,7 @@ status_t ta_get_bundle(const iota_client_service_t* const service, tryte_t const
   ret = iota_client_find_transaction_objects(service, find_tx_req, tx_objs);
   if (ret) {
     ret = SC_CCLIENT_FAILED_RESPONSE;
-    log_error(cc_logger_id, "[%s:%d:%s]\n", __func__, __LINE__, "SC_CCLIENT_FAILED_RESPONSE");
+    ta_log_error("%s\n", "SC_CCLIENT_FAILED_RESPONSE");
     goto done;
   }
 

--- a/accelerator/config.c
+++ b/accelerator/config.c
@@ -11,9 +11,9 @@
 #include "utils/macros.h"
 #include "yaml.h"
 
-#define CONFIG_LOGGER "TA"
+#define CONFIG_LOGGER "config"
 
-static logger_id_t config_logger_id;
+static logger_id_t logger_id;
 
 int get_conf_key(char const* const key) {
   for (int i = 0; i < cli_cmd_num; ++i) {
@@ -39,7 +39,7 @@ struct option* cli_build_options() {
 status_t cli_config_set(char* conf_file, ta_config_t* const info, iota_config_t* const iconf, ta_cache_t* const cache,
                         iota_client_service_t* const service, int key, char* const value) {
   if (value == NULL || info == NULL || iconf == NULL || cache == NULL || service == NULL) {
-    log_error(config_logger_id, "[%s:%d:%s]\n", __func__, __LINE__, "SC_CONF_NULL");
+    ta_log_error("%s\n", "SC_CONF_NULL");
     return SC_CONF_NULL;
   }
 
@@ -105,15 +105,15 @@ status_t ta_config_default_init(ta_config_t* const info, iota_config_t* const ic
                                 iota_client_service_t* const service) {
   status_t ret = SC_OK;
 
-  config_logger_id = logger_helper_enable(CONFIG_LOGGER, LOGGER_DEBUG, true);
-  log_info(config_logger_id, "[%s:%d] enable logger %s.\n", __func__, __LINE__, CONFIG_LOGGER);
+  logger_id = logger_helper_enable(CONFIG_LOGGER, LOGGER_DEBUG, true);
+  ta_log_info("enable logger %s.\n", CONFIG_LOGGER);
 
   if (info == NULL || iconf == NULL || cache == NULL || service == NULL) {
-    log_error(config_logger_id, "[%s:%d:%s]\n", __func__, __LINE__, "SC_TA_NULL");
+    ta_log_error("%s\n", "SC_TA_NULL");
     return SC_TA_NULL;
   }
 
-  log_info(config_logger_id, "Initializing TA information\n");
+  ta_log_info("Initializing TA information\n");
   info->version = TA_VERSION;
   info->host = TA_HOST;
   info->port = TA_PORT;
@@ -122,18 +122,18 @@ status_t ta_config_default_init(ta_config_t* const info, iota_config_t* const ic
   info->mqtt_host = MQTT_HOST;
   info->mqtt_topic_root = TOPIC_ROOT;
 #endif
-  log_info(config_logger_id, "Initializing Redis information\n");
+  ta_log_info("Initializing Redis information\n");
   cache->host = REDIS_HOST;
   cache->port = REDIS_PORT;
   cache->cache_state = false;
 
-  log_info(config_logger_id, "Initializing IRI configuration\n");
+  ta_log_info("Initializing IRI configuration\n");
   iconf->milestone_depth = MILESTONE_DEPTH;
   iconf->mwm = MWM;
   iconf->seed = SEED;
   iconf->mam_file_path = tempnam(MAM_FILE_DIR, MAM_FILE_PREFIX);
 
-  log_info(config_logger_id, "Initializing IRI connection\n");
+  ta_log_info("Initializing IRI connection\n");
   service->http.path = "/";
   service->http.content_type = "application/json";
   service->http.accept = "application/json";
@@ -163,7 +163,7 @@ status_t ta_config_file_init(ta_core_t* const conf, int argc, char** argv) {
 
   if (!yaml_parser_initialize(&parser)) {
     ret = SC_CONF_PARSER_ERROR;
-    log_error(config_logger_id, "[%s:%d:%s]\n", __func__, __LINE__, "SC_CONF_PARSER_ERROR");
+    ta_log_error("%s\n", "SC_CONF_PARSER_ERROR");
     goto done;
   }
 
@@ -172,11 +172,11 @@ status_t ta_config_file_init(ta_core_t* const conf, int argc, char** argv) {
     switch (key) {
       case ':':
         ret = SC_CONF_MISSING_ARGUMENT;
-        log_error(config_logger_id, "[%s:%d:%s]\n", __func__, __LINE__, "SC_CONF_MISSING_ARGUMENT");
+        ta_log_error("%s\n", "SC_CONF_MISSING_ARGUMENT");
         break;
       case '?':
         ret = SC_CONF_UNKNOWN_OPTION;
-        log_error(config_logger_id, "[%s:%d:%s]\n", __func__, __LINE__, "SC_CONF_UNKNOWN_OPTION");
+        ta_log_error("%s\n", "SC_CONF_UNKNOWN_OPTION");
         break;
       case CONF_CLI:
         ret = cli_config_set(conf->conf_file, &conf->info, &conf->iconf, &conf->cache, &conf->service, key, optarg);
@@ -201,7 +201,7 @@ status_t ta_config_file_init(ta_core_t* const conf, int argc, char** argv) {
   if ((file = fopen(conf->conf_file, "r")) == NULL) {
     /* The specified configuration file does not exist */
     ret = SC_CONF_FOPEN_ERROR;
-    log_error(config_logger_id, "[%s:%d:%s]\n", __func__, __LINE__, "SC_CONF_FOPEN_ERROR");
+    ta_log_error("%s\n", "SC_CONF_FOPEN_ERROR");
     goto done;
   }
 
@@ -210,7 +210,7 @@ status_t ta_config_file_init(ta_core_t* const conf, int argc, char** argv) {
   do { /* start reading tokens */
     if (!yaml_parser_scan(&parser, &token)) {
       ret = SC_CONF_PARSER_ERROR;
-      log_error(config_logger_id, "[%s:%d:%s]\n", __func__, __LINE__, "SC_CONF_PARSER_ERROR");
+      ta_log_error("%s\n", "SC_CONF_PARSER_ERROR");
       goto done;
     }
     switch (token.type) {
@@ -259,11 +259,11 @@ status_t ta_config_cli_init(ta_core_t* const conf, int argc, char** argv) {
     switch (key) {
       case ':':
         ret = SC_CONF_MISSING_ARGUMENT;
-        log_error(config_logger_id, "[%s:%d:%s]\n", __func__, __LINE__, "SC_CONF_MISSING_ARGUMENT");
+        ta_log_error("%s\n", "SC_CONF_MISSING_ARGUMENT");
         break;
       case '?':
         ret = SC_CONF_UNKNOWN_OPTION;
-        log_error(config_logger_id, "[%s:%d:%s]\n", __func__, __LINE__, "SC_CONF_UNKNOWN_OPTION");
+        ta_log_error("%s\n", "SC_CONF_UNKNOWN_OPTION");
         break;
       case 'h':
         ta_usage();
@@ -297,32 +297,32 @@ status_t ta_config_cli_init(ta_core_t* const conf, int argc, char** argv) {
 status_t ta_config_set(ta_cache_t* const cache, iota_client_service_t* const service) {
   status_t ret = SC_OK;
   if (cache == NULL || service == NULL) {
-    log_error(config_logger_id, "[%s:%d:%s]\n", __func__, __LINE__, "SC_TA_NULL");
+    ta_log_error("%s\n", "SC_TA_NULL");
     return SC_TA_NULL;
   }
 
   if (iota_client_core_init(service)) {
-    log_critical(config_logger_id, "Initializing IRI connection failed!\n");
+    ta_log_critical("Initializing IRI connection failed!\n");
     ret = SC_TA_OOM;
   }
   iota_client_extended_init();
 
-  log_info(config_logger_id, "Initializing PoW implementation context\n");
+  ta_log_info("Initializing PoW implementation context\n");
   pow_init();
 
-  log_info(config_logger_id, "Initializing cache state\n");
+  ta_log_info("Initializing cache state\n");
   cache_init(cache->cache_state, cache->host, cache->port);
 
   return ret;
 }
 
 void ta_config_destroy(iota_client_service_t* const service) {
-  log_info(config_logger_id, "Destroying IRI connection\n");
+  ta_log_info("Destroying IRI connection\n");
   iota_client_extended_destroy();
   iota_client_core_destroy(service);
 
   pow_destroy();
   cache_stop();
-  logger_helper_release(config_logger_id);
+  logger_helper_release(logger_id);
   br_logger_release();
 }

--- a/accelerator/errors.h
+++ b/accelerator/errors.h
@@ -62,6 +62,16 @@ extern "C" {
 #define SC_ERROR_MASK 0x003F
 /** @} */
 
+/* logger's wrapper (sorted by priority) */
+#define ta_log_debug(fmt, args...) log_debug(logger_id, "[%s : %d] " fmt, __func__, __LINE__, ##args)
+#define ta_log_info(fmt, args...) log_info(logger_id, "[%s : %d] " fmt, __func__, __LINE__, ##args)
+#define ta_log_notice(fmt, args...) log_notice(logger_id, "[%s : %d] " fmt, __func__, __LINE__, ##args)
+#define ta_log_warning(fmt, args...) log_warning(logger_id, "[%s : %d] " fmt, __func__, __LINE__, ##args)
+#define ta_log_error(fmt, args...) log_error(logger_id, "[%s : %d] " fmt, __func__, __LINE__, ##args)
+#define ta_log_critical(fmt, args...) log_critical(logger_id, "[%s : %d] " fmt, __func__, __LINE__, ##args)
+#define ta_log_alert(fmt, args...) log_alert(logger_id, "[%s : %d] " fmt, __func__, __LINE__, ##args)
+#define ta_log_emergency(fmt, args...) log_emergency(logger_id, "[%s : %d] " fmt, __func__, __LINE__, ##args)
+
 bool verbose_mode; /**< flag of verbose mode */
 
 /* status code */

--- a/accelerator/http.c
+++ b/accelerator/http.c
@@ -9,19 +9,19 @@
 
 #define HTTP_LOGGER "http"
 
-static logger_id_t http_logger_id;
+static logger_id_t logger_id;
 
 typedef struct ta_http_request_s {
   bool valid_content_type;
   char *request;
 } ta_http_request_t;
 
-void http_logger_init() { http_logger_id = logger_helper_enable(HTTP_LOGGER, LOGGER_DEBUG, true); }
+void http_logger_init() { logger_id = logger_helper_enable(HTTP_LOGGER, LOGGER_DEBUG, true); }
 
 int http_logger_release() {
-  logger_helper_release(http_logger_id);
+  logger_helper_release(logger_id);
   if (logger_helper_destroy() != RC_OK) {
-    log_critical(http_logger_id, "[%s:%s] Destroying logger failed %s.\n", __func__, __LINE__, HTTP_LOGGER);
+    ta_log_critical("Destroying logger failed %s.\n", HTTP_LOGGER);
     return EXIT_FAILURE;
   }
 
@@ -30,7 +30,7 @@ int http_logger_release() {
 
 static status_t ta_http_url_matcher(char const *const url, char *const regex_rule) {
   if (regex_rule == NULL) {
-    log_error(http_logger_id, "[%s:%d:%s]\n", __func__, __LINE__, "SC_HTTP_NULL");
+    ta_log_error("%s\n", "SC_HTTP_NULL");
     return SC_HTTP_NULL;
   }
   regex_t reg;
@@ -38,12 +38,12 @@ static status_t ta_http_url_matcher(char const *const url, char *const regex_rul
   int reg_flag = REG_EXTENDED | REG_NOSUB;
 
   if (regcomp(&reg, regex_rule, reg_flag) != 0) {
-    log_error(http_logger_id, "[%s:%d:%s]\n", __func__, __LINE__, "SC_HTTP_INVALID_REGEX");
+    ta_log_error("%s\n", "SC_HTTP_INVALID_REGEX");
     return SC_HTTP_INVALID_REGEX;
   }
   if (regexec(&reg, url, 0, NULL, 0) != 0) {
     // Did not match pattern
-    log_error(http_logger_id, "[%s:%d:%s]\n", __func__, __LINE__, "SC_HTTP_URL_NOT_MATCH");
+    ta_log_error("%s\n", "SC_HTTP_URL_NOT_MATCH");
     ret = SC_HTTP_URL_NOT_MATCH;
   }
 
@@ -53,7 +53,7 @@ static status_t ta_http_url_matcher(char const *const url, char *const regex_rul
 
 static status_t ta_get_url_parameter(char const *const url, int index, char **param) {
   if (param == NULL) {
-    log_error(http_logger_id, "[%s:%d:%s]\n", __func__, __LINE__, "SC_HTTP_NULL");
+    ta_log_error("%s\n", "SC_HTTP_NULL");
     return SC_HTTP_NULL;
   }
   if (index < 0) {
@@ -73,7 +73,7 @@ static status_t ta_get_url_parameter(char const *const url, int index, char **pa
     tmp = strtok(NULL, "/");
   }
   if (tmp == NULL) {
-    log_error(http_logger_id, "[%s:%d:%s]\n", __func__, __LINE__, "SC_HTTP_URL_PARSE_ERROR");
+    ta_log_error("%s\n", "SC_HTTP_URL_PARSE_ERROR");
     return SC_HTTP_URL_PARSE_ERROR;
   }
 
@@ -81,7 +81,7 @@ static status_t ta_get_url_parameter(char const *const url, int index, char **pa
   int token_len = strlen(tmp);
   *param = (char *)malloc(token_len * sizeof(char));
   if (param == NULL) {
-    log_error(http_logger_id, "[%s:%d:%s]\n", __func__, __LINE__, "SC_HTTP_OOM");
+    ta_log_error("%s\n", "SC_HTTP_OOM");
     return SC_HTTP_OOM;
   }
   strncpy(*param, tmp, token_len);
@@ -99,18 +99,18 @@ static int set_response_content(status_t ret, char **json_result) {
     case SC_CCLIENT_NOT_FOUND:
     case SC_MAM_NOT_FOUND:
       http_ret = MHD_HTTP_NOT_FOUND;
-      log_error(http_logger_id, "[%s:%d:%s]\n", __func__, __LINE__, "MHD_HTTP_NOT_FOUND");
+      ta_log_error("%s\n", "MHD_HTTP_NOT_FOUND");
       cJSON_AddStringToObject(json_obj, "message", "Request not found");
       break;
     case SC_CCLIENT_JSON_KEY:
     case SC_MAM_NO_PAYLOAD:
       http_ret = MHD_HTTP_BAD_REQUEST;
-      log_error(http_logger_id, "[%s:%d:%s]\n", __func__, __LINE__, "MHD_HTTP_BAD_REQUEST");
+      ta_log_error("%s\n", "MHD_HTTP_BAD_REQUEST");
       cJSON_AddStringToObject(json_obj, "message", "Invalid request header");
       break;
     default:
       http_ret = MHD_HTTP_INTERNAL_SERVER_ERROR;
-      log_error(http_logger_id, "[%s:%d:%s]\n", __func__, __LINE__, "MHD_HTTP_INTERNAL_SERVER_ERROR");
+      ta_log_error("%s\n", "MHD_HTTP_INTERNAL_SERVER_ERROR");
       cJSON_AddStringToObject(json_obj, "message", "Internal service error");
       break;
   }
@@ -300,7 +300,7 @@ static int ta_http_handler(void *cls, struct MHD_Connection *connection, const c
   // Check request header for post request only
   if (post && !http_req->valid_content_type) {
     ret = MHD_NO;
-    log_error(http_logger_id, "[%s:%d:%s]\n", __func__, __LINE__, "MHD_NO");
+    ta_log_error("%s\n", "MHD_NO");
     goto cleanup;
   }
 
@@ -311,7 +311,7 @@ static int ta_http_handler(void *cls, struct MHD_Connection *connection, const c
       strncpy(http_req->request, upload_data, *upload_data_size);
     } else {
       ret = MHD_NO;
-      log_error(http_logger_id, "[%s:%d:%s]\n", __func__, __LINE__, "MHD_NO");
+      ta_log_error("%s\n", "MHD_NO");
       goto cleanup;
     }
 
@@ -322,7 +322,7 @@ static int ta_http_handler(void *cls, struct MHD_Connection *connection, const c
   if (post && (http_req->request == NULL)) {
     // POST but no body, so we skip this request
     ret = MHD_NO;
-    log_error(http_logger_id, "[%s:%d:%s]\n", __func__, __LINE__, "MHD_NO");
+    ta_log_error("%s\n", "MHD_NO");
     goto cleanup;
   }
 
@@ -361,7 +361,7 @@ cleanup:
 
 status_t ta_http_init(ta_http_t *const http, ta_core_t *const core) {
   if (http == NULL) {
-    log_error(http_logger_id, "[%s:%d:%s]\n", __func__, __LINE__, "SC_HTTP_NULL");
+    ta_log_error("%s\n", "SC_HTTP_NULL");
     return SC_HTTP_NULL;
   }
 
@@ -372,7 +372,7 @@ status_t ta_http_init(ta_http_t *const http, ta_core_t *const core) {
 
 status_t ta_http_start(ta_http_t *const http) {
   if (http == NULL) {
-    log_error(http_logger_id, "[%s:%d:%s]\n", __func__, __LINE__, "SC_HTTP_NULL");
+    ta_log_error("%s\n", "SC_HTTP_NULL");
     return SC_HTTP_NULL;
   }
 
@@ -380,7 +380,7 @@ status_t ta_http_start(ta_http_t *const http) {
       MHD_start_daemon(MHD_USE_AUTO_INTERNAL_THREAD | MHD_USE_THREAD_PER_CONNECTION | MHD_USE_ERROR_LOG | MHD_USE_DEBUG,
                        atoi(http->core->info.port), request_log, NULL, ta_http_handler, http, MHD_OPTION_END);
   if (http->daemon == NULL) {
-    log_error(http_logger_id, "[%s:%d:%s]\n", __func__, __LINE__, "SC_HTTP_OOM");
+    ta_log_error("%s\n", "SC_HTTP_OOM");
     return SC_HTTP_OOM;
   }
   http->running = true;
@@ -389,7 +389,7 @@ status_t ta_http_start(ta_http_t *const http) {
 
 status_t ta_http_stop(ta_http_t *const http) {
   if (http == NULL) {
-    log_error(http_logger_id, "[%s:%d:%s]\n", __func__, __LINE__, "SC_HTTP_NULL");
+    ta_log_error("%s\n", "SC_HTTP_NULL");
     return SC_HTTP_NULL;
   }
 

--- a/accelerator/main.c
+++ b/accelerator/main.c
@@ -43,13 +43,13 @@ int main(int argc, char* argv[]) {
   }
 
   if (ta_config_set(&ta_core.cache, &ta_core.service) != SC_OK) {
-    log_critical(logger_id, "[%s:%d] Configure failed %s.\n", __func__, __LINE__, MAIN_LOGGER);
+    ta_log_critical("Configure failed %s.\n", MAIN_LOGGER);
     return EXIT_FAILURE;
   }
 
   // Initialize apis cJSON lock
   if (apis_lock_init() != SC_OK) {
-    log_critical(logger_id, "[%s:%d] Lock initialization failed %s.\n", __func__, __LINE__, MAIN_LOGGER);
+    ta_log_critical("Lock initialization failed %s.\n", MAIN_LOGGER);
     return EXIT_FAILURE;
   }
 
@@ -63,12 +63,12 @@ int main(int argc, char* argv[]) {
   }
 
   if (ta_http_init(&ta_http, &ta_core) != SC_OK) {
-    log_critical(logger_id, "[%s:%d] HTTP initialization failed %s.\n", __func__, __LINE__, MAIN_LOGGER);
+    ta_log_critical("HTTP initialization failed %s.\n", MAIN_LOGGER);
     return EXIT_FAILURE;
   }
 
   if (ta_http_start(&ta_http) != SC_OK) {
-    log_critical(logger_id, "[%s:%d] Starting TA failed %s.\n", __func__, __LINE__, MAIN_LOGGER);
+    ta_log_critical("Starting TA failed %s.\n", MAIN_LOGGER);
     goto cleanup;
   }
 
@@ -80,7 +80,7 @@ int main(int argc, char* argv[]) {
 cleanup:
   log_warning(logger_id, "Destroying API lock\n");
   if (apis_lock_destroy() != SC_OK) {
-    log_critical(logger_id, "[%s:%d] Destroying api lock failed %s.\n", __func__, __LINE__, MAIN_LOGGER);
+    ta_log_critical("Destroying api lock failed %s.\n", MAIN_LOGGER);
     return EXIT_FAILURE;
   }
   log_warning(logger_id, "Destroying TA configurations\n");
@@ -90,7 +90,7 @@ cleanup:
     http_logger_release();
     logger_helper_release(logger_id);
     if (logger_helper_destroy() != RC_OK) {
-      log_critical(logger_id, "[%s:%d] Destroying logger failed %s.\n", __func__, __LINE__, MAIN_LOGGER);
+      ta_log_critical("Destroying logger failed %s.\n", MAIN_LOGGER);
       return EXIT_FAILURE;
     }
   }

--- a/accelerator/server.cc
+++ b/accelerator/server.cc
@@ -19,7 +19,7 @@
 #define SERVER_LOGGER "server"
 
 static ta_core_t ta_core;
-static logger_id_t server_logger_id;
+static logger_id_t logger_id;
 
 void set_method_header(served::response& res, http_method_t method) {
   res.set_header("Server", ta_core.info.version);
@@ -73,7 +73,7 @@ int main(int argc, char* argv[]) {
     return EXIT_FAILURE;
   }
 
-  server_logger_id = logger_helper_enable(SERVER_LOGGER, LOGGER_DEBUG, true);
+  logger_id = logger_helper_enable(SERVER_LOGGER, LOGGER_DEBUG, true);
 
   // Initialize configurations with default value
   if (ta_config_default_init(&ta_core.info, &ta_core.iconf, &ta_core.cache, &ta_core.service) != SC_OK) {
@@ -91,13 +91,13 @@ int main(int argc, char* argv[]) {
   }
 
   if (ta_config_set(&ta_core.cache, &ta_core.service) != SC_OK) {
-    log_critical(server_logger_id, "[%s:%d] Configure failed %s.\n", __func__, __LINE__, SERVER_LOGGER);
+    ta_log_critical("Configure failed %s.\n", SERVER_LOGGER);
     return EXIT_FAILURE;
   }
 
   // Initialize apis cJSON lock
   if (apis_lock_init() != SC_OK) {
-    log_critical(server_logger_id, "[%s:%d] Lock initialization failed %s.\n", __func__, __LINE__, SERVER_LOGGER);
+    ta_log_critical("Lock initialization failed %s.\n", SERVER_LOGGER);
     return EXIT_FAILURE;
   }
 
@@ -109,7 +109,7 @@ int main(int argc, char* argv[]) {
     pow_logger_init();
   } else {
     // Destroy logger when verbose mode is off
-    logger_helper_release(server_logger_id);
+    logger_helper_release(logger_id);
     logger_helper_destroy();
   }
 
@@ -476,7 +476,7 @@ int main(int argc, char* argv[]) {
   server.run(ta_core.info.thread_count);
 
   if (apis_lock_destroy() != SC_OK) {
-    log_critical(server_logger_id, "[%s:%d] Destroying api lock failed %s.\n", __func__, __LINE__, SERVER_LOGGER);
+    ta_log_critical("Destroying api lock failed %s.\n", SERVER_LOGGER);
     return EXIT_FAILURE;
   }
   ta_config_destroy(&ta_core.service);
@@ -486,7 +486,7 @@ int main(int argc, char* argv[]) {
     cc_logger_release();
     serializer_logger_release();
     pow_logger_release();
-    logger_helper_release(server_logger_id);
+    logger_helper_release(logger_id);
     if (logger_helper_destroy() != RC_OK) {
       return EXIT_FAILURE;
     }

--- a/connectivity/mqtt/duplex_callback.c
+++ b/connectivity/mqtt/duplex_callback.c
@@ -11,19 +11,16 @@
 #include <string.h>
 
 #define MQTT_CALLBACK_LOGGER "mqtt-callback"
-static logger_id_t mqtt_callback_logger_id;
+static logger_id_t logger_id;
 
 extern ta_core_t ta_core;
 
-void mqtt_callback_logger_init() {
-  mqtt_callback_logger_id = logger_helper_enable(MQTT_CALLBACK_LOGGER, LOGGER_DEBUG, true);
-}
+void mqtt_callback_logger_init() { logger_id = logger_helper_enable(MQTT_CALLBACK_LOGGER, LOGGER_DEBUG, true); }
 
 int mqtt_callback_logger_release() {
-  logger_helper_release(mqtt_callback_logger_id);
+  logger_helper_release(logger_id);
   if (logger_helper_destroy() != RC_OK) {
-    log_critical(mqtt_callback_logger_id, "[%s:%s] Destroying logger failed %s.\n", __func__, __LINE__,
-                 MQTT_CALLBACK_LOGGER);
+    ta_log_critical("Destroying logger failed %s.\n", MQTT_CALLBACK_LOGGER);
     return EXIT_FAILURE;
   }
 
@@ -42,7 +39,7 @@ static status_t mqtt_request_handler(mosq_config_t *cfg, char *subscribe_topic, 
   // get the Device ID.
   ret = mqtt_device_id_deserialize(req, device_id);
   if (ret != SC_OK) {
-    log_error(mqtt_callback_logger_id, "[%s:%d:%d]\n", __func__, __LINE__, ret);
+    ta_log_error("%d\n", ret);
     goto done;
   }
 
@@ -76,7 +73,7 @@ static status_t mqtt_request_handler(mosq_config_t *cfg, char *subscribe_topic, 
     }
   }
   if (ret != SC_OK) {
-    log_error(mqtt_callback_logger_id, "[%s:%d:%d]\n", __func__, __LINE__, ret);
+    ta_log_error("%d\n", ret);
     goto done;
   }
 
@@ -86,14 +83,14 @@ static status_t mqtt_request_handler(mosq_config_t *cfg, char *subscribe_topic, 
   snprintf(res_topic, res_topic_len, "%s/%s", subscribe_topic, device_id);
   ret = gossip_channel_set(cfg, NULL, NULL, res_topic);
   if (ret != SC_OK) {
-    log_error(mqtt_callback_logger_id, "[%s:%d:%d]\n", __func__, __LINE__, ret);
+    ta_log_error("%d\n", ret);
     goto done;
   }
 
   // Set recv_message as publishing message
   ret = gossip_message_set(cfg, json_result);
   if (ret != SC_OK) {
-    log_error(mqtt_callback_logger_id, "[%s:%d:%d]\n", __func__, __LINE__, ret);
+    ta_log_error("%d\n", ret);
   }
 
 done:
@@ -141,12 +138,12 @@ static void subscribe_callback_duplex_func(struct mosquitto *mosq, void *obj, in
 }
 
 static void log_callback_duplex_func(struct mosquitto *mosq, void *obj, int level, const char *str) {
-  log_info(mqtt_callback_logger_id, "log: %s\n", str);
+  log_info(logger_id, "log: %s\n", str);
 }
 
 status_t duplex_callback_func_set(struct mosquitto *mosq) {
   if (mosq == NULL) {
-    log_error(mqtt_callback_logger_id, "[%s:%d:%s]\n", __func__, __LINE__, "SC_TA_NULL");
+    ta_log_error("%s\n", "SC_TA_NULL");
     return SC_MQTT_NULL;
   }
 

--- a/connectivity/mqtt/duplex_utils.c
+++ b/connectivity/mqtt/duplex_utils.c
@@ -14,14 +14,14 @@
 
 #define MQTT_UTILS_LOGGER "mqtt-utils"
 
-static logger_id_t mqtt_utils_logger_id;
+static logger_id_t logger_id;
 
-void mqtt_utils_logger_init() { mqtt_utils_logger_id = logger_helper_enable(MQTT_UTILS_LOGGER, LOGGER_DEBUG, true); }
+void mqtt_utils_logger_init() { logger_id = logger_helper_enable(MQTT_UTILS_LOGGER, LOGGER_DEBUG, true); }
 
 int mqtt_utils_logger_release() {
-  logger_helper_release(mqtt_utils_logger_id);
+  logger_helper_release(logger_id);
   if (logger_helper_destroy() != RC_OK) {
-    log_critical(mqtt_utils_logger_id, "[%s:%s] Destroying logger failed %s.\n", __func__, __LINE__, MQTT_UTILS_LOGGER);
+    ta_log_critical("Destroying logger failed %s.\n", MQTT_UTILS_LOGGER);
     return EXIT_FAILURE;
   }
 
@@ -31,7 +31,7 @@ int mqtt_utils_logger_release() {
 status_t duplex_config_init(struct mosquitto **config_mosq, mosq_config_t *config_cfg) {
   status_t ret = SC_OK;
   if (config_mosq == NULL || config_cfg == NULL) {
-    log_error(mqtt_utils_logger_id, "[%s:%d:%s]\n", __func__, __LINE__, "SC_TA_NULL");
+    ta_log_error("%s\n", "SC_TA_NULL");
     return SC_MQTT_NULL;
   }
 
@@ -49,10 +49,10 @@ status_t duplex_config_init(struct mosquitto **config_mosq, mosq_config_t *confi
   if (!config_mosq) {
     switch (errno) {
       case ENOMEM:
-        log_error(mqtt_utils_logger_id, "[%s:%d:%s]\n", __func__, __LINE__, "Out of memory");
+        ta_log_error("%s\n", "Out of memory");
         break;
       case EINVAL:
-        log_error(mqtt_utils_logger_id, "[%s:%d:%s]\n", __func__, __LINE__, "Invalid id");
+        ta_log_error("%s\n", "Invalid id");
         break;
     }
     return SC_MOSQ_OBJ_INIT_ERROR;
@@ -66,7 +66,7 @@ status_t duplex_config_init(struct mosquitto **config_mosq, mosq_config_t *confi
 status_t gossip_channel_set(mosq_config_t *channel_cfg, char *host, char *sub_topic, char *pub_topic) {
   status_t ret = SC_OK;
   if (channel_cfg == NULL || (host == NULL && sub_topic == NULL && pub_topic == NULL)) {
-    log_error(mqtt_utils_logger_id, "[%s:%d:%s]\n", __func__, __LINE__, "SC_TA_NULL");
+    ta_log_error("%s\n", "SC_TA_NULL");
     return SC_MQTT_NULL;
   }
 
@@ -94,7 +94,7 @@ status_t gossip_api_channels_set(mosq_config_t *channel_cfg, char *host, char *r
   status_t ret = SC_OK;
 
   if (channel_cfg == NULL || host == NULL || root_path == NULL) {
-    log_error(mqtt_utils_logger_id, "[%s:%d:%s]\n", __func__, __LINE__, "SC_TA_NULL");
+    ta_log_error("%s\n", "SC_TA_NULL");
     return SC_MQTT_NULL;
   }
 
@@ -134,7 +134,7 @@ done:
 
 status_t gossip_message_set(mosq_config_t *cfg, char *message) {
   if (cfg == NULL || message == NULL) {
-    log_error(mqtt_utils_logger_id, "[%s:%d:%s]\n", __func__, __LINE__, "SC_TA_NULL");
+    ta_log_error("%s\n", "SC_TA_NULL");
     return SC_MQTT_NULL;
   }
 
@@ -147,7 +147,7 @@ status_t gossip_message_set(mosq_config_t *cfg, char *message) {
 status_t duplex_client_start(struct mosquitto *mosq, mosq_config_t *cfg) {
   status_t ret = MOSQ_ERR_SUCCESS;
   if (mosq == NULL || cfg == NULL) {
-    log_error(mqtt_utils_logger_id, "[%s:%d:%s]\n", __func__, __LINE__, "SC_TA_NULL");
+    ta_log_error("%s\n", "SC_TA_NULL");
     return SC_MQTT_NULL;
   }
 

--- a/connectivity/mqtt/pub_utils.c
+++ b/connectivity/mqtt/pub_utils.c
@@ -13,14 +13,14 @@
 #include "utils/logger_helper.h"
 
 #define MQTT_PUB_LOGGER "mqtt-pub"
-static logger_id_t mqtt_pub_logger_id;
+static logger_id_t logger_id;
 
-void mqtt_pub_logger_init() { mqtt_pub_logger_id = logger_helper_enable(MQTT_PUB_LOGGER, LOGGER_DEBUG, true); }
+void mqtt_pub_logger_init() { logger_id = logger_helper_enable(MQTT_PUB_LOGGER, LOGGER_DEBUG, true); }
 
 int mqtt_pub_logger_release() {
-  logger_helper_release(mqtt_pub_logger_id);
+  logger_helper_release(logger_id);
   if (logger_helper_destroy() != RC_OK) {
-    log_critical(mqtt_pub_logger_id, "[%s:%s] Destroying logger failed %s.\n", __func__, __LINE__, MQTT_PUB_LOGGER);
+    ta_log_critical("Destroying logger failed %s.\n", MQTT_PUB_LOGGER);
     return EXIT_FAILURE;
   }
 
@@ -30,7 +30,7 @@ int mqtt_pub_logger_release() {
 mosq_retcode_t publish_message(struct mosquitto *mosq, mosq_config_t *cfg, int *mid, const char *topic, int payloadlen,
                                void *payload, int qos, bool retain) {
   if (mosq == NULL || cfg == NULL) {
-    log_error(mqtt_pub_logger_id, "[%s:%d:%s]\n", __func__, __LINE__, "SC_TA_NULL");
+    ta_log_error("%s\n", "SC_TA_NULL");
     return SC_MQTT_NULL;
   }
 
@@ -57,27 +57,22 @@ void connect_callback_pub_func(struct mosquitto *mosq, void *obj, int result, in
       {
         switch (ret) {
           case MOSQ_ERR_INVAL:
-            log_error(mqtt_pub_logger_id, "[%s:%d]:%s.\n", __func__, __LINE__,
-                      "Error: Invalid input. Does your topic contain '+' or '#'?");
+            ta_log_error(":%s.\n", "Error: Invalid input. Does your topic contain '+' or '#'?");
             break;
           case MOSQ_ERR_NOMEM:
-            log_error(mqtt_pub_logger_id, "[%s:%d]:%s.\n", __func__, __LINE__,
-                      "Error: Out of memory when trying to publish message.");
+            ta_log_error(":%s.\n", "Error: Out of memory when trying to publish message.");
             break;
           case MOSQ_ERR_NO_CONN:
-            log_error(mqtt_pub_logger_id, "[%s:%d]:%s.\n", __func__, __LINE__,
-                      "Error: Client not connected when trying to publish.");
+            ta_log_error(":%s.\n", "Error: Client not connected when trying to publish.");
             break;
           case MOSQ_ERR_PROTOCOL:
-            log_error(mqtt_pub_logger_id, "[%s:%d]:%s.\n", __func__, __LINE__,
-                      "Error: Protocol error when communicating with broker.");
+            ta_log_error(":%s.\n", "Error: Protocol error when communicating with broker.");
             break;
           case MOSQ_ERR_PAYLOAD_SIZE:
-            log_error(mqtt_pub_logger_id, "[%s:%d]:%s.\n", __func__, __LINE__, "Error: Message payload is too large.");
+            ta_log_error(":%s.\n", "Error: Message payload is too large.");
             break;
           case MOSQ_ERR_QOS_NOT_SUPPORTED:
-            log_error(mqtt_pub_logger_id, "[%s:%d]:%s.\n", __func__, __LINE__,
-                      "Error: Message QoS not supported on broker, try a lower QoS.");
+            ta_log_error(":%s.\n", "Error: Message QoS not supported on broker, try a lower QoS.");
             break;
           default:
             break;
@@ -88,9 +83,9 @@ void connect_callback_pub_func(struct mosquitto *mosq, void *obj, int result, in
   } else {
     if (result) {
       if (cfg->general_config->protocol_version == MQTT_PROTOCOL_V5) {
-        log_error(mqtt_pub_logger_id, "[%s:%d]:%s.\n", __func__, __LINE__, mosquitto_reason_string(result));
+        ta_log_error(":%s.\n", mosquitto_reason_string(result));
       } else {
-        log_error(mqtt_pub_logger_id, "[%s:%d]:%s.\n", __func__, __LINE__, mosquitto_connack_string(result));
+        ta_log_error(":%s.\n", mosquitto_connack_string(result));
       }
     }
   }
@@ -102,8 +97,7 @@ void publish_callback_pub_func(struct mosquitto *mosq, void *obj, int mid, int r
   UNUSED(properties);
 
   if (reason_code > 127) {
-    log_error(mqtt_pub_logger_id, "[%s:%d]Warning: Publish %d failed: %s.\n", __func__, __LINE__, mid,
-              mosquitto_reason_string(reason_code));
+    ta_log_error("Warning: Publish %d failed: %s.\n", mid, mosquitto_reason_string(reason_code));
   }
 
   mosquitto_disconnect_v5(mosq, 0, cfg->property_config->disconnect_props);
@@ -111,7 +105,7 @@ void publish_callback_pub_func(struct mosquitto *mosq, void *obj, int mid, int r
 
 status_t publish_loop(struct mosquitto *mosq) {
   if (mosq == NULL) {
-    log_error(mqtt_pub_logger_id, "[%s:%d:%s]\n", __func__, __LINE__, "SC_MQTT_NULL");
+    ta_log_error("%s\n", "SC_MQTT_NULL");
     return SC_MQTT_NULL;
   }
   mosq_retcode_t ret = MOSQ_ERR_SUCCESS;
@@ -124,74 +118,68 @@ status_t publish_loop(struct mosquitto *mosq) {
 
 status_t init_check_error(mosq_config_t *cfg, client_type_t client_type) {
   if (cfg == NULL) {
-    log_error(mqtt_pub_logger_id, "[%s:%d:%s]\n", __func__, __LINE__, "SC_TA_NULL");
+    ta_log_error("%s\n", "SC_TA_NULL");
     return SC_MQTT_NULL;
   }
   status_t ret = SC_OK;
 
   if (cfg->general_config->will_payload && !cfg->general_config->will_topic) {
-    log_error(mqtt_pub_logger_id, "[%s:%d]:%s\n", __func__, __LINE__,
-              "Error: Will payload given, but no will topic given.");
+    ta_log_error(":%s\n", "Error: Will payload given, but no will topic given.");
     return SC_MQTT_INIT;
   }
   if (cfg->general_config->will_retain && !cfg->general_config->will_topic) {
-    log_error(mqtt_pub_logger_id, "[%s:%d]Error: Will retain given, but no will topic given.\n", __func__, __LINE__);
+    ta_log_error("Error: Will retain given, but no will topic given.\n");
     return SC_MQTT_INIT;
   }
   if (cfg->general_config->password && !cfg->general_config->username) {
-    log_error(mqtt_pub_logger_id, "[%s:%d]Warning: Not using password since username not set.\n", __func__, __LINE__);
+    ta_log_error("Warning: Not using password since username not set.\n");
   }
 
   if (cfg->general_config->will_payload && !cfg->general_config->will_topic) {
-    log_error(mqtt_pub_logger_id, "[%s:%d]Error: Will payload given, but no will topic given.\n", __func__, __LINE__);
+    ta_log_error("Error: Will payload given, but no will topic given.\n");
     return SC_MQTT_INIT;
   }
   if (cfg->general_config->will_retain && !cfg->general_config->will_topic) {
-    log_error(mqtt_pub_logger_id, "[%s:%d]Error: Will retain given, but no will topic given.\n", __func__, __LINE__);
+    ta_log_error("Error: Will retain given, but no will topic given.\n");
     return SC_MQTT_INIT;
   }
   if (cfg->general_config->password && !cfg->general_config->username) {
-    log_error(mqtt_pub_logger_id, "[%s:%d]Warning: Not using password since username not set.\n", __func__, __LINE__);
+    ta_log_error("Warning: Not using password since username not set.\n");
   }
 #ifdef WITH_TLS
   if ((cfg->tls_config->certfile && !cfg->tls_config->keyfile) ||
       (cfg->tls_config->keyfile && !cfg->tls_config->certfile)) {
-    log_error(mqtt_pub_logger_id, "[%s:%d]Error: Both certfile and keyfile must be provided if one of them is set.\n",
-              __func__, __LINE__);
+    ta_log_error("Error: Both certfile and keyfile must be provided if one of them is set.\n");
     return SC_MQTT_INIT;
   }
   if ((cfg->tls_config->keyform && !cfg->tls_config->keyfile)) {
-    log_error(mqtt_pub_logger_id, "[%s:%d]Error: If keyform is set, keyfile must be also specified\n", __func__,
-              __LINE__);
+    ta_log_error("Error: If keyform is set, keyfile must be also specified\n");
     return SC_MQTT_INIT;
   }
   if ((cfg->tls_config->tls_engine_kpass_sha1 && (!cfg->tls_config->keyform || !cfg->tls_config->tls_engine))) {
-    log_error(mqtt_pub_logger_id,
-              "[%s:%d]Error: when using tls-engine-kpass-sha1, both tls-engine and keyform must also be provided\n",
-              __func__, __LINE__);
+    ta_log_error("Error: when using tls-engine-kpass-sha1, both tls-engine and keyform must also be provided\n");
     return SC_MQTT_INIT;
   }
 #endif
 #ifdef FINAL_WITH_TLS_PSK
   if ((cfg->tls_config->cafile || cfg->tls_config->capath) && cfg->tls_config->psk) {
-    log_error(mqtt_pub_logger_id, "[%s:%d]Error: Only one of --psk or --cafile/--capath may be used at once.\n",
-              __func__, __LINE__);
+    ta_log_error("Error: Only one of --psk or --cafile/--capath may be used at once.\n");
     return SC_MQTT_INIT;
   }
   if (cfg->tls_config->psk && !cfg->tls_config->psk_identity) {
-    log_error(mqtt_pub_logger_id, "[%s:%d]Error: --psk-identity required if --psk used\n", __func__, __LINE__);
+    ta_log_error("Error: --psk-identity required if --psk used\n");
     return SC_MQTT_INIT;
   }
 #endif
 
   if (cfg->general_config->clean_session == false && !cfg->general_config->id) {
-    log_error(mqtt_pub_logger_id, "[%s:%d]Error: You must provide a client id\n", __func__, __LINE__);
+    ta_log_error("Error: You must provide a client id\n");
     return SC_MQTT_INIT;
   }
 
   if (client_type == client_sub) {
     if (cfg->sub_config->topic_count == 0) {
-      log_error(mqtt_pub_logger_id, "[%s:%d]Error: You must specify a topic to subscribe to\n", __func__, __LINE__);
+      ta_log_error("Error: You must specify a topic to subscribe to\n");
       return SC_MQTT_INIT;
     }
   }
@@ -199,44 +187,39 @@ status_t init_check_error(mosq_config_t *cfg, client_type_t client_type) {
   if (!cfg->general_config->host) {
     cfg->general_config->host = strdup("localhost");
     if (!cfg->general_config->host) {
-      log_error(mqtt_pub_logger_id, "[%s:%d:%s]\n", __func__, __LINE__, "SC_MQTT_OOM");
+      ta_log_error("%s\n", "SC_MQTT_OOM");
       return SC_MQTT_OOM;
     }
   }
 
   ret = mosquitto_property_check_all(CMD_CONNECT, cfg->property_config->connect_props);
   if (ret) {
-    log_error(mqtt_pub_logger_id, "[%s:%d]Error in CONNECT properties: %s\n", __func__, __LINE__,
-              mosquitto_strerror(ret));
+    ta_log_error("Error in CONNECT properties: %s\n", mosquitto_strerror(ret));
     return SC_MQTT_INIT;
   }
   ret = mosquitto_property_check_all(CMD_PUBLISH, cfg->property_config->publish_props);
   if (ret) {
-    log_error(mqtt_pub_logger_id, "[%s:%d]Error in PUBLISH properties: %s\n", __func__, __LINE__,
-              mosquitto_strerror(ret));
+    ta_log_error("Error in PUBLISH properties: %s\n", mosquitto_strerror(ret));
     return SC_MQTT_INIT;
   }
   ret = mosquitto_property_check_all(CMD_SUBSCRIBE, cfg->property_config->subscribe_props);
   if (ret) {
-    log_error(mqtt_pub_logger_id, "[%s:%d]Error in SUBSCRIBE properties: %s\n", __func__, __LINE__,
-              mosquitto_strerror(ret));
+    ta_log_error("Error in SUBSCRIBE properties: %s\n", mosquitto_strerror(ret));
     return SC_MQTT_INIT;
   }
   ret = mosquitto_property_check_all(CMD_UNSUBSCRIBE, cfg->property_config->unsubscribe_props);
   if (ret) {
-    log_error(mqtt_pub_logger_id, "[%s:%d]Error in UNSUBSCRIBE properties: %s\n", __func__, __LINE__,
-              mosquitto_strerror(ret));
+    ta_log_error("Error in UNSUBSCRIBE properties: %s\n", mosquitto_strerror(ret));
     return SC_MQTT_INIT;
   }
   ret = mosquitto_property_check_all(CMD_DISCONNECT, cfg->property_config->disconnect_props);
   if (ret) {
-    log_error(mqtt_pub_logger_id, "[%s:%d]Error in DISCONNECT properties: %s\n", __func__, __LINE__,
-              mosquitto_strerror(ret));
+    ta_log_error("Error in DISCONNECT properties: %s\n", mosquitto_strerror(ret));
     return SC_MQTT_INIT;
   }
   ret = mosquitto_property_check_all(CMD_WILL, cfg->property_config->will_props);
   if (ret) {
-    log_error(mqtt_pub_logger_id, "[%s:%d]Error in Will properties: %s\n", __func__, __LINE__, mosquitto_strerror(ret));
+    ta_log_error("Error in Will properties: %s\n", mosquitto_strerror(ret));
     return SC_MQTT_INIT;
   }
 

--- a/connectivity/mqtt/sub_utils.c
+++ b/connectivity/mqtt/sub_utils.c
@@ -13,14 +13,14 @@
 #include "utils/logger_helper.h"
 
 #define MQTT_SUB_LOGGER "mqtt-sub"
-static logger_id_t mqtt_sub_logger_id;
+static logger_id_t logger_id;
 
-void mqtt_sub_logger_init() { mqtt_sub_logger_id = logger_helper_enable(MQTT_SUB_LOGGER, LOGGER_DEBUG, true); }
+void mqtt_sub_logger_init() { logger_id = logger_helper_enable(MQTT_SUB_LOGGER, LOGGER_DEBUG, true); }
 
 int mqtt_sub_logger_release() {
-  logger_helper_release(mqtt_sub_logger_id);
+  logger_helper_release(logger_id);
   if (logger_helper_destroy() != RC_OK) {
-    log_critical(mqtt_sub_logger_id, "[%s:%s] Destroying logger failed %s.\n", __func__, __LINE__, MQTT_SUB_LOGGER);
+    ta_log_critical("Destroying logger failed %s.\n", MQTT_SUB_LOGGER);
     return EXIT_FAILURE;
   }
 
@@ -29,7 +29,7 @@ int mqtt_sub_logger_release() {
 
 static status_t dump_message(mosq_config_t *cfg, const struct mosquitto_message *message) {
   if (cfg == NULL || message == NULL || message->payload == NULL || message->payloadlen == 0) {
-    log_error(mqtt_sub_logger_id, "[%s:%d:%s]\n", __func__, __LINE__, "SC_TA_NULL");
+    ta_log_error("%s\n", "SC_TA_NULL");
     return SC_MQTT_NULL;
   }
 
@@ -89,9 +89,9 @@ void connect_callback_sub_func(struct mosquitto *mosq, void *obj, int result, in
   } else {
     if (result) {
       if (cfg->general_config->protocol_version == MQTT_PROTOCOL_V5) {
-        log_error(mqtt_sub_logger_id, "[%s:%d]:%s\n", __func__, __LINE__, mosquitto_reason_string(result));
+        ta_log_error(":%s\n", mosquitto_reason_string(result));
       } else {
-        log_error(mqtt_sub_logger_id, "[%s:%d]:%s\n", __func__, __LINE__, mosquitto_connack_string(result));
+        ta_log_error(":%s\n", mosquitto_connack_string(result));
       }
     }
     mosquitto_disconnect_v5(mosq, 0, cfg->property_config->disconnect_props);
@@ -105,7 +105,7 @@ void subscribe_callback_sub_func(struct mosquitto *mosq, void *obj, int mid, int
     snprintf(qos_digit, 4, ", %d", granted_qos[i]);
     strcat(qos_str, qos_digit);
   }
-  log_info(mqtt_sub_logger_id, "Subscribed (mid: %d): %d%s\n", mid, granted_qos[0], qos_str);
+  log_info(logger_id, "Subscribed (mid: %d): %d%s\n", mid, granted_qos[0], qos_str);
 
   free(qos_str);
 }

--- a/serializer/serializer.c
+++ b/serializer/serializer.c
@@ -11,14 +11,14 @@
 
 #define SERI_LOGGER "serializer"
 
-static logger_id_t seri_logger_id;
+static logger_id_t logger_id;
 
-void serializer_logger_init() { seri_logger_id = logger_helper_enable(SERI_LOGGER, LOGGER_DEBUG, true); }
+void serializer_logger_init() { logger_id = logger_helper_enable(SERI_LOGGER, LOGGER_DEBUG, true); }
 
 int serializer_logger_release() {
-  logger_helper_release(seri_logger_id);
+  logger_helper_release(logger_id);
   if (logger_helper_destroy() != RC_OK) {
-    log_critical(seri_logger_id, "[%s:%d] Destroying logger failed %s.\n", __func__, __LINE__, SERI_LOGGER);
+    ta_log_critical("Destroying logger failed %s.\n", SERI_LOGGER);
     return EXIT_FAILURE;
   }
 
@@ -30,7 +30,7 @@ status_t ta_get_info_serialize(char** obj, ta_config_t* const info, iota_config_
   status_t ret = SC_OK;
   cJSON* json_root = cJSON_CreateObject();
   if (json_root == NULL) {
-    log_error(seri_logger_id, "[%s:%d:%s]\n", __func__, __LINE__, "SC_SERIALIZER_JSON_CREATE");
+    ta_log_error("%s\n", "SC_SERIALIZER_JSON_CREATE");
     return SC_SERIALIZER_JSON_CREATE;
   }
 
@@ -49,7 +49,7 @@ status_t ta_get_info_serialize(char** obj, ta_config_t* const info, iota_config_
 
   *obj = cJSON_PrintUnformatted(json_root);
   if (*obj == NULL) {
-    log_error(seri_logger_id, "[%s:%d:%s]\n", __func__, __LINE__, "SC_SERIALIZER_JSON_PARSE");
+    ta_log_error("%s\n", "SC_SERIALIZER_JSON_PARSE");
     ret = SC_SERIALIZER_JSON_PARSE;
   }
 
@@ -71,12 +71,12 @@ static status_t ta_hash243_stack_to_json_array(hash243_stack_t stack, cJSON* jso
       if (trits_count != 0) {
         cJSON_AddItemToArray(json_root, cJSON_CreateString((const char*)trytes_out));
       } else {
-        log_error(seri_logger_id, "[%s:%d:%s]\n", __func__, __LINE__, "SC_CCLIENT_INVALID_FLEX_TRITS");
+        ta_log_error("%s\n", "SC_CCLIENT_INVALID_FLEX_TRITS");
         return SC_CCLIENT_INVALID_FLEX_TRITS;
       }
     }
   } else {
-    log_error(seri_logger_id, "[%s:%d:%s]\n", __func__, __LINE__, "SC_CCLIENT_NOT_FOUND");
+    ta_log_error("%s\n", "SC_CCLIENT_NOT_FOUND");
     return SC_CCLIENT_NOT_FOUND;
   }
   return SC_OK;
@@ -88,7 +88,7 @@ static status_t ta_json_array_to_hash243_queue(cJSON const* const obj, char cons
   flex_trit_t hash[FLEX_TRIT_SIZE_243] = {};
   cJSON* json_item = cJSON_GetObjectItemCaseSensitive(obj, obj_name);
   if (!json_item) {
-    log_error(seri_logger_id, "[%s:%d:%s]\n", __func__, __LINE__, "SC_SERIALIZER_NULL");
+    ta_log_error("%s\n", "SC_SERIALIZER_NULL");
     return SC_SERIALIZER_NULL;
   }
 
@@ -99,13 +99,13 @@ static status_t ta_json_array_to_hash243_queue(cJSON const* const obj, char cons
         flex_trits_from_trytes(hash, NUM_TRITS_HASH, (tryte_t const*)current_obj->valuestring, NUM_TRYTES_HASH,
                                NUM_TRYTES_HASH);
         if (hash243_queue_push(queue, hash) != RC_OK) {
-          log_error(seri_logger_id, "[%s:%d:%s]\n", __func__, __LINE__, "SC_SERIALIZER_JSON_PARSE");
+          ta_log_error("%s\n", "SC_SERIALIZER_JSON_PARSE");
           return SC_SERIALIZER_JSON_PARSE;
         }
       }
     }
   } else {
-    log_error(seri_logger_id, "[%s:%d:%s]\n", __func__, __LINE__, "SC_SERIALIZER_JSON_PARSE");
+    ta_log_error("%s\n", "SC_SERIALIZER_JSON_PARSE");
     return SC_SERIALIZER_JSON_PARSE;
   }
   return ret_code;
@@ -125,12 +125,12 @@ static status_t ta_hash243_queue_to_json_array(hash243_queue_t queue, cJSON* con
       if (trits_count != 0) {
         cJSON_AddItemToArray(json_root, cJSON_CreateString((const char*)trytes_out));
       } else {
-        log_error(seri_logger_id, "[%s:%d:%s]\n", __func__, __LINE__, "SC_CCLIENT_INVALID_FLEX_TRITS");
+        ta_log_error("%s\n", "SC_CCLIENT_INVALID_FLEX_TRITS");
         return SC_CCLIENT_INVALID_FLEX_TRITS;
       }
     }
   } else {
-    log_error(seri_logger_id, "[%s:%d:%s]\n", __func__, __LINE__, "SC_CCLIENT_NOT_FOUND");
+    ta_log_error("%s\n", "SC_CCLIENT_NOT_FOUND");
     return SC_CCLIENT_NOT_FOUND;
   }
   return SC_OK;
@@ -142,7 +142,7 @@ static status_t ta_json_array_to_hash8019_array(cJSON const* const obj, char con
   flex_trit_t hash[FLEX_TRIT_SIZE_8019] = {};
   cJSON* json_item = cJSON_GetObjectItemCaseSensitive(obj, obj_name);
   if (!cJSON_IsArray(json_item)) {
-    log_error(seri_logger_id, "[%s:%d:%s]\n", __func__, __LINE__, "SC_CCLIENT_JSON_PARSE");
+    ta_log_error("%s\n", "SC_CCLIENT_JSON_PARSE");
     return SC_CCLIENT_JSON_PARSE;
   }
 
@@ -150,7 +150,7 @@ static status_t ta_json_array_to_hash8019_array(cJSON const* const obj, char con
   cJSON_ArrayForEach(current_obj, json_item) {
     if (current_obj->valuestring != NULL) {
       if (strlen(current_obj->valuestring) != NUM_TRYTES_SERIALIZED_TRANSACTION) {
-        log_error(seri_logger_id, "[%s:%d:%s]\n", __func__, __LINE__, "SC_SERIALIZER_INVALID_REQ");
+        ta_log_error("%s\n", "SC_SERIALIZER_INVALID_REQ");
         return SC_SERIALIZER_INVALID_REQ;
       }
       flex_trits_from_trytes(hash, NUM_TRITS_SERIALIZED_TRANSACTION, (tryte_t const*)current_obj->valuestring,
@@ -172,7 +172,7 @@ status_t ta_hash8019_array_to_json_array(hash8019_array_p array, cJSON* const js
   if (array_count > 0) {
     array_obj = cJSON_CreateArray();
     if (array_obj == NULL) {
-      log_error(seri_logger_id, "[%s:%d:%s]\n", __func__, __LINE__, "SC_SERIALIZER_JSON_CREATE");
+      ta_log_error("%s\n", "SC_SERIALIZER_JSON_CREATE");
       return SC_SERIALIZER_JSON_CREATE;
     }
     cJSON_AddItemToObject(json_root, obj_name, array_obj);
@@ -182,7 +182,7 @@ status_t ta_hash8019_array_to_json_array(hash8019_array_p array, cJSON* const js
                                          NUM_TRITS_SERIALIZED_TRANSACTION, NUM_TRITS_SERIALIZED_TRANSACTION);
       trytes_out[NUM_TRYTES_SERIALIZED_TRANSACTION] = '\0';
       if (trits_count == 0) {
-        log_error(seri_logger_id, "[%s:%d:%s]\n", __func__, __LINE__, "SC_CCLIENT_FLEX_TRITS");
+        ta_log_error("%s\n", "SC_CCLIENT_FLEX_TRITS");
         return SC_CCLIENT_FLEX_TRITS;
       }
       cJSON_AddItemToArray(array_obj, cJSON_CreateString((char const*)trytes_out));
@@ -194,20 +194,20 @@ status_t ta_hash8019_array_to_json_array(hash8019_array_p array, cJSON* const js
 static status_t ta_json_get_string(cJSON const* const json_obj, char const* const obj_name, char* const text) {
   status_t ret = SC_OK;
   if (json_obj == NULL || obj_name == NULL || text == NULL) {
-    log_error(seri_logger_id, "[%s:%d:%s]\n", __func__, __LINE__, "SC_SERIALIZER_NULL");
+    ta_log_error("%s\n", "SC_SERIALIZER_NULL");
     return SC_SERIALIZER_NULL;
   }
 
   cJSON* json_value = cJSON_GetObjectItemCaseSensitive(json_obj, obj_name);
   if (json_value == NULL) {
-    log_error(seri_logger_id, "[%s:%d:%s]\n", __func__, __LINE__, "SC_CCLIENT_JSON_KEY");
+    ta_log_error("%s\n", "SC_CCLIENT_JSON_KEY");
     return SC_CCLIENT_JSON_KEY;
   }
 
   if (cJSON_IsString(json_value) && (json_value->valuestring != NULL)) {
     strcpy(text, json_value->valuestring);
   } else {
-    log_error(seri_logger_id, "[%s:%d:%s]\n", __func__, __LINE__, "SC_CCLIENT_JSON_PARSE");
+    ta_log_error("%s\n", "SC_CCLIENT_JSON_PARSE");
     return SC_CCLIENT_JSON_PARSE;
   }
 
@@ -216,13 +216,13 @@ static status_t ta_json_get_string(cJSON const* const json_obj, char const* cons
 
 status_t iota_transaction_to_json_object(iota_transaction_t const* const txn, cJSON** txn_json) {
   if (txn == NULL) {
-    log_error(seri_logger_id, "[%s:%d:%s]\n", __func__, __LINE__, "SC_CCLIENT_NOT_FOUND");
+    ta_log_error("%s\n", "SC_CCLIENT_NOT_FOUND");
     return SC_CCLIENT_NOT_FOUND;
   }
   char msg_trytes[NUM_TRYTES_SIGNATURE + 1], hash_trytes[NUM_TRYTES_HASH + 1], tag_trytes[NUM_TRYTES_TAG + 1];
 
   if (txn_json == NULL) {
-    log_error(seri_logger_id, "[%s:%d:%s]\n", __func__, __LINE__, "SC_SERIALIZER_JSON_CREATE");
+    ta_log_error("%s\n", "SC_SERIALIZER_JSON_CREATE");
     return SC_SERIALIZER_JSON_CREATE;
   }
 
@@ -317,7 +317,7 @@ status_t ta_generate_address_res_serialize(const ta_generate_address_res_t* cons
   cJSON* json_root = cJSON_CreateArray();
   status_t ret = SC_OK;
   if (json_root == NULL) {
-    log_error(seri_logger_id, "[%s:%d:%s]\n", __func__, __LINE__, "SC_SERIALIZER_JSON_CREATE");
+    ta_log_error("%s\n", "SC_SERIALIZER_JSON_CREATE");
     return SC_SERIALIZER_JSON_CREATE;
   }
   ret = ta_hash243_queue_to_json_array(res->addresses, json_root);
@@ -327,7 +327,7 @@ status_t ta_generate_address_res_serialize(const ta_generate_address_res_t* cons
 
   *obj = cJSON_PrintUnformatted(json_root);
   if (*obj == NULL) {
-    log_error(seri_logger_id, "[%s:%d:%s]\n", __func__, __LINE__, "SC_SERIALIZER_JSON_PARSE");
+    ta_log_error("%s\n", "SC_SERIALIZER_JSON_PARSE");
     return SC_SERIALIZER_JSON_PARSE;
   }
   cJSON_Delete(json_root);
@@ -339,7 +339,7 @@ status_t ta_get_tips_res_serialize(const get_tips_res_t* const res, char** obj) 
 
   cJSON* json_root = cJSON_CreateArray();
   if (json_root == NULL) {
-    log_error(seri_logger_id, "[%s:%d:%s]\n", __func__, __LINE__, "SC_SERIALIZER_JSON_CREATE");
+    ta_log_error("%s\n", "SC_SERIALIZER_JSON_CREATE");
     return RC_CCLIENT_JSON_CREATE;
   }
 
@@ -350,7 +350,7 @@ status_t ta_get_tips_res_serialize(const get_tips_res_t* const res, char** obj) 
 
   *obj = cJSON_PrintUnformatted(json_root);
   if (*obj == NULL) {
-    log_error(seri_logger_id, "[%s:%d:%s]\n", __func__, __LINE__, "SC_SERIALIZER_JSON_PARSE");
+    ta_log_error("%s\n", "SC_SERIALIZER_JSON_PARSE");
     return SC_SERIALIZER_JSON_PARSE;
   }
 
@@ -361,7 +361,7 @@ err:
 
 status_t ta_send_transfer_req_deserialize(const char* const obj, ta_send_transfer_req_t* req) {
   if (obj == NULL) {
-    log_error(seri_logger_id, "[%s:%d:%s]\n", __func__, __LINE__, "SC_SERIALIZER_NULL");
+    ta_log_error("%s\n", "SC_SERIALIZER_NULL");
     return SC_SERIALIZER_NULL;
   }
   cJSON* json_obj = cJSON_Parse(obj);
@@ -373,7 +373,7 @@ status_t ta_send_transfer_req_deserialize(const char* const obj, ta_send_transfe
 
   if (json_obj == NULL) {
     ret = SC_SERIALIZER_JSON_PARSE;
-    log_error(seri_logger_id, "[%s:%d:%s]\n", __func__, __LINE__, "SC_SERIALIZER_JSON_PARSE");
+    ta_log_error("%s\n", "SC_SERIALIZER_JSON_PARSE");
     goto done;
   }
 
@@ -392,7 +392,7 @@ status_t ta_send_transfer_req_deserialize(const char* const obj, ta_send_transfe
     for (int i = 0; i < tag_len; i++) {
       if (json_result->valuestring[i] & (unsigned)128) {
         ret = SC_SERIALIZER_JSON_PARSE_ASCII;
-        log_error(seri_logger_id, "[%s:%d:%s]\n", __func__, __LINE__, "SC_SERIALIZER_JSON_PARSE_ASCII");
+        ta_log_error("%s\n", "SC_SERIALIZER_JSON_PARSE_ASCII");
         goto done;
       }
     }
@@ -416,7 +416,7 @@ status_t ta_send_transfer_req_deserialize(const char* const obj, ta_send_transfe
   ret = hash81_queue_push(&req->tag, tag_trits);
   if (ret) {
     ret = SC_CCLIENT_HASH;
-    log_error(seri_logger_id, "[%s:%d:%s]\n", __func__, __LINE__, "SC_CCLIENT_HASH");
+    ta_log_error("%s\n", "SC_CCLIENT_HASH");
     goto done;
   }
 
@@ -436,7 +436,7 @@ status_t ta_send_transfer_req_deserialize(const char* const obj, ta_send_transfe
     for (int i = 0; i < msg_len; i++) {
       if (json_result->valuestring[i] & 0x80) {
         ret = SC_SERIALIZER_JSON_PARSE_ASCII;
-        log_error(seri_logger_id, "[%s:%d:%s]\n", __func__, __LINE__, "SC_SERIALIZER_JSON_PARSE_ASCII");
+        ta_log_error("%s\n", "SC_SERIALIZER_JSON_PARSE_ASCII");
         goto done;
       }
     }
@@ -470,7 +470,7 @@ status_t ta_send_transfer_req_deserialize(const char* const obj, ta_send_transfe
   ret = hash243_queue_push(&req->address, address_trits);
   if (ret) {
     ret = SC_CCLIENT_HASH;
-    log_error(seri_logger_id, "[%s:%d:%s]\n", __func__, __LINE__, "SC_CCLIENT_HASH");
+    ta_log_error("%s\n", "SC_CCLIENT_HASH");
     goto done;
   }
 
@@ -481,7 +481,7 @@ done:
 
 status_t ta_send_trytes_req_deserialize(const char* const obj, hash8019_array_p out_trytes) {
   if (obj == NULL || out_trytes == NULL) {
-    log_error(seri_logger_id, "[%s:%d:%s]\n", __func__, __LINE__, "SC_SERIALIZER_NULL");
+    ta_log_error("%s\n", "SC_SERIALIZER_NULL");
     return SC_SERIALIZER_NULL;
   }
   status_t ret = SC_OK;
@@ -489,7 +489,7 @@ status_t ta_send_trytes_req_deserialize(const char* const obj, hash8019_array_p 
 
   if (json_obj == NULL) {
     ret = SC_SERIALIZER_JSON_PARSE;
-    log_error(seri_logger_id, "[%s:%d:%s]\n", __func__, __LINE__, "SC_SERIALIZER_JSON_PARSE");
+    ta_log_error("%s\n", "SC_SERIALIZER_JSON_PARSE");
     goto done;
   }
 
@@ -505,7 +505,7 @@ done:
 
 status_t ta_send_trytes_res_serialize(const hash8019_array_p trytes, char** obj) {
   if (trytes == NULL) {
-    log_error(seri_logger_id, "[%s:%d:%s]\n", __func__, __LINE__, "SC_SERIALIZER_NULL");
+    ta_log_error("%s\n", "SC_SERIALIZER_NULL");
     return SC_SERIALIZER_NULL;
   }
 
@@ -519,7 +519,7 @@ status_t ta_send_trytes_res_serialize(const hash8019_array_p trytes, char** obj)
 
   *obj = cJSON_PrintUnformatted(json_root);
   if (*obj == NULL) {
-    log_error(seri_logger_id, "[%s:%d:%s]\n", __func__, __LINE__, "SC_SERIALIZER_JSON_PARSE");
+    ta_log_error("%s\n", "SC_SERIALIZER_JSON_PARSE");
     ret = SC_SERIALIZER_JSON_PARSE;
   }
 
@@ -532,19 +532,19 @@ status_t ta_find_transaction_objects_req_deserialize(const char* const obj,
                                                      ta_find_transaction_objects_req_t* const req) {
   status_t ret = SC_OK;
   if (obj == NULL) {
-    log_error(seri_logger_id, "[%s:%d:%s]\n", __func__, __LINE__, "SC_SERIALIZER_NULL");
+    ta_log_error("%s\n", "SC_SERIALIZER_NULL");
     return SC_SERIALIZER_NULL;
   }
 
   cJSON* json_obj = cJSON_Parse(obj);
   if (json_obj == NULL) {
-    log_error(seri_logger_id, "[%s:%d:%s]\n", __func__, __LINE__, "SC_SERIALIZER_JSON_PARSE");
+    ta_log_error("%s\n", "SC_SERIALIZER_JSON_PARSE");
     return SC_SERIALIZER_JSON_PARSE;
   }
 
   ret = ta_json_array_to_hash243_queue(json_obj, "hashes", &req->hashes);
   if (ret != SC_OK) {
-    log_error(seri_logger_id, "[%s:%d:%s]\n", __func__, __LINE__, "SC_SERIALIZER_JSON_PARSE");
+    ta_log_error("%s\n", "SC_SERIALIZER_JSON_PARSE");
   }
 
   cJSON_Delete(json_obj);
@@ -555,7 +555,7 @@ status_t ta_find_transaction_object_single_res_serialize(transaction_array_t* re
   status_t ret = SC_OK;
   cJSON* json_root = cJSON_CreateObject();
   if (json_root == NULL) {
-    log_error(seri_logger_id, "[%s:%d:%s]\n", __func__, __LINE__, "SC_CCLIENT_JSON_CREATE");
+    ta_log_error("%s\n", "SC_CCLIENT_JSON_CREATE");
     return SC_CCLIENT_JSON_CREATE;
   }
 
@@ -567,7 +567,7 @@ status_t ta_find_transaction_object_single_res_serialize(transaction_array_t* re
   *obj = cJSON_PrintUnformatted(json_root);
   if (*obj == NULL) {
     ret = SC_SERIALIZER_JSON_PARSE;
-    log_error(seri_logger_id, "[%s:%d:%s]\n", __func__, __LINE__, "SC_SERIALIZER_JSON_PARSE");
+    ta_log_error("%s\n", "SC_SERIALIZER_JSON_PARSE");
   }
 
 done:
@@ -579,7 +579,7 @@ status_t ta_find_transaction_objects_res_serialize(const transaction_array_t* co
   status_t ret = SC_OK;
   cJSON* json_root = cJSON_CreateArray();
   if (json_root == NULL) {
-    log_error(seri_logger_id, "[%s:%d:%s]\n", __func__, __LINE__, "SC_CCLIENT_JSON_CREATE");
+    ta_log_error("%s\n", "SC_CCLIENT_JSON_CREATE");
     return SC_CCLIENT_JSON_CREATE;
   }
 
@@ -591,7 +591,7 @@ status_t ta_find_transaction_objects_res_serialize(const transaction_array_t* co
   *obj = cJSON_PrintUnformatted(json_root);
   if (*obj == NULL) {
     ret = SC_SERIALIZER_JSON_PARSE;
-    log_error(seri_logger_id, "[%s:%d:%s]\n", __func__, __LINE__, "SC_SERIALIZER_JSON_PARSE");
+    ta_log_error("%s\n", "SC_SERIALIZER_JSON_PARSE");
   }
 
 done:
@@ -604,7 +604,7 @@ status_t ta_find_transactions_by_tag_res_serialize(const ta_find_transactions_by
   cJSON* json_root = cJSON_CreateArray();
   if (json_root == NULL) {
     ret = SC_SERIALIZER_JSON_CREATE;
-    log_error(seri_logger_id, "[%s:%d:%s]\n", __func__, __LINE__, "SC_SERIALIZER_JSON_CREATE");
+    ta_log_error("%s\n", "SC_SERIALIZER_JSON_CREATE");
     goto done;
   }
 
@@ -614,7 +614,7 @@ status_t ta_find_transactions_by_tag_res_serialize(const ta_find_transactions_by
   }
   *obj = cJSON_PrintUnformatted(json_root);
   if (*obj == NULL) {
-    log_error(seri_logger_id, "[%s:%d:%s]\n", __func__, __LINE__, "SC_SERIALIZER_JSON_PARSE");
+    ta_log_error("%s\n", "SC_SERIALIZER_JSON_PARSE");
     ret = SC_SERIALIZER_JSON_PARSE;
     goto done;
   }
@@ -629,7 +629,7 @@ status_t ta_send_transfer_res_serialize(transaction_array_t* res, char** obj) {
   cJSON* json_root = cJSON_CreateObject();
   if (json_root == NULL) {
     ret = SC_SERIALIZER_JSON_CREATE;
-    log_error(seri_logger_id, "[%s:%d:%s]\n", __func__, __LINE__, "SC_SERIALIZER_JSON_CREATE");
+    ta_log_error("%s\n", "SC_SERIALIZER_JSON_CREATE");
     goto done;
   }
 
@@ -641,7 +641,7 @@ status_t ta_send_transfer_res_serialize(transaction_array_t* res, char** obj) {
   *obj = cJSON_PrintUnformatted(json_root);
   if (*obj == NULL) {
     ret = SC_SERIALIZER_JSON_PARSE;
-    log_error(seri_logger_id, "[%s:%d:%s]\n", __func__, __LINE__, "SC_SERIALIZER_JSON_CREATE");
+    ta_log_error("%s\n", "SC_SERIALIZER_JSON_CREATE");
     goto done;
   }
 
@@ -655,7 +655,7 @@ status_t receive_mam_message_res_serialize(char* const message, char** obj) {
   cJSON* json_root = cJSON_CreateObject();
   if (json_root == NULL) {
     ret = SC_SERIALIZER_JSON_CREATE;
-    log_error(seri_logger_id, "[%s:%d:%s]\n", __func__, __LINE__, "SC_SERIALIZER_JSON_CREATE");
+    ta_log_error("%s\n", "SC_SERIALIZER_JSON_CREATE");
     goto done;
   }
 
@@ -664,7 +664,7 @@ status_t receive_mam_message_res_serialize(char* const message, char** obj) {
   *obj = cJSON_PrintUnformatted(json_root);
   if (*obj == NULL) {
     ret = SC_SERIALIZER_JSON_PARSE;
-    log_error(seri_logger_id, "[%s:%d:%s]\n", __func__, __LINE__, "SC_SERIALIZER_JSON_PARSE");
+    ta_log_error("%s\n", "SC_SERIALIZER_JSON_PARSE");
     goto done;
   }
 
@@ -678,7 +678,7 @@ status_t send_mam_res_serialize(const ta_send_mam_res_t* const res, char** obj) 
   cJSON* json_root = cJSON_CreateObject();
   if (json_root == NULL) {
     ret = SC_SERIALIZER_JSON_CREATE;
-    log_error(seri_logger_id, "[%s:%d:%s]\n", __func__, __LINE__, "SC_SERIALIZER_JSON_CREATE");
+    ta_log_error("%s\n", "SC_SERIALIZER_JSON_CREATE");
     goto done;
   }
 
@@ -691,7 +691,7 @@ status_t send_mam_res_serialize(const ta_send_mam_res_t* const res, char** obj) 
   *obj = cJSON_PrintUnformatted(json_root);
   if (*obj == NULL) {
     ret = SC_SERIALIZER_JSON_PARSE;
-    log_error(seri_logger_id, "[%s:%d:%s]\n", __func__, __LINE__, "SC_SERIALIZER_JSON_PARSE");
+    ta_log_error("%s\n", "SC_SERIALIZER_JSON_PARSE");
     goto done;
   }
 
@@ -702,7 +702,7 @@ done:
 
 status_t send_mam_res_deserialize(const char* const obj, ta_send_mam_res_t* const res) {
   if (obj == NULL) {
-    log_error(seri_logger_id, "[%s:%d:%s]\n", __func__, __LINE__, "SC_SERIALIZER_NULL");
+    ta_log_error("%s\n", "SC_SERIALIZER_NULL");
     return SC_SERIALIZER_NULL;
   }
   cJSON* json_obj = cJSON_Parse(obj);
@@ -711,20 +711,20 @@ status_t send_mam_res_deserialize(const char* const obj, ta_send_mam_res_t* cons
 
   if (json_obj == NULL) {
     ret = SC_SERIALIZER_JSON_PARSE;
-    log_error(seri_logger_id, "[%s:%d:%s]\n", __func__, __LINE__, "SC_SERIALIZER_JSON_PARSE");
+    ta_log_error("%s\n", "SC_SERIALIZER_JSON_PARSE");
     goto done;
   }
 
   if (ta_json_get_string(json_obj, "channel", (char*)addr) != SC_OK) {
     ret = SC_SERIALIZER_NULL;
-    log_error(seri_logger_id, "[%s:%d:%s]\n", __func__, __LINE__, "SC_SERIALIZER_NULL");
+    ta_log_error("%s\n", "SC_SERIALIZER_NULL");
     goto done;
   }
   send_mam_res_set_channel_id(res, addr);
 
   if (ta_json_get_string(json_obj, "bundle_hash", (char*)addr) != SC_OK) {
     ret = SC_SERIALIZER_NULL;
-    log_error(seri_logger_id, "[%s:%d:%s]\n", __func__, __LINE__, "SC_SERIALIZER_NULL");
+    ta_log_error("%s\n", "SC_SERIALIZER_NULL");
     goto done;
   }
   send_mam_res_set_bundle_hash(res, addr);
@@ -736,7 +736,7 @@ done:
 
 status_t send_mam_req_deserialize(const char* const obj, ta_send_mam_req_t* req) {
   if (obj == NULL) {
-    log_error(seri_logger_id, "[%s:%d:%s]\n", __func__, __LINE__, "SC_SERIALIZER_NULL");
+    ta_log_error("%s\n", "SC_SERIALIZER_NULL");
     return SC_SERIALIZER_NULL;
   }
   cJSON* json_obj = cJSON_Parse(obj);
@@ -745,7 +745,7 @@ status_t send_mam_req_deserialize(const char* const obj, ta_send_mam_req_t* req)
 
   if (json_obj == NULL) {
     ret = SC_SERIALIZER_JSON_PARSE;
-    log_error(seri_logger_id, "[%s:%d:%s]\n", __func__, __LINE__, "SC_SERIALIZER_JSON_PARSE");
+    ta_log_error("%s\n", "SC_SERIALIZER_JSON_PARSE");
     goto done;
   }
 
@@ -755,7 +755,7 @@ status_t send_mam_req_deserialize(const char* const obj, ta_send_mam_req_t* req)
 
     if (prng_size != NUM_TRYTES_HASH) {
       ret = SC_SERIALIZER_INVALID_REQ;
-      log_error(seri_logger_id, "[%s:%d:%s]\n", __func__, __LINE__, "SC_SERIALIZER_INVALID_REQ");
+      ta_log_error("%s\n", "SC_SERIALIZER_INVALID_REQ");
       goto done;
     }
     snprintf((char*)req->prng, prng_size + 1, "%s", json_result->valuestring);
@@ -771,7 +771,7 @@ status_t send_mam_req_deserialize(const char* const obj, ta_send_mam_req_t* req)
     for (size_t i = 0; i < payload_size; i++) {
       if (json_result->valuestring[i] & 0x80) {
         ret = SC_SERIALIZER_JSON_PARSE_ASCII;
-        log_error(seri_logger_id, "[%s:%d:%s]\n", __func__, __LINE__, "SC_SERIALIZER_JSON_PARSE_ASCII");
+        ta_log_error("%s\n", "SC_SERIALIZER_JSON_PARSE_ASCII");
         goto done;
       }
     }
@@ -779,7 +779,7 @@ status_t send_mam_req_deserialize(const char* const obj, ta_send_mam_req_t* req)
     snprintf(payload, payload_size + 1, "%s", json_result->valuestring);
     req->payload = payload;
   } else {
-    log_error(seri_logger_id, "[%s:%d:%s]\n", __func__, __LINE__, "SC_SERIALIZER_NULL");
+    ta_log_error("%s\n", "SC_SERIALIZER_NULL");
     ret = SC_SERIALIZER_NULL;
   }
 
@@ -798,7 +798,7 @@ done:
 
 status_t mqtt_device_id_deserialize(const char* const obj, char* device_id) {
   if (obj == NULL) {
-    log_error(seri_logger_id, "[%s:%d:%s]\n", __func__, __LINE__, "SC_SERIALIZER_NULL");
+    ta_log_error("%s\n", "SC_SERIALIZER_NULL");
     return SC_SERIALIZER_NULL;
   }
   status_t ret = SC_OK;
@@ -806,13 +806,13 @@ status_t mqtt_device_id_deserialize(const char* const obj, char* device_id) {
 
   if (json_obj == NULL) {
     ret = SC_SERIALIZER_JSON_PARSE;
-    log_error(seri_logger_id, "[%s:%d:%s]\n", __func__, __LINE__, "SC_SERIALIZER_JSON_PARSE");
+    ta_log_error("%s\n", "SC_SERIALIZER_JSON_PARSE");
     goto done;
   }
 
   ret = ta_json_get_string(json_obj, "device_id", device_id);
   if (ret != SC_OK) {
-    log_error(seri_logger_id, "[%s:%d]\n", __func__, __LINE__);
+    ta_log_error("%d\n", ret);
   }
 
 done:
@@ -822,7 +822,7 @@ done:
 
 status_t mqtt_tag_req_deserialize(const char* const obj, char* tag) {
   if (obj == NULL) {
-    log_error(seri_logger_id, "[%s:%d:%s]\n", __func__, __LINE__, "SC_SERIALIZER_NULL");
+    ta_log_error("%s\n", "SC_SERIALIZER_NULL");
     return SC_SERIALIZER_NULL;
   }
   status_t ret = SC_OK;
@@ -830,13 +830,13 @@ status_t mqtt_tag_req_deserialize(const char* const obj, char* tag) {
 
   if (json_obj == NULL) {
     ret = SC_SERIALIZER_JSON_PARSE;
-    log_error(seri_logger_id, "[%s:%d:%s]\n", __func__, __LINE__, "SC_SERIALIZER_JSON_PARSE");
+    ta_log_error("%s\n", "SC_SERIALIZER_JSON_PARSE");
     goto done;
   }
 
   ret = ta_json_get_string(json_obj, "tag", tag);
   if (ret != SC_OK) {
-    log_error(seri_logger_id, "[%s:%d]\n", __func__, __LINE__);
+    ta_log_error("%d\n", ret);
   }
 
 done:
@@ -846,7 +846,7 @@ done:
 
 status_t mqtt_transaction_hash_req_deserialize(const char* const obj, char* hash) {
   if (obj == NULL) {
-    log_error(seri_logger_id, "[%s:%d:%s]\n", __func__, __LINE__, "SC_SERIALIZER_NULL");
+    ta_log_error("%s\n", "SC_SERIALIZER_NULL");
     return SC_SERIALIZER_NULL;
   }
   status_t ret = SC_OK;
@@ -854,13 +854,13 @@ status_t mqtt_transaction_hash_req_deserialize(const char* const obj, char* hash
 
   if (json_obj == NULL) {
     ret = SC_SERIALIZER_JSON_PARSE;
-    log_error(seri_logger_id, "[%s:%d:%s]\n", __func__, __LINE__, "SC_SERIALIZER_JSON_PARSE");
+    ta_log_error("%s\n", "SC_SERIALIZER_JSON_PARSE");
     goto done;
   }
 
   ret = ta_json_get_string(json_obj, "hash", hash);
   if (ret != SC_OK) {
-    log_error(seri_logger_id, "[%s:%d]\n", __func__, __LINE__);
+    ta_log_error("%d\n", ret);
   }
 
 done:

--- a/utils/backend_redis.c
+++ b/utils/backend_redis.c
@@ -20,18 +20,18 @@ typedef struct {
 
 static cache_t cache;
 static bool cache_state;
-static logger_id_t br_logger_id;
+static logger_id_t logger_id;
 
 /*
  * Private functions
  */
 
-void br_logger_init() { br_logger_id = logger_helper_enable(BR_LOGGER, LOGGER_DEBUG, true); }
+void br_logger_init() { logger_id = logger_helper_enable(BR_LOGGER, LOGGER_DEBUG, true); }
 
 int br_logger_release() {
-  logger_helper_release(br_logger_id);
+  logger_helper_release(logger_id);
   if (logger_helper_destroy() != RC_OK) {
-    log_critical(br_logger_id, "[%s:%d] Destroying logger failed %s.\n", __func__, __LINE__, BR_LOGGER);
+    ta_log_critical("Destroying logger failed %s.\n", BR_LOGGER);
     return EXIT_FAILURE;
   }
 
@@ -41,14 +41,14 @@ int br_logger_release() {
 static status_t redis_del(redisContext* c, const char* const key) {
   status_t ret = SC_OK;
   if (key == NULL) {
-    log_error(br_logger_id, "[%s:%d:%s]\n", __func__, __LINE__, "SC_CACHE_NULL");
+    ta_log_error("%s\n", "SC_CACHE_NULL");
     return SC_CACHE_NULL;
   }
 
   redisReply* reply = redisCommand(c, "DEL %s", key);
   if (!reply->integer) {
     ret = SC_CACHE_FAILED_RESPONSE;
-    log_error(br_logger_id, "[%s:%d:%s]\n", __func__, __LINE__, "SC_CACHE_FAILED_RESPONSE");
+    ta_log_error("%s\n", "SC_CACHE_FAILED_RESPONSE");
   }
 
   freeReplyObject(reply);
@@ -58,7 +58,7 @@ static status_t redis_del(redisContext* c, const char* const key) {
 static status_t redis_get(redisContext* c, const char* const key, char* res) {
   status_t ret = SC_OK;
   if (key == NULL || res[0] != '\0') {
-    log_error(br_logger_id, "[%s:%d:%s]\n", __func__, __LINE__, "SC_CACHE_NULL");
+    ta_log_error("%s\n", "SC_CACHE_NULL");
     return SC_CACHE_NULL;
   }
 
@@ -67,7 +67,7 @@ static status_t redis_get(redisContext* c, const char* const key, char* res) {
     strncpy(res, reply->str, FLEX_TRIT_SIZE_8019);
   } else {
     ret = SC_CACHE_FAILED_RESPONSE;
-    log_error(br_logger_id, "[%s:%d:%s]\n", __func__, __LINE__, "SC_CACHE_FAILED_RESPONSE");
+    ta_log_error("%s\n", "SC_CACHE_FAILED_RESPONSE");
   }
 
   freeReplyObject(reply);
@@ -77,14 +77,14 @@ static status_t redis_get(redisContext* c, const char* const key, char* res) {
 static status_t redis_set(redisContext* c, const char* const key, const char* const value) {
   status_t ret = SC_OK;
   if (key == NULL || value == NULL) {
-    log_error(br_logger_id, "[%s:%d:%s]\n", __func__, __LINE__, "SC_CACHE_NULL");
+    ta_log_error("%s\n", "SC_CACHE_NULL");
     return SC_CACHE_NULL;
   }
 
   redisReply* reply = redisCommand(c, "SETNX %b %b", key, FLEX_TRIT_SIZE_243, value, FLEX_TRIT_SIZE_8019);
   if (!reply->integer) {
     ret = SC_CACHE_FAILED_RESPONSE;
-    log_error(br_logger_id, "[%s:%d:%s]\n", __func__, __LINE__, "SC_CACHE_FAILED_RESPONSE");
+    ta_log_error("%s\n", "SC_CACHE_FAILED_RESPONSE");
   }
 
   freeReplyObject(reply);
@@ -121,7 +121,7 @@ void cache_stop() {
 
 status_t cache_del(const char* const key) {
   if (!cache_state) {
-    log_error(br_logger_id, "[%s:%d:%s]\n", __func__, __LINE__, "SC_CACHE_OFF");
+    ta_log_error("%s\n", "SC_CACHE_OFF");
     return SC_CACHE_OFF;
   }
   return redis_del(CONN(cache)->rc, key);
@@ -129,7 +129,7 @@ status_t cache_del(const char* const key) {
 
 status_t cache_get(const char* const key, char* res) {
   if (!cache_state) {
-    log_error(br_logger_id, "[%s:%d:%s]\n", __func__, __LINE__, "SC_CACHE_OFF");
+    ta_log_error("%s\n", "SC_CACHE_OFF");
     return SC_CACHE_OFF;
   }
   return redis_get(CONN(cache)->rc, key, res);
@@ -137,7 +137,7 @@ status_t cache_get(const char* const key, char* res) {
 
 status_t cache_set(const char* const key, const char* const value) {
   if (!cache_state) {
-    log_error(br_logger_id, "[%s:%d:%s]\n", __func__, __LINE__, "SC_CACHE_OFF");
+    ta_log_error("%s\n", "SC_CACHE_OFF");
     return SC_CACHE_OFF;
   }
   return redis_set(CONN(cache)->rc, key, value);

--- a/utils/pow.c
+++ b/utils/pow.c
@@ -14,14 +14,14 @@
 
 #define POW_LOGGER "pow"
 
-static logger_id_t pow_logger_id;
+static logger_id_t logger_id;
 
-void pow_logger_init() { pow_logger_id = logger_helper_enable(POW_LOGGER, LOGGER_DEBUG, true); }
+void pow_logger_init() { logger_id = logger_helper_enable(POW_LOGGER, LOGGER_DEBUG, true); }
 
 int pow_logger_release() {
-  logger_helper_release(pow_logger_id);
+  logger_helper_release(logger_id);
   if (logger_helper_destroy() != RC_OK) {
-    log_critical(pow_logger_id, "[%s:%d] Destroying logger failed %s.\n", __func__, __LINE__, POW_LOGGER);
+    ta_log_critical("Destroying logger failed %s.\n", POW_LOGGER);
     return EXIT_FAILURE;
   }
 
@@ -65,7 +65,7 @@ status_t ta_pow(const bundle_transactions_t* bundle, const flex_trit_t* const tr
   tx = (iota_transaction_t*)utarray_back(bundle);
   if (tx == NULL) {
     ret = SC_TA_NULL;
-    log_error(pow_logger_id, "[%s:%d:%s]\n", __func__, __LINE__, "SC_TA_NULL");
+    ta_log_error("%s\n", "SC_TA_NULL");
     goto done;
   }
   cur_idx = transaction_last_index(tx) + 1;
@@ -83,7 +83,7 @@ status_t ta_pow(const bundle_transactions_t* bundle, const flex_trit_t* const tr
     transaction_serialize_on_flex_trits(tx, tx_trits);
     if (tx_trits == NULL) {
       ret = SC_CCLIENT_INVALID_FLEX_TRITS;
-      log_error(pow_logger_id, "[%s:%d:%s]\n", __func__, __LINE__, "SC_CCLIENT_INVALID_FLEX_TRITS");
+      ta_log_error("%s\n", "SC_CCLIENT_INVALID_FLEX_TRITS");
       goto done;
     }
 
@@ -91,7 +91,7 @@ status_t ta_pow(const bundle_transactions_t* bundle, const flex_trit_t* const tr
     flex_trit_t* nonce = ta_pow_flex(tx_trits, mwm);
     if (nonce == NULL) {
       ret = SC_TA_OOM;
-      log_error(pow_logger_id, "[%s:%d:%s]\n", __func__, __LINE__, "SC_TA_OOM");
+      ta_log_error("%s\n", "SC_TA_OOM");
       goto done;
     }
     transaction_set_nonce(tx, nonce);


### PR DESCRIPTION
The previous logger function (e.g., `log_error()`) we used to log message
was too troublesome. With this commit, it will be more convenient to
log message by `ta_log_xxx()`. (e.g., `ta_log_error()`)