### PR TITLE
fix(req): Fix NULL pointer dereference

### DIFF
--- a/accelerator/core/request/ta_find_transaction_objects.c
+++ b/accelerator/core/request/ta_find_transaction_objects.c
@@ -19,7 +19,9 @@ ta_find_transaction_objects_req_t* ta_find_transaction_objects_req_new() {
 }
 
 void ta_find_transaction_objects_req_free(ta_find_transaction_objects_req_t** req) {
-  hash243_queue_free(&(*req)->hashes);
-  free((*req));
-  *req = NULL;
+  if (*req) {
+    hash243_queue_free(&(*req)->hashes);
+    free((*req));
+    *req = NULL;
+  }
 }


### PR DESCRIPTION
If `ta_find_transaction_objects_req_t` object was not
corretly declared (i.e. OOM), the destructor
`ta_find_transaction_objects_req_free()` would be called.
However, in this situation, we would derefere the NULL
pointer req.