### PR TITLE
fix: Fix miscellaneous request payload

### DIFF
--- a/accelerator/http.c
+++ b/accelerator/http.c
@@ -360,8 +360,14 @@ static int ta_http_handler(void *cls, struct MHD_Connection *connection, const c
   // While upload_data_size > 0 process upload_data
   if (*upload_data_size > 0) {
     if (http_req->request == NULL) {
-      http_req->request = (char *)malloc(*upload_data_size);
+      http_req->request = (char *)malloc((*upload_data_size) + 1);
+      if (http_req->request == NULL) {
+        ta_log_error("%s\n", "Not enough size for allocating HTTP request payload.");
+        goto cleanup;
+      }
+
       strncpy(http_req->request, upload_data, *upload_data_size);
+      http_req->request[*upload_data_size] = 0;
     } else {
       ret = MHD_NO;
       ta_log_error("%s\n", "MHD_NO");

--- a/tests/test_common.cc
+++ b/tests/test_common.cc
@@ -11,9 +11,9 @@
 #include "accelerator/common_core.h"
 #include "iota_api_mock.hh"
 
-using ::testing::_;
 using ::testing::AtLeast;
 using ::testing::ElementsAreArray;
+using ::testing::_;
 
 APIMock APIMockObj;
 iota_config_t tangle;


### PR DESCRIPTION
Without giving terminate character `\0`, the HTTP payload
may contain some miscellaneous string.

fixes #408