### PR TITLE
Implement transaction reattachment related APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,9 @@ For more information for MQTT connectivity of `tangle-accelerator`, you could re
 ### Optional: Enable external database for transaction reattachment
 Transaction reattachment is an optional feature.
 
-You can enable it in the build time by adding option : `--define db=enable`
+You can enable it in the build time by adding option : `--define db=enable`.
+
+When enabling reattachment, every transaction issues from the `tangle-accelerator` API called `Send Transfer Message` will be stored in the specific ScyllaDB host and response a UUID string for each transfer message as the identifier. With a promoting process that monitors the status of storing transactions, persistent pending transactions will be reattached to the Tangle.
 
 Transaction reattachment relies on ScyllDB, you need to install the dependency by following commands.
 

--- a/accelerator/BUILD
+++ b/accelerator/BUILD
@@ -54,13 +54,26 @@ cc_binary(
             "-pg",
         ],
         "//conditions:default": ["-DNDEBUG"],
+    }) + select({
+        "//connectivity/mqtt:mqtt_enable": [
+            "-DMQTT_ENABLE",
+        ],
+        "//conditions:default": [],
+    }) + select({
+        "//storage:db_enable": ["-DDB_ENABLE"],
+        "//conditions:default": [],
     }),
     deps = [
         ":http",
         ":ta_config",
         ":ta_errors",
         "@entangled//utils/handles:signal",
-    ],
+    ] + select({
+        "//connectivity/mqtt:mqtt_enable": [
+            "//connectivity/mqtt:mqtt_utils",
+        ],
+        "//conditions:default": [],
+    }),
 )
 
 cc_image(
@@ -81,6 +94,15 @@ cc_library(
     name = "apis",
     srcs = ["apis.c"],
     hdrs = ["apis.h"],
+    copts = select({
+        "//connectivity/mqtt:mqtt_enable": [
+            "-DMQTT_ENABLE",
+        ],
+        "//conditions:default": [],
+    }) + select({
+        "//storage:db_enable": ["-DDB_ENABLE"],
+        "//conditions:default": [],
+    }),
     linkopts = ["-lpthread"],
     visibility = ["//visibility:public"],
     deps = [
@@ -114,6 +136,15 @@ cc_library(
     name = "http",
     srcs = ["http.c"],
     hdrs = ["http.h"],
+    copts = select({
+        "//connectivity/mqtt:mqtt_enable": [
+            "-DMQTT_ENABLE",
+        ],
+        "//conditions:default": [],
+    }) + select({
+        "//storage:db_enable": ["-DDB_ENABLE"],
+        "//conditions:default": [],
+    }),
     visibility = ["//visibility:public"],
     deps = [
         ":apis",
@@ -128,6 +159,10 @@ cc_library(
     name = "common_core",
     srcs = ["common_core.c"],
     hdrs = ["common_core.h"],
+    copts = select({
+        "//storage:db_enable": ["-DDB_ENABLE"],
+        "//conditions:default": [],
+    }),
     visibility = ["//visibility:public"],
     deps = [
         ":ta_config",

--- a/accelerator/apis.h
+++ b/accelerator/apis.h
@@ -167,8 +167,7 @@ status_t api_mam_send_message(const iota_config_t* const iconf, const iota_clien
  * fields include address, value, tag, and message. This API would also try to
  * find the transactions after bundle sent.
  *
- * @param[in] iconf IOTA API parameter configurations
- * @param[in] service IRI node end point service
+ * @param core[in] Pointer to Tangle-accelerator core configuration structure
  * @param[in] obj Input data in JSON
  * @param[out] json_result Result containing transaction objects in json format
  *
@@ -176,8 +175,7 @@ status_t api_mam_send_message(const iota_config_t* const iconf, const iota_clien
  * - SC_OK on success
  * - non-zero on error
  */
-status_t api_send_transfer(const iota_config_t* const iconf, const iota_client_service_t* const service,
-                           const char* const obj, char** json_result);
+status_t api_send_transfer(const ta_core_t* const core, const char* const obj, char** json_result);
 
 /**
  * @brief Return transaction object with given single transaction hash.
@@ -268,6 +266,54 @@ status_t api_find_transactions_obj_by_tag(const iota_client_service_t* const ser
  */
 status_t api_send_trytes(const iota_config_t* const iconf, const iota_client_service_t* const service,
                          const char* const obj, char** json_result);
+#ifdef DB_ENABLE
+/**
+ * @brief Return transaction object with given single identity number.
+ *
+ * Explore transaction hash information with given single identity number. This would
+ * return whole transaction object details in json format instead of raw trytes.
+ *
+ * @param[in] iota_service IRI node end point service
+ * @param[in] db_service db client service
+ * @param[in] obj identity number
+ * @param[out] json_result Result containing the only one transaction object in json format
+ *
+ * @return
+ * - SC_OK on success
+ * - non-zero on error
+ */
+status_t api_find_transactions_by_id(const iota_client_service_t* const iota_service,
+                                     const db_client_service_t* const db_service, const char* const obj,
+                                     char** json_result);
+
+/**
+ * @brief Return db identity object with given single transaction hash.
+ *
+ * @param[in] db_service db client service
+ * @param[in] obj transaction hash
+ * @param[out] json_result Result containing the only one db identity object in json format
+ *
+ * @return
+ * - SC_OK on success
+ * - non-zero on error
+ */
+status_t api_get_identity_info_by_hash(const db_client_service_t* const db_service, const char* const obj,
+                                       char** json_result);
+
+/**
+ * @brief Return db identity object with given single transaction id.
+ *
+ * @param[in] db_service db client service
+ * @param[in] obj transaction id
+ * @param[out] json_result Result containing the only one db identity object in json format
+ *
+ * @return
+ * - SC_OK on success
+ * - non-zero on error
+ */
+status_t api_get_identity_info_by_id(const db_client_service_t* const db_service, const char* const obj,
+                                     char** json_result);
+#endif
 
 #ifdef __cplusplus
 }

--- a/accelerator/server.cc
+++ b/accelerator/server.cc
@@ -355,7 +355,7 @@ int main(int argc, char* argv[]) {
           res.set_status(SC_HTTP_BAD_REQUEST);
           cJSON_Delete(json_obj);
         } else {
-          ret = api_send_transfer(&ta_core.iota_conf, &ta_core.iota_service, req.body().c_str(), &json_result);
+          ret = api_send_transfer(&ta_core, req.body().c_str(), &json_result);
           ret = set_response_content(ret, &json_result);
           res.set_status(ret);
         }

--- a/connectivity/mqtt/duplex_callback.c
+++ b/connectivity/mqtt/duplex_callback.c
@@ -63,7 +63,7 @@ static status_t mqtt_request_handler(mosq_config_t *cfg, char *subscribe_topic, 
       mqtt_transaction_hash_req_deserialize(req, hash);
       ret = api_find_transaction_object_single(&ta_core.iota_service, hash, &json_result);
     } else if (!strncmp(p + 12, "send", 4)) {
-      ret = api_send_transfer(&ta_core.iota_conf, &ta_core.iota_service, req, &json_result);
+      ret = api_send_transfer(&ta_core, req, &json_result);
     }
   } else if ((p = strstr(api_sub_topic, "tips"))) {
     if (!strncmp(p + 5, "all", 3)) {

--- a/response/BUILD
+++ b/response/BUILD
@@ -6,6 +6,10 @@ cc_library(
     hdrs = glob([
         "*.h",
     ]),
+    copts = select({
+        "//storage:db_enable": ["-DDB_ENABLE"],
+        "//conditions:default": [],
+    }),
     include_prefix = "response",
     visibility = ["//visibility:public"],
     deps = [
@@ -15,5 +19,8 @@ cc_library(
         "@entangled//mam/mam:message",
         "@entangled//utils/containers/hash:hash243_queue",
         "@entangled//utils/containers/hash:hash243_stack",
-    ],
+    ] + select({
+        "//storage:db_enable": ["//storage"],
+        "//conditions:default": [],
+    }),
 )

--- a/response/ta_send_transfer.h
+++ b/response/ta_send_transfer.h
@@ -10,6 +10,10 @@
 #define RESPONSE_TA_SEND_TRANSFER_H_
 
 #include <stdlib.h>
+#ifdef DB_ENABLE
+#include "storage/ta_storage.h"
+#endif
+#include "common/model/transaction.h"
 #include "utils/containers/hash/hash243_queue.h"
 
 #ifdef __cplusplus
@@ -24,6 +28,10 @@ extern "C" {
 typedef struct {
   /** Transaction address is a 243 long flex trits hash queue. */
   hash243_queue_t hash;
+  transaction_array_t* txn_array;
+#ifdef DB_ENABLE
+  char uuid_string[DB_UUID_STRING_LENGTH];
+#endif
 } ta_send_transfer_res_t;
 
 /**

--- a/serializer/BUILD
+++ b/serializer/BUILD
@@ -7,6 +7,9 @@ cc_library(
     copts = ["-DLOGGER_ENABLE"] + select({
         "//connectivity/mqtt:mqtt_enable": ["-DMQTT_ENABLE"],
         "//conditions:default": [],
+    }) + select({
+        "//storage:db_enable": ["-DDB_ENABLE"],
+        "//conditions:default": [],
     }),
     visibility = ["//visibility:public"],
     deps = [

--- a/serializer/serializer.h
+++ b/serializer/serializer.h
@@ -73,6 +73,19 @@ int serializer_logger_release();
 status_t ta_get_info_serialize(char** obj, ta_config_t* const ta_config, iota_config_t* const tangle,
                                ta_cache_t* const cache);
 
+#ifdef DB_ENABLE
+/**
+ * @brief Serialze identity info into JSON
+ *
+ * @param[out] obj db identity info in JSON
+ * @param[in] id_obj pointer to db_identity_t;
+ * @return
+ * - SC_OK on success
+ * - non-zero on error
+ */
+status_t db_identity_serialize(char** obj, db_identity_t* id_obj);
+#endif
+
 /**
  * @brief Serialze type of ta_generate_address_res_t to JSON string
  *
@@ -98,6 +111,19 @@ status_t ta_generate_address_res_serialize(const ta_generate_address_res_t* cons
 status_t ta_get_tips_res_serialize(const get_tips_res_t* const res, char** obj);
 
 /**
+ * @brief Serialze the response of api_insert_identity()
+ *
+ * @param[in] hash Response transaction hash
+ * @param[in] uuid_string Response uuid string
+ * @param[out] obj Input values in JSON
+ *
+ * @return
+ * - SC_OK on success
+ * - non-zero on error
+ */
+status_t ta_insert_identity_res_serialize(const char* hash, const char* uuid_string, char** obj);
+
+/**
  * @brief Deserialze JSON string to type of ta_send_transfer_req_t
  *
  * @param[in] obj Input values in JSON
@@ -112,14 +138,14 @@ status_t ta_send_transfer_req_deserialize(const char* const obj, ta_send_transfe
 /**
  * @brief Serialze the response of api_send_transfer()
  *
- * @param[in] res Response data in type of transaction_array_t
+ * @param[in] res Response data in type of ta_send_transfer_res_t
  * @param[out] obj Input values in JSON
  *
  * @return
  * - SC_OK on success
  * - non-zero on error
  */
-status_t ta_send_transfer_res_serialize(transaction_array_t* res, char** obj);
+status_t ta_send_transfer_res_serialize(ta_send_transfer_res_t* res, char** obj);
 
 /**
  * @brief Deserialze JSON string to hash8019_array_p

--- a/storage/scylladb_client.h
+++ b/storage/scylladb_client.h
@@ -14,6 +14,14 @@ extern "C" {
 #include "scylladb_utils.h"
 
 #define DB_UUID_STRING_LENGTH CASS_UUID_STRING_LENGTH
+
+/*
+ * DB_USAGE_NULL is for non-preserved usage and user-defined keyspace.
+ * Call db_init_identity_keyspace to give the keyspace name.
+ * This method could be enhanced by supporting user-defined keyspace name when
+ * specific the preserved usage.
+ */
+typedef enum { DB_USAGE_REATTACH = 0, DB_USAGE_NULL, NUM_DB_USAGE } db_client_usage_t;
 typedef struct {
   CassCluster* cluster;
   CassSession* session;
@@ -27,11 +35,12 @@ typedef struct {
  * @brief init ScyllaDB client serivce and connect to specific cluster
  *
  * @param[out] service ScyllaDB client service
+ * @param[in] usage specfic usage for db client serivce
  * @return
  * - SC_OK on success
  * - non-zero on error
  */
-status_t db_client_service_init(db_client_service_t* service);
+status_t db_client_service_init(db_client_service_t* service, db_client_usage_t usage);
 
 /**
  * @brief free ScyllaDB client serivce

--- a/tests/test_scylladb.c
+++ b/tests/test_scylladb.c
@@ -136,7 +136,7 @@ void test_permanode(void) {
   size_t tx_num = sizeof(hashes) / (NUM_FLEX_TRITS_HASH);
   scylla_iota_transaction_t* transaction;
   db_client_service.host = strdup(host);
-  TEST_ASSERT_EQUAL_INT(db_client_service_init(&db_client_service), SC_OK);
+  TEST_ASSERT_EQUAL_INT(db_client_service_init(&db_client_service, DB_USAGE_NULL), SC_OK);
   TEST_ASSERT_EQUAL_INT(db_permanent_keyspace_init(&db_client_service, true, keyspace_name), SC_OK);
 
   new_scylla_iota_transaction(&transaction);
@@ -221,7 +221,7 @@ void test_db_get_identity_objs_by_hash(db_client_service_t* db_client_service) {
 void test_db_identity_table(void) {
   db_client_service_t db_client_service;
   db_client_service.host = strdup(host);
-  TEST_ASSERT_EQUAL_INT(db_client_service_init(&db_client_service), SC_OK);
+  TEST_ASSERT_EQUAL_INT(db_client_service_init(&db_client_service, DB_USAGE_NULL), SC_OK);
   TEST_ASSERT_EQUAL_INT(db_init_identity_keyspace(&db_client_service, true, keyspace_name), SC_OK);
   for (int i = 0; i < identity_num; i++) {
     db_insert_tx_into_identity(&db_client_service, identities[i].hash, identities[i].status, identities[i].uuid_string);


### PR DESCRIPTION
Insert a new pending transaction after successfully send a transfer message.

3 new APIs
 - /identity/hash/<hash> : get identity info by hash
 - /identity/id/<id> : get identity info by uuid string
 - /transaction/id/<id> : get transaction info by uuid string

Close #362