### PR TITLE
Apply security rules

### DIFF
--- a/connectivity/mqtt/BUILD
+++ b/connectivity/mqtt/BUILD
@@ -32,6 +32,7 @@ cc_library(
         "sub_utils.h",
     ],
     copts = ["-DENABLE_MQTT"],
+    visibility = ["//serializer:__pkg__"],
     deps = [
         "//accelerator:ta_config",
         "//accelerator:ta_errors",

--- a/connectivity/mqtt/duplex_callback.c
+++ b/connectivity/mqtt/duplex_callback.c
@@ -34,7 +34,7 @@ static status_t mqtt_request_handler(mosq_config_t *cfg, char *subscribe_topic, 
 
   status_t ret = SC_OK;
   char *json_result = NULL;
-  char device_id[ID_LEN];
+  char device_id[ID_LEN] = {0};
 
   // get the Device ID.
   ret = mqtt_device_id_deserialize(req, device_id);
@@ -49,11 +49,11 @@ static status_t mqtt_request_handler(mosq_config_t *cfg, char *subscribe_topic, 
     ret = api_generate_address(&ta_core.iconf, &ta_core.service, &json_result);
   } else if ((p = strstr(api_sub_topic, "tag"))) {
     if (!strncmp(p + 4, "hashes", 6)) {
-      char tag[NUM_TRYTES_TAG + 1];
+      char tag[NUM_TRYTES_TAG + 1] = {0};
       mqtt_tag_req_deserialize(req, tag);
       ret = api_find_transactions_by_tag(&ta_core.service, tag, &json_result);
     } else if (!strncmp(p + 4, "object", 6)) {
-      char tag[NUM_TRYTES_TAG + 1];
+      char tag[NUM_TRYTES_TAG + 1] = {0};
       mqtt_tag_req_deserialize(req, tag);
       ret = api_find_transactions_obj_by_tag(&ta_core.service, tag, &json_result);
     }

--- a/hooks/pre-commit/03-function-check
+++ b/hooks/pre-commit/03-function-check
@@ -1,0 +1,1 @@
+../scripts/function_check

--- a/hooks/scripts/function_check
+++ b/hooks/scripts/function_check
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+root=$(git rev-parse --show-toplevel)
+banned="([^f]gets\()|(sprintf\()|(strcpy\()"
+status=0
+for file in $(git diff --staged --name-only | grep -E "\.(c|cc|cpp|h|hh|hpp)\$")
+do
+  filepath="${root}/${file}"
+  output=$(grep -nrE "${banned}" "${filepath}")
+  if [ ! -z "${output}" ]; then
+      echo "Dangerous function detected in ${filepath}"
+      echo "${output}"
+      status=1
+  fi
+done
+exit $status

--- a/serializer/BUILD
+++ b/serializer/BUILD
@@ -9,6 +9,7 @@ cc_library(
     deps = [
         "//accelerator:ta_config",
         "//accelerator:ta_errors",
+        "//connectivity/mqtt:mqtt_common",
         "//request",
         "//response",
         "//utils:fill_nines",

--- a/serializer/serializer.c
+++ b/serializer/serializer.c
@@ -8,6 +8,7 @@
 
 #include "serializer.h"
 #include "utils/logger.h"
+#include "connectivity/mqtt/client_common.h"
 
 #define SERI_LOGGER "serializer"
 
@@ -191,7 +192,8 @@ status_t ta_hash8019_array_to_json_array(hash8019_array_p array, cJSON* const js
   return SC_OK;
 }
 
-static status_t ta_json_get_string(cJSON const* const json_obj, char const* const obj_name, char* const text) {
+static status_t ta_json_get_string(cJSON const* const json_obj, char const* const obj_name, char* const text,
+                                   const size_t size) {
   status_t ret = SC_OK;
   if (json_obj == NULL || obj_name == NULL || text == NULL) {
     ta_log_error("%s\n", "SC_SERIALIZER_NULL");
@@ -205,7 +207,7 @@ static status_t ta_json_get_string(cJSON const* const json_obj, char const* cons
   }
 
   if (cJSON_IsString(json_value) && (json_value->valuestring != NULL)) {
-    strcpy(text, json_value->valuestring);
+    strncpy(text, json_value->valuestring, size);
   } else {
     ta_log_error("%s\n", "SC_CCLIENT_JSON_PARSE");
     return SC_CCLIENT_JSON_PARSE;
@@ -715,14 +717,14 @@ status_t send_mam_res_deserialize(const char* const obj, ta_send_mam_res_t* cons
     goto done;
   }
 
-  if (ta_json_get_string(json_obj, "channel", (char*)addr) != SC_OK) {
+  if (ta_json_get_string(json_obj, "channel", (char*)addr, NUM_TRYTES_ADDRESS + 1) != SC_OK) {
     ret = SC_SERIALIZER_NULL;
     ta_log_error("%s\n", "SC_SERIALIZER_NULL");
     goto done;
   }
   send_mam_res_set_channel_id(res, addr);
 
-  if (ta_json_get_string(json_obj, "bundle_hash", (char*)addr) != SC_OK) {
+  if (ta_json_get_string(json_obj, "bundle_hash", (char*)addr, NUM_TRYTES_ADDRESS + 1) != SC_OK) {
     ret = SC_SERIALIZER_NULL;
     ta_log_error("%s\n", "SC_SERIALIZER_NULL");
     goto done;
@@ -810,7 +812,7 @@ status_t mqtt_device_id_deserialize(const char* const obj, char* device_id) {
     goto done;
   }
 
-  ret = ta_json_get_string(json_obj, "device_id", device_id);
+  ret = ta_json_get_string(json_obj, "device_id", device_id, ID_LEN + 1);
   if (ret != SC_OK) {
     ta_log_error("%d\n", ret);
   }
@@ -834,7 +836,7 @@ status_t mqtt_tag_req_deserialize(const char* const obj, char* tag) {
     goto done;
   }
 
-  ret = ta_json_get_string(json_obj, "tag", tag);
+  ret = ta_json_get_string(json_obj, "tag", tag, NUM_TRYTES_TAG + 1);
   if (ret != SC_OK) {
     ta_log_error("%d\n", ret);
   }
@@ -858,7 +860,7 @@ status_t mqtt_transaction_hash_req_deserialize(const char* const obj, char* hash
     goto done;
   }
 
-  ret = ta_json_get_string(json_obj, "hash", hash);
+  ret = ta_json_get_string(json_obj, "hash", hash, NUM_TRYTES_HASH + 1);
   if (ret != SC_OK) {
     ta_log_error("%d\n", ret);
   }

--- a/tests/driver.c
+++ b/tests/driver.c
@@ -137,7 +137,7 @@ void test_send_transfer(void) {
   gen_rand_tag(driver_tag_msg);
   int json_len = strlen(pre_json);
   char json[json_len + NUM_TRYTES_TAG];
-  sprintf(json, pre_json, driver_tag_msg);
+  snprintf(json, json_len + NUM_TRYTES_TAG, pre_json, driver_tag_msg);
 
   for (size_t count = 0; count < TEST_COUNT; count++) {
     test_time_start(&start_time);

--- a/tests/test_serializer.c
+++ b/tests/test_serializer.c
@@ -6,6 +6,7 @@
  * "LICENSE" at the root of this distribution.
  */
 
+#include "connectivity/mqtt/client_common.h"
 #include "serializer/serializer.h"
 #include "test_define.h"
 
@@ -300,7 +301,7 @@ void test_serialize_ta_send_trytes_res(void) {
 void test_mqtt_device_id_deserialize(void) {
   const char* json = "{\"device_id\":\"" DEVICE_ID "\", \"trytes\":[\"" TRYTES_2673_1 "\",\"" TRYTES_2673_2 "\"]}";
   const int id_len = 32;
-  char device_id[id_len + 1];
+  char device_id[ID_LEN + 1] = {0};
   TEST_ASSERT_EQUAL_INT(SC_OK, mqtt_device_id_deserialize(json, device_id));
 
   TEST_ASSERT_EQUAL_STRING(device_id, DEVICE_ID);
@@ -308,7 +309,7 @@ void test_mqtt_device_id_deserialize(void) {
 
 void test_mqtt_tag_req_deserialize(void) {
   const char* json = "{\"device_id\":\"" DEVICE_ID "\", \"tag\":\"" TAG_MSG "\"}";
-  char tag[NUM_TRYTES_TAG + 1];
+  char tag[NUM_TRYTES_TAG + 1] = {0};
   TEST_ASSERT_EQUAL_INT(SC_OK, mqtt_tag_req_deserialize(json, tag));
 
   TEST_ASSERT_EQUAL_STRING(tag, TAG_MSG);


### PR DESCRIPTION
As mentioned in #301, I searched the project directory for the existence of `gets`, `strcpy` and `sprintf`  strings, and changed them to suggested fixes.

I think rules should also be added to detect the usage of dangerous functions in compile time like [git/banned.h](https://github.com/git/git/blob/master/banned.h), but I have no idea where to add this header file at this point.