### PR TITLE
Fix server hang on request to /address

### DIFF
--- a/accelerator/BUILD
+++ b/accelerator/BUILD
@@ -90,6 +90,7 @@ cc_library(
     name = "apis",
     srcs = ["apis.c"],
     hdrs = ["apis.h"],
+    linkopts = ["-lpthread"],
     visibility = ["//visibility:public"],
     deps = [
         ":common_core",
@@ -143,6 +144,7 @@ cc_library(
         "//request",
         "//response",
         "//utils:bundle_array",
+        "//utils:timer",
         "@com_github_uthash//:uthash",
         "@entangled//cclient/api",
         "@entangled//cclient/serialization:serializer",

--- a/accelerator/apis.c
+++ b/accelerator/apis.c
@@ -7,6 +7,7 @@
  */
 
 #include "apis.h"
+#include <sys/time.h>
 #include "map/mode.h"
 #include "utils/handles/lock.h"
 
@@ -135,6 +136,8 @@ status_t api_generate_address(const iota_config_t* const iconf, const iota_clien
   ret = ta_generate_address(iconf, service, res);
   if (ret) {
     lock_handle_unlock(&cjson_lock);
+    ret = SC_TA_ERROR;
+    ta_log_error("%s\n", "SC_TA_ERROR");
     goto done;
   }
   lock_handle_unlock(&cjson_lock);

--- a/accelerator/common_core.h
+++ b/accelerator/common_core.h
@@ -9,12 +9,14 @@
 #ifndef ACCELERATOR_COMMON_CORE_H_
 #define ACCELERATOR_COMMON_CORE_H_
 
+#include <sys/time.h>
 #include "accelerator/config.h"
 #include "common/model/transfer.h"
 #include "request/request.h"
 #include "response/response.h"
 #include "utils/bundle_array.h"
 #include "utils/time.h"
+#include "utils/timer.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -45,6 +47,12 @@ void cc_logger_init();
  * - EXIT_FAILURE on error
  */
 int cc_logger_release();
+
+typedef struct {
+  const iota_config_t* iconf;
+  const iota_client_service_t* service;
+  ta_generate_address_res_t* res;
+} ta_generate_address_args_t;
 
 /**
  * @brief Generate an unused address.

--- a/accelerator/errors.h
+++ b/accelerator/errors.h
@@ -81,6 +81,7 @@ typedef enum {
   /**< wrong TA request object */
   SC_TA_LOGGER_INIT_FAIL = 0x04 | SC_MODULE_TA | SC_SEVERITY_MAJOR,
   /**< fail to init ta logger */
+  SC_TA_ERROR = 0x05 | SC_MODULE_TA | SC_SEVERITY_MAJOR,
 
   // CClient module
   SC_CCLIENT_OOM = 0x01 | SC_MODULE_CCLIENT | SC_SEVERITY_FATAL,
@@ -173,7 +174,11 @@ typedef enum {
   // UTILS module
   SC_UTILS_NULL = 0x01 | SC_MODULE_UTILS | SC_SEVERITY_FATAL,
   SC_UTILS_WRONG_REQUEST_OBJ = 0x02 | SC_MODULE_UTILS | SC_SEVERITY_FATAL,
-  /**< wrong TA request object */
+  /**< Wrong TA request object */
+  SC_UTILS_TIMER_ERROR = 0x03 | SC_MODULE_UTILS | SC_SEVERITY_FATAL,
+  /**< Errors occurred in timer function */
+  SC_UTILS_TIMER_EXPIRED = 0x04 | SC_MODULE_UTILS | SC_SEVERITY_FATAL,
+  /**< Timer expired */
 
   // HTTP module
   SC_HTTP_OOM = 0x01 | SC_MODULE_HTTP | SC_SEVERITY_FATAL,

--- a/accelerator/server.cc
+++ b/accelerator/server.cc
@@ -108,6 +108,7 @@ int main(int argc, char* argv[]) {
     cc_logger_init();
     serializer_logger_init();
     pow_logger_init();
+    timer_logger_init();
   } else {
     // Destroy logger when verbose mode is off
     logger_helper_release(logger_id);
@@ -487,6 +488,7 @@ int main(int argc, char* argv[]) {
     cc_logger_release();
     serializer_logger_release();
     pow_logger_release();
+    timer_logger_release();
     logger_helper_release(logger_id);
     if (logger_helper_destroy() != RC_OK) {
       return EXIT_FAILURE;

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -116,3 +116,14 @@ cc_test(
         "//storage",
     ],
 )
+
+cc_test(
+    name = "test_timer",
+    srcs = [
+        "test_timer.c",
+    ],
+    deps = [
+        ":test_define",
+        "//utils:timer",
+    ],
+)

--- a/tests/test_timer.c
+++ b/tests/test_timer.c
@@ -1,0 +1,75 @@
+/*
+ * Copyright (C) 2018-2019 BiiLabs Co., Ltd. and Contributors
+ * All Rights Reserved.
+ * This is free software; you can redistribute it and/or modify it under the
+ * terms of the MIT license. A copy of the license can be found in the file
+ * "LICENSE" at the root of this distribution.
+ */
+
+#include <pthread.h>
+#include "test_define.h"
+#include "utils/timer.h"
+
+int finite_thread(void *args) { 
+    long x = *(int*)args;
+    pthread_exit((void *)x); 
+}
+
+int infinite_thread(void *args) {
+    long x = *(int*)args;
+  while (1) {
+    // Cancellation point
+    pthread_testcancel();
+  }
+  pthread_exit((void*)x);
+}
+
+void test_timer_finite(void) {
+  const struct itimerspec timeout = {.it_interval = {.tv_sec = 0, .tv_nsec = 0},
+                                     .it_value = {.tv_sec = 1, .tv_nsec = 0}};
+  int *args = (int*)malloc(sizeof(int));
+  TEST_ASSERT(args != NULL);
+  *args = 7;
+
+  ta_timer_t *timer_id = ta_timer_start(&timeout, finite_thread, args);
+  TEST_ASSERT(timer_id != NULL);
+
+  int *rval; 
+  int ret = ta_timer_stop(timer_id, (void**)&rval);
+  TEST_ASSERT(ret == SC_OK);
+  TEST_ASSERT((intptr_t)rval == *args);
+
+  free(args);
+}
+
+void test_timer_infinite(void) {
+  const struct itimerspec timeout = {.it_interval = {.tv_sec = 0, .tv_nsec = 0},
+                                     .it_value = {.tv_sec = 1, .tv_nsec = 0}};
+  int *args = (int*)malloc(sizeof(int));
+  TEST_ASSERT(args != NULL);
+  *args = 7;
+
+  ta_timer_t *timer_id = ta_timer_start(&timeout, infinite_thread, args);
+  TEST_ASSERT(timer_id != NULL);
+
+  int *rval;
+  int ret = ta_timer_stop(timer_id, (void**)&rval);
+  TEST_ASSERT(ret == SC_UTILS_TIMER_EXPIRED);
+
+  free(args);
+}
+
+int main(void) {
+  UNITY_BEGIN();
+
+  // Initialize logger
+  if (ta_logger_init() != SC_OK) {
+    return EXIT_FAILURE;
+  }
+
+  timer_logger_init();
+  RUN_TEST(test_timer_finite);
+  RUN_TEST(test_timer_infinite);
+  timer_logger_release();
+  return UNITY_END();
+}

--- a/utils/BUILD
+++ b/utils/BUILD
@@ -59,3 +59,17 @@ cc_library(
     name = "hash_algo_djb2",
     hdrs = ["hash_algo_djb2.h"],
 )
+
+cc_library(
+    name = "timer",
+    srcs = ["timer.c"],
+    hdrs = ["timer.h"],
+    linkopts = [
+        "-lpthread",
+        "-lrt",
+    ],
+    deps = [
+        ":ta_logger",
+        "//accelerator:ta_errors",
+    ],
+)

--- a/utils/timer.c
+++ b/utils/timer.c
@@ -1,0 +1,104 @@
+/*
+ * Copyright (C) 2019 BiiLabs Co., Ltd. and Contributors
+ * All Rights Reserved.
+ * This is free software; you can redistribute it and/or modify it under the
+ * terms of the MIT license. A copy of the license can be found in the file
+ * "LICENSE" at the root of this distribution.
+ */
+
+#include "timer.h"
+#include "utils/logger.h"
+
+#define TIMER_LOGGER "timer"
+
+static logger_id_t logger_id;
+static pthread_mutex_t timer_lock = PTHREAD_MUTEX_INITIALIZER;
+struct _ta_timer_t {
+  pthread_t *thread_id;
+  timer_t *timer_id;
+};
+
+void timer_logger_init() { logger_id = logger_helper_enable(TIMER_LOGGER, LOGGER_DEBUG, true); }
+
+int timer_logger_release() {
+  logger_helper_release(logger_id);
+  if (logger_helper_destroy() != RC_OK) {
+    ta_log_error("Destroying logger failed %s.\n", TIMER_LOGGER);
+    return EXIT_FAILURE;
+  }
+
+  return 0;
+}
+
+static void handler(union sigval v) {
+  ta_timer_t *args = (ta_timer_t *)v.sival_ptr;
+  ta_log_error("timer_id: %p expired\n", *(args->timer_id));
+
+  /* Cancel the thread */
+  pthread_mutex_lock(&timer_lock);
+  pthread_cancel(*(args->thread_id));
+  pthread_mutex_unlock(&timer_lock);
+}
+
+ta_timer_t *ta_timer_start(const struct itimerspec *timer, void *callback, void *args) {
+  pthread_t *thread_id;
+  timer_t *timer_id;
+  ta_timer_t *ta_timer;
+
+  thread_id = (pthread_t *)malloc(sizeof(pthread_t));
+  timer_id = (timer_t *)malloc(sizeof(timer_t));
+  ta_timer = (ta_timer_t *)malloc(sizeof(ta_timer_t));
+  struct sigevent sev = {.sigev_notify = SIGEV_THREAD,
+                         .sigev_signo = SIGALRM,
+                         .sigev_value.sival_ptr = (void *)ta_timer,
+                         .sigev_notify_function = handler};
+  if (thread_id == NULL || timer_id == NULL || ta_timer == NULL) goto cleanup;
+  ta_timer->thread_id = thread_id;
+  ta_timer->timer_id = timer_id;
+
+  if (timer_create(CLOCK_REALTIME, &sev, timer_id) == -1) {
+    ta_log_error("%s\n", "timer_create_failed");
+    goto cleanup;
+  } else {
+    ta_log_debug("Create timer_id: %p\n", *timer_id);
+  }
+
+  timer_settime(*timer_id, 0, timer, NULL);
+  pthread_create(thread_id, NULL, callback, args);
+
+  return ta_timer;
+
+cleanup:
+  free(thread_id);
+  free(timer_id);
+  free(ta_timer);
+  return NULL;
+}
+
+status_t ta_timer_stop(ta_timer_t *ta_timer, void **rval) {
+  int ret = 0;
+  ret = pthread_join(*(ta_timer->thread_id), rval);
+
+  if (ret) {
+    ta_log_error("pthread_join failed: %d\n", ret);
+    return SC_UTILS_TIMER_ERROR;
+  }
+
+  pthread_mutex_lock(&timer_lock);
+  ret = timer_delete(*(ta_timer->timer_id));
+  free(ta_timer->timer_id);
+  free(ta_timer->thread_id);
+  free(ta_timer);
+  pthread_mutex_unlock(&timer_lock);
+
+  if (ret) {
+    ta_log_error("timer_delete failed: %d\n", ret);
+    return SC_UTILS_TIMER_ERROR;
+  }
+
+  if (*rval == PTHREAD_CANCELED) {
+    return SC_UTILS_TIMER_EXPIRED;
+  }
+
+  return SC_OK;
+}

--- a/utils/timer.h
+++ b/utils/timer.h
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C) 2019 BiiLabs Co., Ltd. and Contributors
+ * All Rights Reserved.
+ * This is free software; you can redistribute it and/or modify it under the
+ * terms of the MIT license. A copy of the license can be found in the file
+ * "LICENSE" at the root of this distribution.
+ */
+
+#ifndef UTILS_TIMER_H_
+#define UTILS_TIMER_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @file timer.h
+ * @brief Implementation of one-shot timer. The wrapper wraps and executes the callback,
+ * executes in a different thread, and cancels the thread after the given tiemout.
+ */
+
+#include <pthread.h>
+#include <signal.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/time.h>
+#include "accelerator/errors.h"
+
+/**
+ * Initialize logger
+ */
+void timer_logger_init();
+
+/**
+ * Release logger
+ *
+ * @return
+ * - zero on success
+ * - EXIT_FAILURE on error
+ */
+int timer_logger_release();
+
+typedef struct _ta_timer_t ta_timer_t;
+
+/**
+ * Create and initialize a ta_timer
+ * @param[in] timer Timeout to wait until callback being halted
+ * @param[in] callback The actual function being called
+ * @param[in] args The arguments to pass to the callback function
+ *
+ * @return
+ * - ta_timer pointer
+ * - NULL on error
+ */
+ta_timer_t *ta_timer_start(const struct itimerspec *timer, void *callback, void *args);
+
+/**
+ * Stop a timer and block the current thread until timeout or callback finishes.
+ * @param[in] ta_timer timer obtained by ta_timer_start
+ * @param[out] rval Return value of the callback
+ *
+ * @return
+ * - SC_OK on success
+ * - non zero on error
+ */
+status_t ta_timer_stop(ta_timer_t *ta_timer, void **rval);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // UTILS_TIMER_H_


### PR DESCRIPTION
The server hangs when user requests `/address` and IRI connections are
down.

At this moment, we can't shutdown the server by sending `SIGINT` or
`SIGTERM` since served has already registered the signal handler for
those signals.

I added a timeout to `api_generate_address`, separating a new `/address`
request to a new thread, and simply cancel the thread if exceeded the
time limit.