### PR TITLE
fix(server): Apply pause() to wait signal for termination in MHD

### DIFF
--- a/accelerator/http.c
+++ b/accelerator/http.c
@@ -374,7 +374,6 @@ status_t ta_http_init(ta_http_t *const http, ta_core_t *const core) {
   }
 
   http->core = core;
-  http->running = false;
   return SC_OK;
 }
 
@@ -391,7 +390,6 @@ status_t ta_http_start(ta_http_t *const http) {
     ta_log_error("%s\n", "SC_HTTP_OOM");
     return SC_HTTP_OOM;
   }
-  http->running = true;
   return SC_OK;
 }
 
@@ -402,6 +400,5 @@ status_t ta_http_stop(ta_http_t *const http) {
   }
 
   MHD_stop_daemon(http->daemon);
-  http->running = false;
   return SC_OK;
 }

--- a/accelerator/http.h
+++ b/accelerator/http.h
@@ -12,7 +12,6 @@ extern "C" {
 #endif
 
 typedef struct ta_http_s {
-  bool running;
   void *daemon;
   ta_core_t *core;
 } ta_http_t;

--- a/accelerator/main.c
+++ b/accelerator/main.c
@@ -1,3 +1,5 @@
+#include <errno.h>
+
 #include "accelerator/errors.h"
 #include "accelerator/http.h"
 #include "utils/handles/signal.h"
@@ -73,8 +75,14 @@ int main(int argc, char* argv[]) {
   }
 
   log_warning(logger_id, "Tangle-accelerator starts running\n");
-  while (ta_http.running) {
-    ;
+
+  /* pause() cause TA to sleep until it catch a signal,
+   * also the return value and errno should be -1 and EINTR on success.
+   */
+  int sig_ret = pause();
+  if (sig_ret == -1 && errno != EINTR) {
+    ta_log_error("Signal caught failed %s.\n", MAIN_LOGGER);
+    return EXIT_FAILURE;
   }
 
 cleanup:


### PR DESCRIPTION
The infinite loop in `accelerator/main.c` costs high CPU usage while launching, this could be replaced with `getchar()`.