### PR TITLE
Rework data model and query functions for transaction reattachment 

### DIFF
--- a/storage/scylla_api.h
+++ b/storage/scylla_api.h
@@ -358,7 +358,7 @@ status_t get_transactions(db_client_service_t* service, hash243_queue_t* res_que
 status_t db_init_identity_keyspace(db_client_service_t* service, bool need_drop, const char* keyspace_name);
 
 /**
- * @brief get db_identity_array_t with selected status from identity table
+ * @brief get identity objs with selected status from identity table
  *
  * @param[in] service ScyllaDB client service for connection
  * @param[in] status selected status TXN status
@@ -368,8 +368,35 @@ status_t db_init_identity_keyspace(db_client_service_t* service, bool need_drop,
  * - SC_OK on success
  * - non-zero on error
  */
-status_t db_select_identity_table(db_client_service_t* service, cass_int8_t status,
-                                  db_identity_array_t* db_identity_array);
+status_t db_get_identity_objs_by_status(db_client_service_t* service, cass_int8_t status,
+                                        db_identity_array_t* db_identity_array);
+/**
+ * @brief get identity objs with selected id from identity table
+ *
+ * @param[in] service ScyllaDB client service for connection
+ * @param[in] id selected TXN id
+ * @param[out] db_identity_array UT arrray for db_identity_t
+ *
+ * @return
+ * - SC_OK on success
+ * - non-zero on error
+ */
+status_t db_get_identity_objs_by_id(db_client_service_t* service, cass_int64_t id,
+                                    db_identity_array_t* db_identity_array);
+
+/**
+ * @brief get identity objs with selected hash from identity table
+ *
+ * @param[in] service ScyllaDB client service for connection
+ * @param[in] hash selected TXN hash
+ * @param[out] db_identity_array UT arrray for db_identity_t
+ *
+ * @return
+ * - SC_OK on success
+ * - non-zero on error
+ */
+status_t db_get_identity_objs_by_hash(db_client_service_t* service, const cass_byte_t* hash,
+                                      db_identity_array_t* db_identity_array);
 
 /**
  * @brief insert db_identity_t into identity table

--- a/storage/scylla_table.c
+++ b/storage/scylla_table.c
@@ -7,6 +7,7 @@
  */
 #include "scylla_table.h"
 #include "common/model/transaction.h"
+#include "time.h"
 #include "utils/logger.h"
 
 static logger_id_t logger_id;
@@ -24,6 +25,7 @@ int scylla_table_logger_release() {
 
 struct db_identity_s {
   cass_int64_t id;
+  cass_int64_t timestamp;
   cass_int8_t status;
   cass_byte_t hash[NUM_FLEX_TRITS_BUNDLE];
 };
@@ -48,8 +50,8 @@ status_t db_set_identity_id(db_identity_t* obj, cass_int64_t id) {
     ta_log_error("NULL pointer to ScyllaDB identity object\n");
     return SC_TA_NULL;
   }
-  if (id < 0) {
-    ta_log_error("Invaild input : nagative ID\n");
+  if (id <= 0) {
+    ta_log_error("Invaild ID\n");
     return SC_STORAGE_INVAILD_INPUT;
   }
   obj->id = id;
@@ -59,7 +61,7 @@ status_t db_set_identity_id(db_identity_t* obj, cass_int64_t id) {
 cass_int64_t db_ret_identity_id(const db_identity_t* obj) {
   if (obj == NULL) {
     ta_log_error("NULL pointer to ScyllaDB identity object\n");
-    return INT64_MAX;
+    return 0;
   }
   return obj->id;
 }
@@ -83,6 +85,31 @@ cass_int8_t db_ret_identity_status(const db_identity_t* obj) {
     return 0;
   }
   return obj->status;
+}
+
+status_t db_set_identity_timestamp(db_identity_t* obj, cass_int64_t ts) {
+  if (obj == NULL) {
+    ta_log_error("NULL pointer to ScyllaDB identity object\n");
+    return SC_TA_NULL;
+  }
+  obj->timestamp = ts;
+  return SC_OK;
+}
+
+cass_int64_t db_ret_identity_timestamp(const db_identity_t* obj) {
+  if (obj == NULL) {
+    ta_log_error("NULL pointer to ScyllaDB identity object\n");
+    return 0;
+  }
+  return obj->timestamp;
+}
+
+cass_int64_t db_ret_identity_time_elapsed(db_identity_t* obj) {
+  if (obj == NULL) {
+    ta_log_error("NULL pointer to ScyllaDB identity object\n");
+    return SC_TA_NULL;
+  }
+  return (cass_int64_t)time(NULL) - obj->timestamp;
 }
 
 status_t db_set_identity_hash(db_identity_t* obj, const cass_byte_t* hash, size_t length) {

--- a/storage/scylla_table.h
+++ b/storage/scylla_table.h
@@ -82,6 +82,39 @@ status_t db_set_identity_id(db_identity_t* obj, cass_int64_t id);
 cass_int64_t db_ret_identity_id(const db_identity_t* obj);
 
 /**
+ * @brief set time(in seconds) in db_identity_t
+ *
+ * @param[in] obj pointer to db_identity_t
+ * @param[in] ts timestamp to be set into db_identity_t
+ * @return
+ * - SC_OK on success
+ * - SC_TA_NULL/SC_STORAGE_INVAILD_INPUT on error
+ */
+status_t db_set_identity_timestamp(db_identity_t* obj, cass_int64_t ts);
+
+/**
+ * @brief return time(in seconds) in db_identity_t
+ *
+ * @param[in] obj pointer to db_identity_t
+ *
+ * @return
+ * - time(in seconds) on success
+ * - NULL on error
+ */
+cass_int64_t db_ret_identity_timestamp(const db_identity_t* obj);
+
+/**
+ * @brief return time(in seconds) elapsed from identity obj update time to current time
+ *
+ * @param[in] obj pointer to db_identity_t
+ *
+ * @return
+ * - time(in seconds) on success
+ * - 0 on error
+ */
+cass_int64_t db_ret_identity_time_elapsed(db_identity_t* obj);
+
+/**
  * @brief set status in db_identity_t
  *
  * @param[in] obj pointer to db_identity_t


### PR DESCRIPTION
Implement select functions either by status, id or hash.

Add timestamp column to identity table and implement time elapsed function

The time elapsed could be used for transaction reattachment.  Preform reattachment when a transaction has pended for a while.

Close #360