### PR TITLE
fix: bazel caused  IRI connection error

### DIFF
--- a/accelerator/BUILD
+++ b/accelerator/BUILD
@@ -5,7 +5,10 @@ load("@io_bazel_rules_docker//container:container.bzl", "container_push")
 
 cc_binary(
     name = "accelerator",
-    srcs = select({
+    srcs = [
+        "config.c",
+        "config.h",
+    ] + select({
         "//connectivity/mqtt:mqtt_enable": [
             "conn_mqtt.c",
         ],
@@ -23,7 +26,6 @@ cc_binary(
         "//conditions:default": ["-DNDEBUG"],
     }),
     deps = [
-        ":ta_config",
         ":ta_errors",
         ":http",
         "@entangled//utils/handles:signal",

--- a/connectivity/mqtt/BUILD
+++ b/connectivity/mqtt/BUILD
@@ -1,6 +1,6 @@
 config_setting(
     name = "mqtt_enable",
-    values = {"define": "build=mqtt"},
+    values = {"define": "mqtt=enable"},
 )
 
 cc_library(


### PR DESCRIPTION
Error was caused without including `config.c`
and `config.h` in bazel rule `accelerator`.

The error caused varriable `iota_service.serializer_type` was written
wrongly.

fix #381 