### PR TITLE
Implement importer for historical data, listener for new data

### DIFF
--- a/accelerator/errors.h
+++ b/accelerator/errors.h
@@ -255,6 +255,8 @@ typedef enum {
   /**< Fail to execute Cassandra query   */
   SC_STORAGE_SYNC_ERROR = 0x05 | SC_MODULE_STORAGE | SC_SEVERITY_MAJOR,
   /**< ZeroMQ process error   */
+  SC_STORAGE_OPEN_ERROR = 0x06 | SC_MODULE_STORAGE | SC_SEVERITY_FATAL,
+  /**< fail to open file */
 
 } status_t;
 

--- a/storage/BUILD
+++ b/storage/BUILD
@@ -15,3 +15,22 @@ cc_library(
         "//accelerator:ta_errors",
     ],
 )
+
+cc_binary(
+    name = "listener",
+    srcs = ["scylla_listener.c"],
+    linkopts = [
+        "-lzmq",
+    ],
+    deps = [
+        ":storage",
+    ],
+)
+
+cc_binary(
+    name = "importer",
+    srcs = ["scylla_importer.c"],
+    deps = [
+        ":storage",
+    ],
+)

--- a/storage/scylla_api.c
+++ b/storage/scylla_api.c
@@ -229,10 +229,13 @@ static void print_error(CassFuture* future) {
   cass_future_error_message(future, &message, &message_length);
   ta_log_error("Error: %.*s\n", (int)message_length, message);
 }
