### PR TITLE
Add an option for ScyllaDB connection

### DIFF
--- a/accelerator/BUILD
+++ b/accelerator/BUILD
@@ -162,6 +162,7 @@ cc_library(
     deps = [
         ":message",
         ":ta_errors",
+        "//storage",
         "//utils:cache",
         "//utils:pow",
         "//utils:ta_logger",

--- a/accelerator/config.h
+++ b/accelerator/config.h
@@ -15,6 +15,7 @@
 #include "accelerator/message.h"
 #include "cclient/api/core/core_api.h"
 #include "cclient/api/extended/extended_api.h"
+#include "storage/scylla_api.h"
 #include "utils/cache.h"
 #include "utils/logger.h"
 #include "utils/pow.h"
@@ -42,6 +43,7 @@ extern "C" {
 #define TA_THREAD_COUNT 10
 #define IRI_HOST "localhost"
 #define IRI_PORT 14265
+#define DB_HOST "localhost"
 #define MILESTONE_DEPTH 3
 #define MWM 14
 #define SEED                                                                   \
@@ -89,6 +91,7 @@ typedef struct ta_core_s {
   ta_cache_t cache;                   /**< redis configiuration structure */
   iota_config_t iota_conf;            /**< iota configuration structure */
   iota_client_service_t iota_service; /**< iota connection structure */
+  db_client_service_t db_service;     /**< db connection structure */
   char conf_file[FILE_PATH_SIZE];     /**< path to the configuration file */
 } ta_core_t;
 
@@ -118,7 +121,7 @@ int get_conf_key(char const* const key);
  * - non-zero on error
  */
 status_t ta_core_default_init(ta_config_t* const ta_conf, iota_config_t* const iota_conf, ta_cache_t* const cache,
-                              iota_client_service_t* const iota_service);
+                              iota_client_service_t* const iota_service, db_client_service_t* const db_service);
 
 /**
  * Initializes configurations with configuration file
@@ -151,19 +154,23 @@ status_t ta_core_cli_init(ta_core_t* const core, int argc, char** argv);
  *
  * @param cache[in] Redis server configuration variables
  * @param iota_service[in] IRI connection configuration variables
+ * @param db_service[in] DB connection configuratin variables
  *
  * @return
  * - SC_OK on success
  * - non-zero on error
  */
-status_t ta_core_set(ta_cache_t* const cache, iota_client_service_t* const iota_service);
+status_t ta_core_set(ta_cache_t* const cache, iota_client_service_t* const iota_service,
+                     db_client_service_t* const db_service);
 
 /**
  * Free memory of configuration variables
  *
- * @param service[in] IRI connection configuration variables
+ * @param iota_service[in] IRI connection configuration variables
+ * @param db_service[in] DB connection configuratin variables
+ *
  */
-void ta_core_destroy(iota_client_service_t* const iota_service);
+void ta_core_destroy(iota_client_service_t* const iota_service, db_client_service_t* const db_service);
 
 #ifdef __cplusplus
 }

--- a/accelerator/conn_mqtt.c
+++ b/accelerator/conn_mqtt.c
@@ -23,7 +23,8 @@ int main(int argc, char *argv[]) {
   logger_id = logger_helper_enable(CONN_MQTT_LOGGER, LOGGER_DEBUG, true);
 
   // Initialize configurations with default value
-  if (ta_core_default_init(&ta_core.ta_conf, &ta_core.iota_conf, &ta_core.cache, &ta_core.iota_service) != SC_OK) {
+  if (ta_core_default_init(&ta_core.ta_conf, &ta_core.iota_conf, &ta_core.cache, &ta_core.iota_service,
+                           &ta_core.db_service) != SC_OK) {
     return EXIT_FAILURE;
   }
 
@@ -32,7 +33,7 @@ int main(int argc, char *argv[]) {
     return EXIT_FAILURE;
   }
 
-  if (ta_core_set(&ta_core.cache, &ta_core.iota_service) != SC_OK) {
+  if (ta_core_set(&ta_core.cache, &ta_core.iota_service, &ta_core.db_service) != SC_OK) {
     ta_log_error("Configure failed %s.\n", CONN_MQTT_LOGGER);
     return EXIT_FAILURE;
   }

--- a/accelerator/main.c
+++ b/accelerator/main.c
@@ -30,7 +30,8 @@ int main(int argc, char* argv[]) {
   logger_id = logger_helper_enable(MAIN_LOGGER, LOGGER_DEBUG, true);
 
   // Initialize configurations with default value
-  if (ta_core_default_init(&ta_core.ta_conf, &ta_core.iota_conf, &ta_core.cache, &ta_core.iota_service) != SC_OK) {
+  if (ta_core_default_init(&ta_core.ta_conf, &ta_core.iota_conf, &ta_core.cache, &ta_core.iota_service,
+                           &ta_core.db_service) != SC_OK) {
     return EXIT_FAILURE;
   }
 
@@ -44,7 +45,7 @@ int main(int argc, char* argv[]) {
     return EXIT_FAILURE;
   }
 
-  if (ta_core_set(&ta_core.cache, &ta_core.iota_service) != SC_OK) {
+  if (ta_core_set(&ta_core.cache, &ta_core.iota_service, &ta_core.db_service) != SC_OK) {
     ta_log_error("Configure failed %s.\n", MAIN_LOGGER);
     return EXIT_FAILURE;
   }
@@ -92,7 +93,7 @@ cleanup:
     return EXIT_FAILURE;
   }
   log_warning(logger_id, "Destroying TA configurations\n");
-  ta_core_destroy(&ta_core.iota_service);
+  ta_core_destroy(&ta_core.iota_service, &ta_core.db_service);
 
   if (verbose_mode) {
     http_logger_release();

--- a/accelerator/message.h
+++ b/accelerator/message.h
@@ -32,6 +32,9 @@ typedef enum ta_cli_arg_value_e {
   REDIS_HOST_CLI,
   REDIS_PORT_CLI,
 
+  /** DB */
+  DB_HOST_CLI,
+
   /** CONFIG */
   MILESTONE_DEPTH_CLI,
   MWM_CLI,
@@ -59,6 +62,7 @@ static struct ta_cli_argument_s {
                           {"iri_port", IRI_PORT_CLI, "IRI listening port", REQUIRED_ARG},
                           {"redis_host", REDIS_HOST_CLI, "Redis server listening host", REQUIRED_ARG},
                           {"redis_port", REDIS_PORT_CLI, "Redis server listening port", REQUIRED_ARG},
+                          {"db_host", DB_HOST_CLI, "DB server listening host", REQUIRED_ARG},
                           {"milestone_depth", MILESTONE_DEPTH_CLI, "IRI milestone depth", OPTIONAL_ARG},
                           {"mwm", MWM_CLI, "minimum weight magnitude", OPTIONAL_ARG},
                           {"seed", SEED_CLI, "IOTA seed", OPTIONAL_ARG},

--- a/accelerator/server.cc
+++ b/accelerator/server.cc
@@ -77,7 +77,8 @@ int main(int argc, char* argv[]) {
   logger_id = logger_helper_enable(SERVER_LOGGER, LOGGER_DEBUG, true);
 
   // Initialize configurations with default value
-  if (ta_core_default_init(&ta_core.ta_conf, &ta_core.iota_conf, &ta_core.cache, &ta_core.iota_service) != SC_OK) {
+  if (ta_core_default_init(&ta_core.ta_conf, &ta_core.iota_conf, &ta_core.cache, &ta_core.iota_service,
+                           &ta_core.db_service) != SC_OK) {
     return EXIT_FAILURE;
   }
 
@@ -91,7 +92,7 @@ int main(int argc, char* argv[]) {
     return EXIT_FAILURE;
   }
 
-  if (ta_core_set(&ta_core.cache, &ta_core.iota_service) != SC_OK) {
+  if (ta_core_set(&ta_core.cache, &ta_core.iota_service, &ta_core.db_service) != SC_OK) {
     ta_log_error("Configure failed %s.\n", SERVER_LOGGER);
     return EXIT_FAILURE;
   }
@@ -482,7 +483,7 @@ int main(int argc, char* argv[]) {
     ta_log_error("Destroying api lock failed %s.\n", SERVER_LOGGER);
     return EXIT_FAILURE;
   }
-  ta_core_destroy(&ta_core.iota_service);
+  ta_core_destroy(&ta_core.iota_service, &ta_core.db_service);
 
   if (verbose_mode) {
     apis_logger_release();

--- a/storage/BUILD
+++ b/storage/BUILD
@@ -12,8 +12,8 @@ cc_library(
     ],
     deps = [
         ":scylla_table",
-        "//accelerator:common_core",
         "//accelerator:ta_errors",
+        "@entangled//utils/containers/hash:hash243_queue",
     ],
 )
 
@@ -24,7 +24,9 @@ cc_library(
     copts = ["-DLOGGER_ENABLE"],
     linkopts = ["-lcassandra"],
     deps = [
-        "//accelerator:common_core",
         "//accelerator:ta_errors",
+        "//utils:ta_logger",
+        "@com_github_uthash//:uthash",
+        "@entangled//common/model:bundle",
     ],
 )

--- a/storage/scylla_api.c
+++ b/storage/scylla_api.c
@@ -458,21 +458,23 @@ exit:
   return ret;
 }
 
-status_t db_client_service_init(db_client_service_t* service, const char* host) {
+status_t db_client_service_init(db_client_service_t* service) {
   if (service == NULL) {
     ta_log_error("NULL pointer to ScyllaDB client service for connection endpoint(s)\n");
     return SC_TA_NULL;
   }
-  if (host == NULL) {
+  if (service->host == NULL) {
     ta_log_error("NULL pointer to ScyllaDB hostname\n");
     return SC_TA_NULL;
   }
   service->session = cass_session_new();
-  service->cluster = create_cluster(host);
+  service->cluster = create_cluster(service->host);
   if (connect_session(service->session, service->cluster) != CASS_OK) {
-    ta_log_error("%s\n", "connect ScyllaDB cluster fail");
+    ta_log_error("connect ScyllaDB cluster with host : %s failed\n", service->host);
+    service->enabled = false;
     return SC_STORAGE_CONNECT_FAIL;
   }
+  service->enabled = true;
   return SC_OK;
 }
 
@@ -487,6 +489,7 @@ status_t db_client_service_free(db_client_service_t* service) {
   if (service->cluster != NULL) {
     cass_cluster_free(service->cluster);
   }
+  free(service->host);
   return SC_OK;
 }
 

--- a/storage/scylla_api.h
+++ b/storage/scylla_api.h
@@ -21,20 +21,21 @@ extern "C" {
 typedef struct {
   CassCluster* cluster;
   CassSession* session;
+  char* host;
+  bool enabled; /**< switch of db connection */
 } db_client_service_t;
 
 typedef struct scylla_iota_transaction_s scylla_iota_transaction_t;
 
 /**
- * @brief init Scylla client serivce and connect to specific cluster
+ * @brief init ScyllaDB client serivce and connect to specific cluster
  *
- * @param[out] service Scylla client service
- * @param[in] hosts Scylla cluster entry point IP address
+ * @param[out] service ScyllaDB client service
  * @return
  * - SC_OK on success
  * - non-zero on error
  */
-status_t db_client_service_init(db_client_service_t* service, const char* hosts);
+status_t db_client_service_init(db_client_service_t* service);
 
 /**
  * @brief free Scylla client serivce
@@ -344,11 +345,9 @@ status_t get_transactions(db_client_service_t* service, hash243_queue_t* res_que
                           hash243_queue_t addresses, hash243_queue_t approves);
 
 /**
- * @brief connect to Scylla cluster and initialize identity keyspace and table
+ * @brief connect to ScyllaDB cluster and initialize identity keyspace and table
  *
- * @param[out] cluster Scylla node cluster
- * @param[out] service Scylla client service
- * @param[in] hosts Scylla cluster entry point ip
+ * @param[in] service ScyllaDB client service for connection
  * @param[in] need_drop true : drop table, false : keep old table
  * @param[in] keyspace_name keyspace name the session should use
  *
@@ -361,7 +360,7 @@ status_t db_init_identity_keyspace(db_client_service_t* service, bool need_drop,
 /**
  * @brief get db_identity_array_t with selected status from identity table
  *
- * @param[in] session Scylla session
+ * @param[in] service ScyllaDB client service for connection
  * @param[in] status selected status TXN status
  * @param[out] db_identity_array UT arrray for db_identity_t
  *
@@ -375,7 +374,7 @@ status_t db_select_identity_table(db_client_service_t* service, cass_int8_t stat
 /**
  * @brief insert db_identity_t into identity table
  *
- * @param[in] session Scylla session
+ * @param[in] service ScyllaDB client service for connection
  * @param[in] obj inserted db_identity_t
  *
  * @return

--- a/tests/driver.c
+++ b/tests/driver.c
@@ -264,9 +264,10 @@ int main(int argc, char* argv[]) {
     return EXIT_FAILURE;
   }
 
-  ta_core_default_init(&ta_core.ta_conf, &ta_core.iota_conf, &ta_core.cache, &ta_core.iota_service);
+  ta_core_default_init(&ta_core.ta_conf, &ta_core.iota_conf, &ta_core.cache, &ta_core.iota_service,
+                       &ta_core.db_service);
   ta_core_cli_init(&ta_core, argc, argv);
-  ta_core_set(&ta_core.cache, &ta_core.iota_service);
+  ta_core_set(&ta_core.cache, &ta_core.iota_service, &ta_core.db_service);
 
   printf("Total samples for each API test: %d\n", TEST_COUNT);
   RUN_TEST(test_generate_address);
@@ -280,6 +281,6 @@ int main(int argc, char* argv[]) {
   RUN_TEST(test_find_transactions_by_tag);
   RUN_TEST(test_find_transactions_obj_by_tag);
   RUN_TEST(test_proxy_apis);
-  ta_core_destroy(&ta_core.iota_service);
+  ta_core_destroy(&ta_core.iota_service, &ta_core.db_service);
   return UNITY_END();
 }


### PR DESCRIPTION
**Motivation**: To insert new pending transaction and query transactions' status, TA needs connecting to a ScyllaDB host. 

**Usage**: Connect to ScyllaDB host when performing initialization. The default setting of connection is disabled.

- Use  "--db_host [host]" to specify the host.

This PR would close #346.