### PR TITLE
Conditional build for ScyllaDB backend and its dependance

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,31 @@ make MQTT && bazel run //accelerator:accelerator_mqtt
 Note you may need to set up the `MQTT_HOST` and `TOPIC_ROOT` in `config.h` to connect to a MQTT broker.
 For more information for MQTT connectivity of `tangle-accelerator`, you could read `connectivity/mqtt/usage.md`.
 
+### Optional: Enable external database for transaction reattachment
+Transaction reattachment is an optional feature.
+
+You can enable it in the build time by adding option : `--define db=enable`
+
+Transaction reattachment relies on ScyllDB, you need to install the dependency by following commands.
+
+For Ubuntu Linux 16.04/x86_64:
+
+```
+wget https://downloads.datastax.com/cpp-driver/ubuntu/16.04/cassandra/v2.14.1/cassandra-cpp-driver_2.14.1-1_amd64.deb
+wget https://downloads.datastax.com/cpp-driver/ubuntu/16.04/cassandra/v2.14.1/cassandra-cpp-driver-dev_2.14.1-1_amd64.deb
+sudo dpkg -i cassandra-cpp-driver_2.14.1-1_amd64.deb
+sudo dpkg -i cassandra-cpp-driver-dev_2.14.1-1_amd64.deb
+```
+
+For Ubuntu Linux 18.04/x86_64:
+
+```
+wget https://downloads.datastax.com/cpp-driver/ubuntu/18.04/cassandra/v2.14.1/cassandra-cpp-driver_2.14.1-1_amd64.deb
+wget https://downloads.datastax.com/cpp-driver/ubuntu/18.04/cassandra/v2.14.1/cassandra-cpp-driver-dev_2.14.1-1_amd64.deb
+sudo dpkg -i cassandra-cpp-driver_2.14.1-1_amd64.deb
+sudo dpkg -i cassandra-cpp-driver-dev_2.14.1-1_amd64.deb
+```
+
 ## Developing
 
 The codebase of this repository follows [Google's C++ guidelines](https://google.github.io/styleguide/cppguide.html):

--- a/accelerator/BUILD
+++ b/accelerator/BUILD
@@ -25,6 +25,9 @@ cc_binary(
             "-DMQTT_ENABLE",
         ],
         "//conditions:default": [],
+    }) + select({
+        "//storage:db_enable": ["-DDB_ENABLE"],
+        "//conditions:default": [],
     }),
     deps = [
         ":ta_errors",
@@ -151,18 +154,23 @@ cc_library(
             "-DMQTT_ENABLE",
         ],
         "//conditions:default": [],
+    }) + select({
+        "//storage:db_enable": ["-DDB_ENABLE"],
+        "//conditions:default": [],
     }),
     visibility = ["//visibility:public"],
     deps = [
         ":message",
         ":ta_errors",
-        "//storage",
         "//utils:cache",
         "//utils:pow",
         "//utils:ta_logger",
         "@entangled//cclient/api",
         "@yaml",
-    ],
+    ] + select({
+        "//storage:db_enable": ["//storage"],
+        "//conditions:default": [],
+    }),
 )
 
 config_setting(

--- a/accelerator/config.h
+++ b/accelerator/config.h
@@ -15,7 +15,9 @@
 #include "accelerator/message.h"
 #include "cclient/api/core/core_api.h"
 #include "cclient/api/extended/extended_api.h"
+#ifdef DB_ENABLE
 #include "storage/ta_storage.h"
+#endif
 #include "utils/cache.h"
 #include "utils/logger.h"
 #include "utils/pow.h"
@@ -92,8 +94,10 @@ typedef struct ta_core_s {
   ta_cache_t cache;                   /**< redis configiuration structure */
   iota_config_t iota_conf;            /**< iota configuration structure */
   iota_client_service_t iota_service; /**< iota connection structure */
-  db_client_service_t db_service;     /**< db connection structure */
-  char conf_file[FILE_PATH_SIZE];     /**< path to the configuration file */
+#ifdef DB_ENABLE
+  db_client_service_t db_service; /**< db connection structure */
+#endif
+  char conf_file[FILE_PATH_SIZE]; /**< path to the configuration file */
 } ta_core_t;
 
 /**
@@ -112,22 +116,18 @@ int get_conf_key(char const* const key);
 /**
  * Initializes configurations with default values
  *
- * @param ta_conf[in] Tangle-accelerator configuration variables
- * @param iota_conf[in] iota configuration variables
- * @param cache[in] redis configuration variables
- * @param iota_service[in] IRI connection configuration variables
+ * @param core[in] Pointer to Tangle-accelerator core configuration structure
  *
  * @return
  * - SC_OK on success
  * - non-zero on error
  */
-status_t ta_core_default_init(ta_config_t* const ta_conf, iota_config_t* const iota_conf, ta_cache_t* const cache,
-                              iota_client_service_t* const iota_service, db_client_service_t* const db_service);
+status_t ta_core_default_init(ta_core_t* const core);
 
 /**
  * Initializes configurations with configuration file
  *
- * @param core[in] Tangle-accelerator core configuration variable
+ * @param core[in] Pointer to Tangle-accelerator core configuration structure
  * @param argc[in] Number of argument of CLI
  * @param argv[in] Argument of CLI
  *
@@ -140,7 +140,7 @@ status_t ta_core_file_init(ta_core_t* const core, int argc, char** argv);
 /**
  * Initializes configurations with CLI values
  *
- * @param core[in] Tangle-accelerator core configuration variable
+ * @param core[in] Pointer to Tangle-accelerator core configuration structure
  * @param argc[in] Number of argument of CLI
  * @param argv[in] Argument of CLI
  *
@@ -153,25 +153,21 @@ status_t ta_core_cli_init(ta_core_t* const core, int argc, char** argv);
 /**
  * Start services after configurations are set
  *
- * @param cache[in] Redis server configuration variables
- * @param iota_service[in] IRI connection configuration variables
- * @param db_service[in] DB connection configuratin variables
+ * @param core[in] Pointer to Tangle-accelerator core configuration structure
  *
  * @return
  * - SC_OK on success
  * - non-zero on error
  */
-status_t ta_core_set(ta_cache_t* const cache, iota_client_service_t* const iota_service,
-                     db_client_service_t* const db_service);
+status_t ta_core_set(ta_core_t* const core);
 
 /**
  * Free memory of configuration variables
  *
- * @param iota_service[in] IRI connection configuration variables
- * @param db_service[in] DB connection configuratin variables
+ * @param core[in] Pointer to Tangle-accelerator core configuration structure.
  *
  */
-void ta_core_destroy(iota_client_service_t* const iota_service, db_client_service_t* const db_service);
+void ta_core_destroy(ta_core_t* const core);
 
 #ifdef __cplusplus
 }