-
-static CassCluster* create_cluster(const char* hosts) {
+/* set port <= 0 to use default port */
+static CassCluster* create_cluster(const char* hosts, int port) {
   CassCluster* cluster = cass_cluster_new();
   cass_cluster_set_contact_points(cluster, hosts);
+  if (port > 0) {
+    cass_cluster_set_port(cluster, port);
+  }
   return cluster;
 }
 
@@ -403,7 +406,7 @@ static status_t create_edge_table(CassSession* session) {
 exit:
   return ret;
 }
-status_t init_scylla(CassCluster** cluster, CassSession* session, char* hosts, bool is_need_create_table,
+status_t init_scylla(CassCluster** cluster, CassSession* session, char* hosts, int port, bool is_need_create_table,
                      const char* keyspace_name) {
   if (hosts == NULL) {
     ta_log_error("%s\n", "SC_TA_NULL");
@@ -413,7 +416,7 @@ status_t init_scylla(CassCluster** cluster, CassSession* session, char* hosts, b
   CassStatement* use_statement = NULL;
   char* use_query = NULL;
   /* Add contact points */
-  *cluster = create_cluster(hosts);
+  *cluster = create_cluster(hosts, port);
   if (connect_session(session, *cluster) != CASS_OK) {
     ta_log_error("%s\n", "connect Scylla cluster fail");
     ret = SC_STORAGE_CONNECT_FAIL;

--- a/storage/scylla_api.c
+++ b/storage/scylla_api.c
@@ -358,12 +358,14 @@ static status_t create_permanent_keyspace(CassSession* session, const char* keys
   return ret;
 }
 
-static status_t create_bundle_table(CassSession* session) {
+static status_t create_bundle_table(CassSession* session, bool is_need_drop_table) {
   status_t ret = SC_OK;
-  if (execute_query(session, "DROP TABLE IF EXISTS bundleTable;") != CASS_OK) {
-    ta_log_error("%s\n", "SC_STORAGE_CASSANDRA_QUREY_FAIL");
-    ret = SC_STORAGE_CASSANDRA_QUREY_FAIL;
-    goto exit;
+  if (is_need_drop_table == true) {
+    if (execute_query(session, "DROP TABLE IF EXISTS bundleTable;") != CASS_OK) {
+      ta_log_error("%s\n", "SC_STORAGE_CASSANDRA_QUREY_FAIL");
+      ret = SC_STORAGE_CASSANDRA_QUREY_FAIL;
+      goto exit;
+    }
   }
   if (execute_query(session,
                     "CREATE TABLE IF NOT EXISTS bundleTable ("
@@ -384,12 +386,14 @@ exit:
   return ret;
 }
 
-static status_t create_edge_table(CassSession* session) {
+static status_t create_edge_table(CassSession* session, bool is_need_drop_table) {
   status_t ret = SC_OK;
-  if (execute_query(session, "DROP TABLE IF EXISTS edgeTable;") != CASS_OK) {
-    ta_log_error("%s\n", "SC_STORAGE_CASSANDRA_QUREY_FAIL");
-    ret = SC_STORAGE_CASSANDRA_QUREY_FAIL;
-    goto exit;
+  if (is_need_drop_table == true) {
+    if (execute_query(session, "DROP TABLE IF EXISTS edgeTable;") != CASS_OK) {
+      ta_log_error("%s\n", "SC_STORAGE_CASSANDRA_QUREY_FAIL");
+      ret = SC_STORAGE_CASSANDRA_QUREY_FAIL;
+      goto exit;
+    }
   }
   if (execute_query(session,
                     "CREATE TABLE IF NOT EXISTS edgeTable("
@@ -406,7 +410,7 @@ static status_t create_edge_table(CassSession* session) {
 exit:
   return ret;
 }
-status_t init_scylla(CassCluster** cluster, CassSession* session, char* hosts, int port, bool is_need_create_table,
+status_t init_scylla(CassCluster** cluster, CassSession* session, char* hosts, int port, bool is_need_drop_table,
                      const char* keyspace_name) {
   if (hosts == NULL) {
     ta_log_error("%s\n", "SC_TA_NULL");
@@ -438,15 +442,13 @@ status_t init_scylla(CassCluster** cluster, CassSession* session, char* hosts, i
     goto exit;
   }
 
-  if (is_need_create_table == true) {
-    if ((ret = create_bundle_table(session)) != SC_OK) {
-      ta_log_error("%s\n", "create bundle table fail");
-      goto exit;
-    }
-    if ((ret = create_edge_table(session)) != SC_OK) {
-      ta_log_error("%s\n", "create edge table fail");
-      goto exit;
-    }
+  if ((ret = create_bundle_table(session, is_need_drop_table)) != SC_OK) {
+    ta_log_error("%s\n", "create bundle table fail");
+    goto exit;
+  }
+  if ((ret = create_edge_table(session, is_need_drop_table)) != SC_OK) {
+    ta_log_error("%s\n", "create edge table fail");
+    goto exit;
   }
 
 exit:

--- a/storage/scylla_api.h
+++ b/storage/scylla_api.h
@@ -240,14 +240,14 @@ int scylla_api_logger_release();
  * @param[out] session Scylla cluster session
  * @param[in] hosts Scylla cluster entry ip
  * @param[in] port scylla cluster entry port, set <= 0 as default
- * @param[in] is_need_create_table true : create, false : not to create
+ * @param[in] is_need_create_table true : drop exist table, false : do not drop
  * @param[in] keyspace_name keyspace name the session should use
  *
  * @return
  * - SC_OK on success
  * - non-zero on error
  */
-status_t init_scylla(CassCluster** cluster, CassSession* session, char* hosts, int port, bool is_need_create_table,
+status_t init_scylla(CassCluster** cluster, CassSession* session, char* hosts, int port, bool is_need_drop_table,
                      const char* keyspace_name);
 
 /**

--- a/storage/scylla_api.h
+++ b/storage/scylla_api.h
@@ -238,7 +238,8 @@ int scylla_api_logger_release();
  *
  * @param[out] cluster Scylla node cluster
  * @param[out] session Scylla cluster session
- * @param[in] hosts Scylla node ip
+ * @param[in] hosts Scylla cluster entry ip
+ * @param[in] port scylla cluster entry port, set <= 0 as default
  * @param[in] is_need_create_table true : create, false : not to create
  * @param[in] keyspace_name keyspace name the session should use
  *
@@ -246,7 +247,7 @@ int scylla_api_logger_release();
  * - SC_OK on success
  * - non-zero on error
  */
-status_t init_scylla(CassCluster** cluster, CassSession* session, char* hosts, bool is_need_create_table,
+status_t init_scylla(CassCluster** cluster, CassSession* session, char* hosts, int port, bool is_need_create_table,
                      const char* keyspace_name);
 
 /**

--- a/storage/scylla_importer.c
+++ b/storage/scylla_importer.c
@@ -1,0 +1,132 @@
+/*
+ * Copyright (C) 2019 BiiLabs Co., Ltd. and Contributors
+ * All Rights Reserved.
+ * This is free software; you can redistribute it and/or modify it under the
+ * terms of the MIT license. A copy of the license can be found in the file
+ * "LICENSE" at the root of this distribution.
+ */
+#include <getopt.h>
+#include "scylla_api.h"
+
+#define SCYLLA_IMPORTER_LOGGER "SCYLLA_IMPORTER"
+
+static logger_id_t logger_id;
+void scylla_importer_logger_init() { logger_id = logger_helper_enable(SCYLLA_IMPORTER_LOGGER, LOGGER_DEBUG, true); }
+
+int scylla_importer_logger_release() {
+  logger_helper_release(logger_id);
+  if (logger_helper_destroy() != RC_OK) {
+    log_critical(logger_id, "%s.\n", SCYLLA_IMPORTER_LOGGER);
+    return EXIT_FAILURE;
+  }
+  return 0;
+}
+
+static status_t import_historical_data(CassSession* session, char* file_path) {
+  /* The format of each line in dump files is HASH,MessageAddressTagBundleTrunkBranchNonce */
+#define BUFFER_SIZE                                                                                  \
+  (NUM_FLEX_TRITS_HASH + 1 + NUM_FLEX_TRITS_MESSAGE + NUM_FLEX_TRITS_ADDRESS + NUM_FLEX_TRITS_HASH + \
+   NUM_FLEX_TRITS_BUNDLE + NUM_FLEX_TRITS_TRUNK + NUM_FLEX_TRITS_BRANCH + FLEX_TRIT_SIZE_243 + 2)
+  status_t ret = SC_OK;
+  FILE* file = NULL;
+  char* input_buffer = malloc(BUFFER_SIZE * sizeof(char));
+  scylla_iota_transaction_t* transaction;
+
+  int buf_idx;
+
+  if (input_buffer == NULL) {
+    ta_log_error("%s\n", "SC_STORAGE_OOM");
+    ret = SC_STORAGE_OOM;
+    goto exit;
+  }
+  if (new_scylla_iota_transaction(&transaction) != SC_OK) {
+    ta_log_error("%s\n", "SC_STORAGE_OOM");
+    ret = SC_STORAGE_OOM;
+    goto exit;
+  }
+  if ((file = fopen(file_path, "r")) == NULL) {
+    /* The specified configuration file does not exist */
+    ret = SC_STORAGE_OPEN_ERROR;
+    ta_log_error("%s\n", "SC_STORAGE_OPEN_ERROR");
+    goto exit;
+  }
+
+  while (fgets(input_buffer, BUFFER_SIZE, file) != NULL) {
+    puts(input_buffer);
+    if (input_buffer[strlen(input_buffer) - 1] != '\n') {
+      ret = SC_STORAGE_INVAILD_INPUT;
+      ta_log_error("%s\n", "historical dump file format error");
+      goto exit;
+    }
+    buf_idx = 0;
+    set_transaction_hash(transaction, (cass_byte_t*)(input_buffer + buf_idx), NUM_FLEX_TRITS_HASH);
+    buf_idx += NUM_FLEX_TRITS_HASH + 1;
+    set_transaction_message(transaction, (cass_byte_t*)(input_buffer + buf_idx), NUM_FLEX_TRITS_MESSAGE);
+    buf_idx += NUM_FLEX_TRITS_MESSAGE;
+    set_transaction_address(transaction, (cass_byte_t*)(input_buffer + buf_idx), NUM_FLEX_TRITS_ADDRESS);
+    buf_idx += NUM_FLEX_TRITS_ADDRESS;
+    /* skip tag */
+    buf_idx += NUM_FLEX_TRITS_HASH;
+    set_transaction_bundle(transaction, (cass_byte_t*)(input_buffer + buf_idx), NUM_FLEX_TRITS_BUNDLE);
+    buf_idx += NUM_FLEX_TRITS_BUNDLE;
+    set_transaction_trunk(transaction, (cass_byte_t*)(input_buffer + buf_idx), NUM_FLEX_TRITS_TRUNK);
+    buf_idx += NUM_FLEX_TRITS_TRUNK;
+    set_transaction_branch(transaction, (cass_byte_t*)(input_buffer + buf_idx), NUM_FLEX_TRITS_BRANCH);
+    set_transaction_timestamp(transaction, 0);
+    set_transaction_value(transaction, 0);
+
+    insert_transaction_into_bundleTable(session, transaction, 1);
+    insert_transaction_into_edgeTable(session, transaction, 1);
+  }
+
+exit:
+  free(input_buffer);
+  return ret;
+}
+
+int main(int argc, char* argv[]) {
+  CassCluster* cluster = NULL;
+  CassSession* session = cass_session_new();
+  char* scylla_host = NULL;
+  int cmdOpt;
+  int optIdx;
+  char* file_path = NULL;
+  const struct option longOpt[] = {
+      {"scylla_host", required_argument, NULL, 's'}, {"file", required_argument, NULL, 'f'}, {NULL, 0, NULL, 0}};
+
+  /* Parse the command line options */
+  while (1) {
+    cmdOpt = getopt_long(argc, argv, "sf:", longOpt, &optIdx);
+    if (cmdOpt == -1) break;
+
+    /* Invalid option */
+    if (cmdOpt == '?') break;
+
+    if (cmdOpt == 's') {
+      scylla_host = optarg;
+    }
+    if (cmdOpt == 'f') {
+      file_path = optarg;
+    }
+  }
+  if (scylla_host == NULL || file_path == NULL) {
+    ta_log_error("%s\n", "TA_NULL");
+    return 0;
+  }
+  if (logger_helper_init(LOGGER_ERR) != RC_OK) {
+    return 0;
+  }
+  scylla_api_logger_init();
+  scylla_importer_logger_init();
+
+  /* setting Scylla */
+  init_scylla(&cluster, session, scylla_host, false, "zmq_table");
+  import_historical_data(session, file_path);
+
+  cass_cluster_free(cluster);
+  cass_session_free(session);
+  scylla_api_logger_release();
+  scylla_importer_logger_release();
+
+  return 0;
+}

--- a/storage/scylla_listener.c
+++ b/storage/scylla_listener.c
@@ -84,6 +84,7 @@ int main(int argc, char* argv[]) {
   CassCluster* cluster = NULL;
   CassSession* session = cass_session_new();
   char* scylla_host = NULL;
+  int scylla_port = 0;
   char* iri_host = IRI_HOST;
   uint16_t iri_port = IRI_PORT;
   char* zmq_server = NULL;
@@ -94,15 +95,14 @@ int main(int argc, char* argv[]) {
   char tx_buffer[NUM_FLEX_TRITS_HASH + 1];
   int cmdOpt;
   int optIdx;
-  const struct option longOpt[] = {{"scylla_host", required_argument, NULL, 's'},
-                                   {"zmq_server", required_argument, NULL, 'z'},
-                                   {"iri_host", required_argument, NULL, 'i'},
-                                   {"iri_port", required_argument, NULL, 'p'},
-                                   {NULL, 0, NULL, 0}};
+  const struct option longOpt[] = {
+      {"scylla_host", required_argument, NULL, 's'}, {"scylla_port", required_argument, NULL, 'x'},
+      {"zmq_server", required_argument, NULL, 'z'},  {"iri_host", required_argument, NULL, 'i'},
+      {"iri_port", required_argument, NULL, 'p'},    {NULL, 0, NULL, 0}};
 
   /* Parse the command line options */
   while (1) {
-    cmdOpt = getopt_long(argc, argv, "sizp:", longOpt, &optIdx);
+    cmdOpt = getopt_long(argc, argv, "sizpx:", longOpt, &optIdx);
     if (cmdOpt == -1) break;
 
     /* Invalid option */
@@ -110,6 +110,9 @@ int main(int argc, char* argv[]) {
 
     if (cmdOpt == 's') {
       scylla_host = optarg;
+    }
+    if (cmdOpt == 'x') {
+      scylla_port = atoi(optarg);
     }
     if (cmdOpt == 'i') {
       iri_host = optarg;
@@ -139,7 +142,7 @@ int main(int argc, char* argv[]) {
   init_iri_client_service(&iri_serv, iri_host, iri_port);
 
   /* setting Scylla */
-  init_scylla(&cluster, session, scylla_host, true, "zmq_table");
+  init_scylla(&cluster, session, scylla_host, scylla_port, true, "zmq_table");
 
   /* setting ZeroMQ */
   void* context = zmq_ctx_new();

--- a/storage/scylla_listener.c
+++ b/storage/scylla_listener.c
@@ -1,0 +1,199 @@
+/*
+ * Copyright (C) 2019 BiiLabs Co., Ltd. and Contributors
+ * All Rights Reserved.
+ * This is free software; you can redistribute it and/or modify it under the
+ * terms of the MIT license. A copy of the license can be found in the file
+ * "LICENSE" at the root of this distribution.
+ */
+#include <zmq.h>
+#include "accelerator/config.h"
+#include "cclient/service.h"
+#include "scylla_api.h"
+
+#define SCYLLA_LISTENER_LOGGER "SCYLLA_LISTENER"
+
+static logger_id_t logger_id;
+void scylla_listener_logger_init() { logger_id = logger_helper_enable(SCYLLA_LISTENER_LOGGER, LOGGER_DEBUG, true); }
+
+int scylla_listener_logger_release() {
+  logger_helper_release(logger_id);
+  if (logger_helper_destroy() != RC_OK) {
+    log_critical(logger_id, "%s.\n", SCYLLA_LISTENER_LOGGER);
+    return EXIT_FAILURE;
+  }
+  return 0;
+}
+
+//  Receive ZMQ string from socket and convert into C string
+//  Caller must free returned string. Returns NULL if the context
+//  is being terminated.
+static char* receive_zmq_string_to_heap(void* socket) {
+#define BUFFER_LEN 450
+  char buffer[BUFFER_LEN];
+
+  int size = zmq_recv(socket, buffer, BUFFER_LEN - 1, 0);
+  if (size == -1) {
+    return NULL;
+  }
+  if (size < BUFFER_LEN) {
+    buffer[size] = '\0';
+  }
+
+  return strndup(buffer, sizeof(buffer) - 1);
+}
+
+static void init_iri_client_service(iota_client_service_t* const serv, char const* const host, uint16_t const port) {
+  serv->http.path = "/";
+  serv->http.content_type = "application/json";
+  serv->http.accept = "application/json";
+  serv->http.host = host;
+  serv->http.port = port;
+  serv->http.api_version = 1;
+  serv->http.ca_pem = NULL;
+  serv->serializer_type = SR_JSON;
+  iota_client_core_init(serv);
+}
+
+static status_t insert_tx_objs_into_ScyllaDB(CassSession* session, transaction_array_t* const transactions,
+                                             scylla_iota_transaction_t* trans) {
+  status_t ret = SC_OK;
+  iota_transaction_t* curr_tx = NULL;
+  TX_OBJS_FOREACH(transactions, curr_tx) {
+    set_transaction_bundle(trans, (cass_byte_t*)curr_tx->essence.bundle, NUM_FLEX_TRITS_BUNDLE);
+    set_transaction_address(trans, (cass_byte_t*)curr_tx->essence.address, NUM_FLEX_TRITS_ADDRESS);
+    set_transaction_hash(trans, (cass_byte_t*)curr_tx->consensus.hash, NUM_FLEX_TRITS_HASH);
+    set_transaction_trunk(trans, (cass_byte_t*)curr_tx->attachment.trunk, NUM_FLEX_TRITS_TRUNK);
+    set_transaction_branch(trans, (cass_byte_t*)curr_tx->attachment.branch, NUM_FLEX_TRITS_BRANCH);
+    set_transaction_message(trans, (cass_byte_t*)curr_tx->data.signature_or_message, NUM_FLEX_TRITS_MESSAGE);
+    set_transaction_value(trans, curr_tx->essence.value);
+    set_transaction_timestamp(trans, curr_tx->essence.timestamp);
+    if ((ret = insert_transaction_into_bundleTable(session, trans, 1)) != SC_OK) {
+      goto exit;
+    }
+    if ((ret = insert_transaction_into_edgeTable(session, trans, 1)) != SC_OK) {
+      goto exit;
+    }
+  }
+
+exit:
+  return ret;
+}
+
+int main(int argc, char* argv[]) {
+  status_t ret = SC_OK;
+  CassCluster* cluster = NULL;
+  CassSession* session = cass_session_new();
+  char* scylla_host = NULL;
+  char* iri_host = IRI_HOST;
+  uint16_t iri_port = IRI_PORT;
+  char* zmq_server = NULL;
+  iota_client_service_t iri_serv;
+  retcode_t ret_code;
+
+  scylla_iota_transaction_t* transaction;
+  char tx_buffer[NUM_FLEX_TRITS_HASH + 1];
+  int cmdOpt;
+  int optIdx;
+  const struct option longOpt[] = {{"scylla_host", required_argument, NULL, 's'},
+                                   {"zmq_server", required_argument, NULL, 'z'},
+                                   {"iri_host", required_argument, NULL, 'i'},
+                                   {"iri_port", required_argument, NULL, 'p'},
+                                   {NULL, 0, NULL, 0}};
+
+  /* Parse the command line options */
+  while (1) {
+    cmdOpt = getopt_long(argc, argv, "sizp:", longOpt, &optIdx);
+    if (cmdOpt == -1) break;
+
+    /* Invalid option */
+    if (cmdOpt == '?') break;
+
+    if (cmdOpt == 's') {
+      scylla_host = optarg;
+    }
+    if (cmdOpt == 'i') {
+      iri_host = optarg;
+    }
+    if (cmdOpt == 'p') {
+      iri_port = atoi(optarg);
+    }
+    if (cmdOpt == 'z') {
+      zmq_server = optarg;
+    }
+  }
+  if (scylla_host == NULL || zmq_server == NULL) {
+    ta_log_error("%s\n", "must specify options --scylla_host  --zmq_server");
+    return -1;
+  }
+  if (logger_helper_init(LOGGER_ERR) != RC_OK) {
+    return -1;
+  }
+  scylla_api_logger_init();
+  scylla_listener_logger_init();
+  if (new_scylla_iota_transaction(&transaction) != SC_OK) {
+    ta_log_error("%s\n", "new_scylla_iota_transaction fail");
+    return -1;
+  }
+
+  /* setting IRI */
+  init_iri_client_service(&iri_serv, iri_host, iri_port);
+
+  /* setting Scylla */
+  init_scylla(&cluster, session, scylla_host, true, "zmq_table");
+
+  /* setting ZeroMQ */
+  void* context = zmq_ctx_new();
+  void* subscriber = zmq_socket(context, ZMQ_SUB);
+  if (zmq_connect(subscriber, zmq_server) != 0) {
+    goto exit;
+  }
+  if (zmq_setsockopt(subscriber, ZMQ_SUBSCRIBE, "sn", strlen("sn")) != 0) {
+    goto exit;
+  }
+  /* receiving IRI publication */
+  while (1) {
+    get_trytes_req_t* tx_req = get_trytes_req_new();
+    transaction_array_t* tx_objs = transaction_array_new();
+    int milestone_idx;
+    char* zmq_receive_string = receive_zmq_string_to_heap(subscriber);
+
+    sscanf(zmq_receive_string, "sn %d %s", &milestone_idx, tx_buffer);
+    if ((ret_code = hash243_queue_push(&tx_req->hashes, (flex_trit_t const* const)tx_buffer)) != RC_OK) {
+      ret = SC_STORAGE_OOM;
+      ta_log_error("%s\n", "SC_STORAGE_OOM");
+      goto loop_end;
+    }
+
+    if ((ret_code = iota_client_get_transaction_objects(&iri_serv, tx_req, tx_objs)) != RC_OK) {
+      ret = SC_STORAGE_SYNC_ERROR;
+      ta_log_error("%s\n", "SC_STORAGE_SYNC_ERROR");
+      goto loop_end;
+    }
+
+    if ((ret = insert_tx_objs_into_ScyllaDB(session, tx_objs, transaction)) != SC_OK) {
+      ta_log_alert("%s\n", "insert transaction fail\n");
+      goto loop_end;
+    }
+
+  loop_end:
+    free(zmq_receive_string);
+    get_trytes_req_free(&tx_req);
+    transaction_array_free(tx_objs);
+    if (ret != SC_OK) {
+      goto exit;
+    }
+  }
+
+exit:
+  free_scylla_iota_transaction(&transaction);
+  zmq_close(subscriber);
+  zmq_ctx_destroy(context);
+  cass_cluster_free(cluster);
+  cass_session_free(session);
+  scylla_api_logger_release();
+  scylla_listener_logger_release();
+  if (ret != SC_OK) {
+    return -1;
+  }
+  return 0;
+}

--- a/tests/test_scylla.c
+++ b/tests/test_scylla.c
@@ -123,7 +123,7 @@ void test_scylla(void) {
   size_t tx_num = sizeof(hashes) / (NUM_FLEX_TRITS_HASH);
   scylla_iota_transaction_t* transaction;
   TEST_ASSERT_NOT_EQUAL(host, NULL);
-  TEST_ASSERT_EQUAL_INT(init_scylla(&cluster, session, host, true, keyspace_name), SC_OK);
+  TEST_ASSERT_EQUAL_INT(init_scylla(&cluster, session, host, 0, true, keyspace_name), SC_OK);
   new_scylla_iota_transaction(&transaction);
 
   for (size_t i = 0; i < tx_num; i++) {


### PR DESCRIPTION
The importer will parse historical data from the specific dump file (option --file) and store into specific Scylla host (option --scylla_host)

The listener listen zmq "sn" event from specific IRI (option --zmq_server) then get full data from specific IRI (option -- iri_host) and store into specific Scylla host (option --scylla_host)