### PR TITLE
Rename `common_core` into `core`

### DIFF
--- a/accelerator/BUILD
+++ b/accelerator/BUILD
@@ -71,7 +71,7 @@ cc_library(
     hdrs = ["apis.h"],
     visibility = ["//visibility:public"],
     deps = [
-        ":common_core",
+        ":core",
         ":ta_errors",
         "//map:mode",
         "//serializer",
@@ -110,9 +110,9 @@ cc_library(
 )
 
 cc_library(
-    name = "common_core",
-    srcs = ["common_core.c"],
-    hdrs = ["common_core.h"],
+    name = "core",
+    srcs = ["core.c"],
+    hdrs = ["core.h"],
     visibility = ["//visibility:public"],
     deps = [
         ":ta_config",

--- a/accelerator/apis.h
+++ b/accelerator/apis.h
@@ -9,7 +9,7 @@
 #ifndef ACCELERATOR_APIS_H_
 #define ACCELERATOR_APIS_H_
 
-#include "accelerator/common_core.h"
+#include "accelerator/core.h"
 #include "common/trinary/trit_tryte.h"
 #include "mam/api/api.h"
 #include "mam/mam/mam_channel_t_set.h"

--- a/accelerator/core.c
+++ b/accelerator/core.c
@@ -6,10 +6,10 @@
  * "LICENSE" at the root of this distribution.
  */
 
-#include "common_core.h"
+#include "core.h"
 #include <sys/time.h>
 
-#define CC_LOGGER "common_core"
+#define CC_LOGGER "core"
 
 static logger_id_t logger_id;
 

--- a/accelerator/core.h
+++ b/accelerator/core.h
@@ -20,7 +20,7 @@ extern "C" {
 #endif
 
 /**
- * @file common_core.h
+ * @file core.h
  * @brief General tangle-accelerator core functions
  *
  * tangle-accelerator core functions provide major IOTA usage with

--- a/connectivity/mqtt/BUILD
+++ b/connectivity/mqtt/BUILD
@@ -13,7 +13,7 @@ cc_library(
     deps = [
         ":mqtt_common",
         "//accelerator:apis",
-        "//accelerator:common_core",
+        "//accelerator:core",
         "//accelerator:ta_errors",
         "@entangled//common/model:transaction",
     ],

--- a/connectivity/mqtt/duplex_callback.h
+++ b/connectivity/mqtt/duplex_callback.h
@@ -10,7 +10,7 @@
 #define DUPLEX_CALLBACK_H
 
 #include "accelerator/apis.h"
-#include "accelerator/common_core.h"
+#include "accelerator/core.h"
 #include "common/model/transaction.h"
 #include "duplex_utils.h"
 #include "serializer/serializer.h"

--- a/storage/BUILD
+++ b/storage/BUILD
@@ -11,7 +11,7 @@ cc_library(
         "-lcassandra",
     ],
     deps = [
-        "//accelerator:common_core",
+        "//accelerator:core",
         "//accelerator:ta_errors",
     ],
 )

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -7,7 +7,7 @@ cc_test(
     ],
     deps = [
         ":iota_api_mock",
-        "//accelerator:common_core",
+        "//accelerator:core",
     ],
 )
 
@@ -19,7 +19,7 @@ cc_library(
     hdrs = ["iota_api_mock.hh"],
     deps = [
         ":test_define",
-        "//accelerator:common_core",
+        "//accelerator:core",
         "@com_google_googletest//:gtest_main",
         "@entangled//cclient/api",
     ],

--- a/tests/iota_api_mock.hh
+++ b/tests/iota_api_mock.hh
@@ -6,7 +6,7 @@
  * "LICENSE" at the root of this distribution.
  */
 
-#include "accelerator/common_core.h"
+#include "accelerator/core.h"
 #include "cclient/api/core/core_api.h"
 #include "cclient/api/extended/extended_api.h"
 #include "gmock/gmock.h"

--- a/tests/test_common.cc
+++ b/tests/test_common.cc
@@ -8,7 +8,7 @@
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
-#include "accelerator/common_core.h"
+#include "accelerator/core.h"
 #include "iota_api_mock.hh"
 
 using ::testing::AtLeast;


### PR DESCRIPTION
Fixes #305.