### PR TITLE
Consolidate MQTT specific translation units

### DIFF
--- a/tests/BUILD
+++ b/tests/BUILD
@@ -30,6 +30,12 @@ cc_test(
     srcs = [
         "driver.c",
     ],
+    copts = select({
+        "//connectivity/mqtt:mqtt_enable": [
+            "-DMQTT_ENABLE",
+        ],
+        "//conditions:default": [],
+    }),
     deps = [
         ":test_define",
         "//accelerator:apis",


### PR DESCRIPTION
The definition of ta_core_t in translation unit driver.c is different from config.c and main.c after merging #395.

Since the code in driver.c does declare ta_core_t, the MQTT_ENABLE should be defined when using option --define mqtt=enable at build time.

We could find that the size of ta_core_t will be different if #ifdef MQTT_ENABLE have different results

```
show the sizeof(ta_core_t)
sizeof ta_core_t in driver.c = 744
sizeof ta_core_t in config.c = 768
```

close #399 