### PR TITLE
Fix incorrect assigned size and remove dead code

### DIFF
--- a/accelerator/core/core.c
+++ b/accelerator/core/core.c
@@ -112,7 +112,7 @@ status_t ta_send_trytes(const iota_config_t* const iconf, const iota_client_serv
   }
 
   // set the value of attach_res->trytes as output trytes result
-  memcpy(trytes, attach_res->trytes, hash_array_len(attach_res->trytes) * sizeof(hash8019_array_p));
+  memcpy(trytes, attach_res->trytes, hash_array_len(attach_res->trytes) * sizeof(flex_trit_t));
 
 done:
   get_transactions_to_approve_req_free(&tx_approve_req);

--- a/accelerator/core/pow.c
+++ b/accelerator/core/pow.c
@@ -80,8 +80,8 @@ status_t ta_pow(const bundle_transactions_t* bundle, const flex_trit_t* const tr
     transaction_set_attachment_timestamp_upper(tx, 3812798742493LL);
     transaction_set_attachment_timestamp_lower(tx, 0);
 
-    transaction_serialize_on_flex_trits(tx, tx_trits);
-    if (tx_trits == NULL) {
+    size_t offset = transaction_serialize_on_flex_trits(tx, tx_trits);
+    if (offset != NUM_TRITS_SERIALIZED_TRANSACTION) {
       ret = SC_CCLIENT_INVALID_FLEX_TRITS;
       ta_log_error("%s\n", "SC_CCLIENT_INVALID_FLEX_TRITS");
       goto done;


### PR DESCRIPTION
`attach_res->trytes` is a pointer which points to a memory space. Each elements in the `attach_res->trytes` is a `flex_trit_t`, so we need to multiple the length of the hash_array to the size of `flex_trit_t` but not the size of `hash8019_array_p`.

In the 2nd commit, `tx_trits` is a defined array, so it would never be `NULL`.