### PR TITLE
Fix regression test

### DIFF
--- a/tests/regression/0_build.sh
+++ b/tests/regression/0_build.sh
@@ -8,4 +8,4 @@ pid=$!
 kill $pid
 wait $pid
 
-trap 'exit 0' SIGTERM
+trap 'exit 0' TERM

--- a/tests/regression/1_run_TA_API.sh
+++ b/tests/regression/1_run_TA_API.sh
@@ -16,4 +16,4 @@ then
 fi
 
 wait $(kill -9 $TA)
-trap 'exit 0' SIGTERM
+trap 'exit 0' TERM


### PR DESCRIPTION
Fixes #359, #393.

Removed `test_find_transactions` since this route no longer exists now.
More checks are added in case of non-200 status code which may lead
the test to stop unexpectedly.