### PR TITLE
Allow IRI_HOST and IRI_PORT set via command line for test case

### DIFF
--- a/tests/driver.c
+++ b/tests/driver.c
@@ -253,7 +253,7 @@ void test_proxy_apis() {
   }
 }
 
-int main(void) {
+int main(int argc, char *argv[]) {
   srand(time(NULL));
 
   UNITY_BEGIN();
@@ -264,6 +264,7 @@ int main(void) {
   }
 
   ta_config_default_init(&ta_core.info, &ta_core.iconf, &ta_core.cache, &ta_core.service);
+  ta_config_cli_init(&ta_core, argc, argv);
   ta_config_set(&ta_core.cache, &ta_core.service);
 
   printf("Total samples for each API test: %d\n", TEST_COUNT);


### PR DESCRIPTION
Close #304.
From bazel user manual, we can add `--test_arg=<a string>` to the
`bazel test` command to pass additional arguments.

For example, we could run `bazel test -c dbg //tests:driver
--test_arg=--iri_host="localhost"` to set the IRI host.