### PR TITLE
fix(build): Fix wrong Makefile clean rule

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ $(MOSQITTO_LIB): $(MOSQITTO_DIR)
 
 clean:
 	$(MAKE) -C $(DCURL_DIR) clean
-	$(MAKE) -C $(MOSQITTO_LIB) clean
+	$(MAKE) -C $(MOSQITTO_DIR) clean
 
 distclean: clean
 	$(RM) -r $(DCURL_DIR)


### PR DESCRIPTION
The top level Makefile clean rule directed to a wrong directory.