### PR TITLE
fix: Fix wrongly define MQTT_ENABLE in accelerator

### DIFF
--- a/accelerator/BUILD
+++ b/accelerator/BUILD
@@ -5,10 +5,7 @@ load("@io_bazel_rules_docker//container:container.bzl", "container_push")
 
 cc_binary(
     name = "accelerator",
-    srcs = [
-        "config.c",
-        "config.h",
-    ] + select({
+    srcs = select({
         "//connectivity/mqtt:mqtt_enable": [
             "conn_mqtt.c",
         ],
@@ -16,7 +13,6 @@ cc_binary(
     }),
     copts = [
         "-DLOGGER_ENABLE",
-        "-DMQTT_ENABLE",
     ] + select({
         ":DEBUG_MODE": ["-g"],
         ":PROFILING_MODE": [
@@ -24,9 +20,15 @@ cc_binary(
             "-pg",
         ],
         "//conditions:default": ["-DNDEBUG"],
+    }) + select({
+        "//connectivity/mqtt:mqtt_enable": [
+            "-DMQTT_ENABLE",
+        ],
+        "//conditions:default": [],
     }),
     deps = [
         ":ta_errors",
+        ":ta_config",
         ":http",
         "@entangled//utils/handles:signal",
         ":apis",
@@ -144,6 +146,12 @@ cc_library(
     name = "ta_config",
     srcs = ["config.c"],
     hdrs = ["config.h"],
+    copts = select({
+        "//connectivity/mqtt:mqtt_enable": [
+            "-DMQTT_ENABLE",
+        ],
+        "//conditions:default": [],
+    }),
     visibility = ["//visibility:public"],
     deps = [
         ":message",

--- a/accelerator/config.c
+++ b/accelerator/config.c
@@ -131,7 +131,7 @@ status_t ta_core_default_init(ta_config_t* const ta_conf, iota_config_t* const i
   ta_conf->port = TA_PORT;
   ta_conf->thread_count = TA_THREAD_COUNT;
   ta_conf->proxy_passthrough = false;
-#ifdef ENABLE_MQTT
+#ifdef MQTT_ENABLE
   ta_conf->mqtt_host = MQTT_HOST;
   ta_conf->mqtt_topic_root = TOPIC_ROOT;
 #endif

--- a/accelerator/config.h
+++ b/accelerator/config.h
@@ -34,7 +34,7 @@ extern "C" {
 #define TA_VERSION "tangle-accelerator/0.5.0"
 #define TA_HOST "localhost"
 
-#ifdef MQTT_ENABLE 
+#ifdef MQTT_ENABLE
 #define MQTT_HOST "localhost"
 #define TOPIC_ROOT "root/topics"
 #endif
@@ -63,7 +63,7 @@ typedef struct ta_config_s {
   char* host;           /**< Binding address of tangle-accelerator */
   char* port;           /**< Binding port of tangle-accelerator */
   uint8_t thread_count; /**< Thread count of tangle-accelerator instance */
-#ifdef MQTT_ENABLE 
+#ifdef MQTT_ENABLE
   char* mqtt_host;       /**< Address of MQTT broker host */
   char* mqtt_topic_root; /**< The topic root of MQTT topic */
 #endif

--- a/accelerator/conn_mqtt.c
+++ b/accelerator/conn_mqtt.c
@@ -1,8 +1,8 @@
 #include "accelerator/config.h"
 #include "config.h"
-#include "connectivity/mqtt/mqtt_common.h"
 #include "connectivity/mqtt/duplex_callback.h"
 #include "connectivity/mqtt/duplex_utils.h"
+#include "connectivity/mqtt/mqtt_common.h"
 #include "errors.h"
 
 #define CONN_MQTT_LOGGER "conn-mqtt"


### PR DESCRIPTION
We wrongly defined `MQTT_ENABLE` in rule `accelerator` which causes the whole program crashed.
`MQTT_ENABLE` should be a building identifier for MQTT is chosen only and keep consistency of define building identifier.