### PR TITLE
Separate connection policy with build options

### DIFF
--- a/accelerator/BUILD
+++ b/accelerator/BUILD
@@ -5,8 +5,16 @@ load("@io_bazel_rules_docker//container:container.bzl", "container_push")
 
 cc_binary(
     name = "accelerator",
-    srcs = ["server.cc"],
-    copts = ["-DLOGGER_ENABLE"] + select({
+    srcs = select({
+        "//connectivity/mqtt:mqtt_enable": [
+            "conn_mqtt.c",
+        ],
+        "//conditions:default": ["main.c"],
+    }),
+    copts = [
+        "-DLOGGER_ENABLE",
+        "-DMQTT_ENABLE",
+    ] + select({
         ":DEBUG_MODE": ["-g"],
         ":PROFILING_MODE": [
             "-DNDEBUG",
@@ -15,12 +23,18 @@ cc_binary(
         "//conditions:default": ["-DNDEBUG"],
     }),
     deps = [
-        ":apis",
-        ":proxy_apis",
         ":ta_config",
         ":ta_errors",
-        "@served",
-    ],
+        ":http",
+        "@entangled//utils/handles:signal",
+        ":apis",
+        ":proxy_apis",
+    ] + select({
+        "//connectivity/mqtt:mqtt_enable": [
+            "//connectivity/mqtt:mqtt_utils",
+        ],
+        "//conditions:default": [],
+    }),
 )
 
 cc_binary(
@@ -38,36 +52,6 @@ cc_binary(
         ":http",
         ":ta_config",
         ":ta_errors",
-        "@entangled//utils/handles:signal",
-    ],
-)
-
-cc_binary(
-    name = "accelerator_mqtt",
-    srcs = [
-        "config.c",
-        "config.h",
-        "conn_mqtt.c",
-    ],
-    copts = [
-        "-DLOGGER_ENABLE",
-        "-DENABLE_MQTT",
-    ] + select({
-        ":DEBUG_MODE": ["-g"],
-        ":PROFILING_MODE": [
-            "-DNDEBUG",
-            "-pg",
-        ],
-        "//conditions:default": ["-DNDEBUG"],
-    }),
-    deps = [
-        ":message",
-        ":ta_config",
-        ":ta_errors",
-        "//connectivity/mqtt:mqtt_utils",
-        "//utils:cache",
-        "//utils:pow",
-        "@entangled//cclient/api",
         "@entangled//utils/handles:signal",
     ],
 )

--- a/accelerator/config.c
+++ b/accelerator/config.c
@@ -123,7 +123,7 @@ status_t ta_core_default_init(ta_config_t* const ta_conf, iota_config_t* const i
   ta_conf->host = TA_HOST;
   ta_conf->port = TA_PORT;
   ta_conf->thread_count = TA_THREAD_COUNT;
-#ifdef ENABLE_MQTT
+#ifdef MQTT_ENABLE 
   ta_conf->mqtt_host = MQTT_HOST;
   ta_conf->mqtt_topic_root = TOPIC_ROOT;
 #endif

--- a/accelerator/config.h
+++ b/accelerator/config.h
@@ -34,7 +34,7 @@ extern "C" {
 #define TA_VERSION "tangle-accelerator/0.5.0"
 #define TA_HOST "localhost"
 
-#ifdef ENABLE_MQTT
+#ifdef MQTT_ENABLE 
 #define MQTT_HOST "localhost"
 #define TOPIC_ROOT "root/topics"
 #endif
@@ -63,7 +63,7 @@ typedef struct ta_config_s {
   char* host;           /**< Binding address of tangle-accelerator */
   char* port;           /**< Binding port of tangle-accelerator */
   uint8_t thread_count; /**< Thread count of tangle-accelerator instance */
-#ifdef ENABLE_MQTT
+#ifdef MQTT_ENABLE 
   char* mqtt_host;       /**< Address of MQTT broker host */
   char* mqtt_topic_root; /**< The topic root of MQTT topic */
 #endif

--- a/accelerator/conn_mqtt.c
+++ b/accelerator/conn_mqtt.c
@@ -1,6 +1,6 @@
 #include "accelerator/config.h"
 #include "config.h"
-#include "connectivity/mqtt/client_common.h"
+#include "connectivity/mqtt/mqtt_common.h"
 #include "connectivity/mqtt/duplex_callback.h"
 #include "connectivity/mqtt/duplex_utils.h"
 #include "errors.h"

--- a/connectivity/mqtt/BUILD
+++ b/connectivity/mqtt/BUILD
@@ -1,3 +1,8 @@
+config_setting(
+    name = "mqtt_enable",
+    values = {"define": "build=mqtt"},
+)
+
 cc_library(
     name = "mqtt_utils",
     srcs = [
@@ -8,7 +13,7 @@ cc_library(
         "duplex_callback.h",
         "duplex_utils.h",
     ],
-    copts = ["-DENABLE_MQTT"],
+    copts = ["-DMQTT_ENABLE"],
     visibility = ["//visibility:public"],
     deps = [
         ":mqtt_common",
@@ -22,16 +27,16 @@ cc_library(
 cc_library(
     name = "mqtt_common",
     srcs = [
-        "client_common.c",
+        "mqtt_common.c",
         "pub_utils.c",
         "sub_utils.c",
     ],
     hdrs = [
-        "client_common.h",
+        "mqtt_common.h",
         "pub_utils.h",
         "sub_utils.h",
     ],
-    copts = ["-DENABLE_MQTT"],
+    copts = ["-DMQTT_ENABLE"],
     visibility = ["//serializer:__pkg__"],
     deps = [
         "//accelerator:ta_config",

--- a/connectivity/mqtt/mqtt_common.c
+++ b/connectivity/mqtt/mqtt_common.c
@@ -6,7 +6,7 @@
  * "LICENSE" at the root of this distribution.
  */
 
-#include "client_common.h"
+#include "mqtt_common.h"
 #include <errno.h>
 #include <stdlib.h>
 #include <string.h>

--- a/connectivity/mqtt/mqtt_common.h
+++ b/connectivity/mqtt/mqtt_common.h
@@ -11,14 +11,17 @@
 
 #include <stdio.h>
 #include "accelerator/errors.h"
+
+#ifdef MQTT_ENABLE
 #include "third_party/mosquitto/lib/mosquitto.h"
+#endif
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 /**
- * @file connectivity/mqtt/client_common.h
+ * @file connectivity/mqtt/mqtt_common.h
  */
 
 #define ID_LEN 32
@@ -26,6 +29,7 @@ extern "C" {
 
 typedef enum client_type_s { client_pub, client_sub, client_duplex } client_type_t;
 
+#ifdef MQTT_ENABLE
 typedef enum mosq_err_t mosq_retcode_t;  // typedef the original enum
 
 typedef struct mosq_general_config_s {
@@ -205,6 +209,7 @@ status_t mosq_client_connect(struct mosquitto *mosq, mosq_config_t *cfg);
  * - non-zero on error
  */
 status_t cfg_add_topic(mosq_config_t *cfg, client_type_t client_type, char *topic);
+#endif
 
 #ifdef __cplusplus
 }

--- a/connectivity/mqtt/pub_utils.h
+++ b/connectivity/mqtt/pub_utils.h
@@ -9,7 +9,7 @@
 #ifndef PUB_UTILS_H
 #define PUB_UTILS_H
 
-#include "client_common.h"
+#include "mqtt_common.h"
 #undef uthash_free
 #undef uthash_malloc
 #include "third_party/mosquitto/config.h"

--- a/connectivity/mqtt/sub_utils.h
+++ b/connectivity/mqtt/sub_utils.h
@@ -9,7 +9,7 @@
 #ifndef SUB_UTILS_H
 #define SUB_UTILS_H
 
-#include "client_common.h"
+#include "mqtt_common.h"
 #include "third_party/mosquitto/config.h"
 
 #ifdef __cplusplus

--- a/serializer/BUILD
+++ b/serializer/BUILD
@@ -4,12 +4,14 @@ cc_library(
     name = "serializer",
     srcs = ["serializer.c"],
     hdrs = ["serializer.h"],
-    copts = ["-DLOGGER_ENABLE"],
+    copts = ["-DLOGGER_ENABLE"] + select({
+        "//connectivity/mqtt:mqtt_enable": ["-DMQTT_ENABLE"],
+        "//conditions:default": [],
+    }),
     visibility = ["//visibility:public"],
     deps = [
         "//accelerator:ta_config",
         "//accelerator:ta_errors",
-        "//connectivity/mqtt:mqtt_common",
         "//request",
         "//response",
         "//utils:fill_nines",
@@ -20,5 +22,8 @@ cc_library(
         "@entangled//common/trinary:tryte_ascii",
         "@entangled//utils:char_buffer",
         "@entangled//utils/containers/hash:hash_array",
-    ],
+    ] + select({
+        "//connectivity/mqtt:mqtt_enable": ["//connectivity/mqtt:mqtt_common"],
+        "//conditions:default": [],
+    }),
 )

--- a/serializer/serializer.c
+++ b/serializer/serializer.c
@@ -7,7 +7,9 @@
  */
 
 #include "serializer.h"
-#include "connectivity/mqtt/client_common.h"
+#ifdef MQTT_ENABLE
+#include "connectivity/mqtt/mqtt_common.h"
+#endif
 #include "utils/logger.h"
 #define SERI_LOGGER "serializer"
 
@@ -867,6 +869,7 @@ done:
   return ret;
 }
 
+#ifdef MQTT_ENABLE
 status_t mqtt_device_id_deserialize(const char* const obj, char* device_id) {
   if (obj == NULL) {
     ta_log_error("%s\n", "SC_SERIALIZER_NULL");
@@ -938,6 +941,7 @@ done:
   cJSON_Delete(json_obj);
   return ret;
 }
+#endif
 
 status_t proxy_apis_command_req_deserialize(const char* const obj, char* command) {
   if (obj == NULL) {

--- a/serializer/serializer.h
+++ b/serializer/serializer.h
@@ -243,6 +243,7 @@ status_t send_mam_res_deserialize(const char* const obj, ta_send_mam_res_t* cons
  */
 status_t send_mam_res_serialize(const ta_send_mam_res_t* const res, char** obj);
 
+#ifdef MQTT_ENABLE
 /**
  * @brief Deserialze device ID from MQTT JSON request.
  *
@@ -278,6 +279,7 @@ status_t mqtt_tag_req_deserialize(const char* const obj, char* tag);
  * - non-zero on error
  */
 status_t mqtt_transaction_hash_req_deserialize(const char* const obj, char* hash);
+#endif
 
 /**
  * @brief Deserialze proxy api command.

--- a/tests/test_serializer.c
+++ b/tests/test_serializer.c
@@ -6,7 +6,7 @@
  * "LICENSE" at the root of this distribution.
  */
 
-#include "connectivity/mqtt/client_common.h"
+#include "connectivity/mqtt/mqtt_common.h"
 #include "serializer/serializer.h"
 #include "test_define.h"
 


### PR DESCRIPTION
Fixes #352.

This commit merges `accelerator` and `accelerator_mqtt` into `accelerator`. To use the mqtt version, we need to add the option `--define build=mqtt` after the original command.