--- a/accelerator/conn_mqtt.c
+++ b/accelerator/conn_mqtt.c
@@ -23,8 +23,7 @@ int main(int argc, char *argv[]) {
   logger_id = logger_helper_enable(CONN_MQTT_LOGGER, LOGGER_DEBUG, true);
 
   // Initialize configurations with default value
-  if (ta_core_default_init(&ta_core.ta_conf, &ta_core.iota_conf, &ta_core.cache, &ta_core.iota_service,
-                           &ta_core.db_service) != SC_OK) {
+  if (ta_core_default_init(&ta_core) != SC_OK) {
     return EXIT_FAILURE;
   }
 
@@ -33,7 +32,7 @@ int main(int argc, char *argv[]) {
     return EXIT_FAILURE;
   }
 
-  if (ta_core_set(&ta_core.cache, &ta_core.iota_service, &ta_core.db_service) != SC_OK) {
+  if (ta_core_set(&ta_core) != SC_OK) {
     ta_log_error("Configure failed %s.\n", CONN_MQTT_LOGGER);
     return EXIT_FAILURE;
   }

--- a/accelerator/main.c
+++ b/accelerator/main.c
@@ -30,8 +30,7 @@ int main(int argc, char* argv[]) {
   logger_id = logger_helper_enable(MAIN_LOGGER, LOGGER_DEBUG, true);
 
   // Initialize configurations with default value
-  if (ta_core_default_init(&ta_core.ta_conf, &ta_core.iota_conf, &ta_core.cache, &ta_core.iota_service,
-                           &ta_core.db_service) != SC_OK) {
+  if (ta_core_default_init(&ta_core) != SC_OK) {
     return EXIT_FAILURE;
   }
 
@@ -45,7 +44,7 @@ int main(int argc, char* argv[]) {
     return EXIT_FAILURE;
   }
 
-  if (ta_core_set(&ta_core.cache, &ta_core.iota_service, &ta_core.db_service) != SC_OK) {
+  if (ta_core_set(&ta_core) != SC_OK) {
     ta_log_error("Configure failed %s.\n", MAIN_LOGGER);
     return EXIT_FAILURE;
   }
@@ -93,7 +92,7 @@ cleanup:
     return EXIT_FAILURE;
   }
   log_warning(logger_id, "Destroying TA configurations\n");
-  ta_core_destroy(&ta_core.iota_service, &ta_core.db_service);
+  ta_core_destroy(&ta_core);
 
   if (verbose_mode) {
     http_logger_release();

--- a/accelerator/server.cc
+++ b/accelerator/server.cc
@@ -77,8 +77,7 @@ int main(int argc, char* argv[]) {
   logger_id = logger_helper_enable(SERVER_LOGGER, LOGGER_DEBUG, true);
 
   // Initialize configurations with default value
-  if (ta_core_default_init(&ta_core.ta_conf, &ta_core.iota_conf, &ta_core.cache, &ta_core.iota_service,
-                           &ta_core.db_service) != SC_OK) {
+  if (ta_core_default_init(&ta_core) != SC_OK) {
     return EXIT_FAILURE;
   }
 
@@ -92,7 +91,7 @@ int main(int argc, char* argv[]) {
     return EXIT_FAILURE;
   }
 
-  if (ta_core_set(&ta_core.cache, &ta_core.iota_service, &ta_core.db_service) != SC_OK) {
+  if (ta_core_set(&ta_core) != SC_OK) {
     ta_log_error("Configure failed %s.\n", SERVER_LOGGER);
     return EXIT_FAILURE;
   }

--- a/storage/BUILD
+++ b/storage/BUILD
@@ -1,5 +1,10 @@
 package(default_visibility = ["//visibility:public"])
 
+config_setting(
+    name = "db_enable",
+    values = {"define": "db=enable"},
+)
+
 cc_library(
     name = "storage",
     hdrs = ["ta_storage.h"],

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -35,6 +35,9 @@ cc_test(
             "-DMQTT_ENABLE",
         ],
         "//conditions:default": [],
+    }) + select({
+        "//storage:db_enable": ["-DDB_ENABLE"],
+        "//conditions:default": [],
     }),
     deps = [
         ":test_define",
@@ -114,13 +117,16 @@ cc_library(
 
 cc_test(
     name = "test_scylladb",
-    srcs = [
-        "test_scylladb.c",
-    ],
+    srcs = select({
+        "//storage:db_enable": ["test_scylladb.c"],
+        "//conditions:default": ["empty_test.c"],
+    }),
     deps = [
         ":test_define",
-        "//storage",
-    ],
+    ] + select({
+        "//storage:db_enable": ["//storage"],
+        "//conditions:default": [],
+    }),
 )
 
 cc_test(

--- a/tests/driver.c
+++ b/tests/driver.c
@@ -265,10 +265,9 @@ int main(int argc, char* argv[]) {
     return EXIT_FAILURE;
   }
 
-  ta_core_default_init(&ta_core.ta_conf, &ta_core.iota_conf, &ta_core.cache, &ta_core.iota_service,
-                       &ta_core.db_service);
+  ta_core_default_init(&ta_core);
   ta_core_cli_init(&ta_core, argc, argv);
-  ta_core_set(&ta_core.cache, &ta_core.iota_service, &ta_core.db_service);
+  ta_core_set(&ta_core);
 
   printf("Total samples for each API test: %d\n", TEST_COUNT);
   RUN_TEST(test_generate_address);
@@ -282,6 +281,6 @@ int main(int argc, char* argv[]) {
   RUN_TEST(test_find_transactions_by_tag);
   RUN_TEST(test_find_transactions_obj_by_tag);
   RUN_TEST(test_proxy_apis);
-  ta_core_destroy(&ta_core.iota_service, &ta_core.db_service);
+  ta_core_destroy(&ta_core);
   return UNITY_END();
 }

--- a/tests/empty_test.c
+++ b/tests/empty_test.c
@@ -1,0 +1,16 @@
+/*
+ * Copyright (C) 2019 BiiLabs Co., Ltd. and Contributors
+ * All Rights Reserved.
+ * This is free software; you can redistribute it and/or modify it under the
+ * terms of the MIT license. A copy of the license can be found in the file
+ * "LICENSE" at the root of this distribution.
+ */
+
+/* To disable some checks of sanitizer tools to certain Bazel tests, one way is
+ * redirecting test source files to empty_test.c in the Bazel BULID file. Using
+ * Bazel `select()` function with user-defined `config_setting` to achieve the
+ * ignorement of sanitrizer tools. For exmaple, command `bazel test //tests/test_scylladb`
+ * will perform tests in `test_scylladb.c` only when users add `--define db=enable`
+ * at build time. Otherwise, the tests will be redirecting to this file.
+ */
+int main(void) { return 0; }

--- a/tests/test_common.cc
+++ b/tests/test_common.cc
@@ -11,9 +11,9 @@
 #include "accelerator/common_core.h"
 #include "iota_api_mock.hh"
 
+using ::testing::_;
 using ::testing::AtLeast;
 using ::testing::ElementsAreArray;
-using ::testing::_;
 
 APIMock APIMockObj;
 iota_config_t tangle;

--- a/tests/test_scylladb.c
+++ b/tests/test_scylladb.c
@@ -259,6 +259,7 @@ int main(int argc, char** argv) {
 
   UNITY_BEGIN();
   if (ta_logger_init() != SC_OK) {
+    ta_log_error("logger init fail\n");
     return EXIT_FAILURE;
   }
   scylladb_logger_init();


### PR DESCRIPTION
To enable ScyllaDB backend and tests :

Add Bazel CLI option --define db_enable

Otherwise, TA won't build ScyllaDB backend and tests by default.

close #383