### PR TITLE
fix(http): Fix NULL request error under root path

### DIFF
--- a/connectivity/http/http.c
+++ b/connectivity/http/http.c
@@ -295,17 +295,17 @@ static int ta_http_process_request(ta_http_t *const http, char const *const url,
   } else if (ta_http_url_matcher(url, "/mam[/]?") == SC_OK) {
     if (payload != NULL) {
       return process_mam_send_msg_request(http, payload, out);
-    } else {
-      return process_method_not_allowed_request(out);
     }
+    return process_method_not_allowed_request(out);
+
   } else if (ta_http_url_matcher(url, "/transaction/[A-Z9]{81}[/]?") == SC_OK) {
     return process_find_txn_obj_single_request(http, url, out);
   } else if (ta_http_url_matcher(url, "/transaction/object[/]?") == SC_OK) {
     if (payload != NULL) {
       return process_find_txn_obj_request(http, payload, out);
-    } else {
-      return process_method_not_allowed_request(out);
     }
+    return process_method_not_allowed_request(out);
+
   } else if (ta_http_url_matcher(url, "/tips/pair[/]?") == SC_OK) {
     return process_get_tips_pair_request(http, out);
   } else if (ta_http_url_matcher(url, "/tips[/]?") == SC_OK) {
@@ -329,20 +329,23 @@ static int ta_http_process_request(ta_http_t *const http, char const *const url,
   else if (ta_http_url_matcher(url, "/transaction[/]?") == SC_OK) {
     if (payload != NULL) {
       return process_send_transfer_request(http, payload, out);
-    } else {
-      return process_method_not_allowed_request(out);
     }
+    return process_method_not_allowed_request(out);
+
   } else if (ta_http_url_matcher(url, "/tryte[/]?") == SC_OK) {
     if (payload != NULL) {
       return process_send_trytes_request(http, payload, out);
-    } else {
-      return process_method_not_allowed_request(out);
     }
+    return process_method_not_allowed_request(out);
+
   } else if (ta_http_url_matcher(url, "/info[/]?") == SC_OK) {
     return process_get_ta_info_request(http, out);
   } else if (ta_http_url_matcher(url, "/") == SC_OK) {
-    // POST request
-    return process_proxy_api_request(http, payload, out);
+    if (payload != NULL) {
+      return process_proxy_api_request(http, payload, out);
+    }
+    return process_method_not_allowed_request(out);
+
   } else {
     ta_log_error("SC_HTTP_URL_NOT_MATCH : %s\n", url);
     return process_invalid_path_request(out);


### PR DESCRIPTION
If we send GET request under root URL path, the HTTP
router would not handle it and return segmentation fault. We
need to use function `process_method_not_allowed_request()`
to block this error