### PR TITLE
fix(cli): Append zeros in CLI option array

### DIFF
--- a/accelerator/cli_info.h
+++ b/accelerator/cli_info.h
@@ -72,7 +72,8 @@ static struct ta_cli_argument_s {
                           {"cache", CACHE, "Enable cache server with Y", REQUIRED_ARG},
                           {"config", CONF_CLI, "Read configuration file", REQUIRED_ARG},
                           {"proxy_passthrough", PROXY_API, "Pass proxy API directly to IRI without processing", NO_ARG},
-                          {"verbose", VERBOSE, "Enable logger", NO_ARG}};
+                          {"verbose", VERBOSE, "Enable logger", NO_ARG},
+                          {NULL, 0, NULL, (ta_cli_arg_requirement_t)0}};
 
 static const int cli_cmd_num = sizeof(ta_cli_arguments_g) / sizeof(struct ta_cli_argument_s);
 

--- a/accelerator/cli_info.h
+++ b/accelerator/cli_info.h
@@ -49,31 +49,31 @@ typedef enum ta_cli_arg_value_e {
   VERBOSE,
 } ta_cli_arg_value_t;
 
-typedef enum ta_cli_arg_requirement_e { NO_ARG, REQUIRED_ARG, OPTIONAL_ARG } ta_cli_arg_requirement_t;
-
 static struct ta_cli_argument_s {
   char const* name;
+  int has_arg; /* one of: no_argument, required_argument, optional_argument */
+  int* flag;
   int val;
-  char const* desc;
-  ta_cli_arg_requirement_t has_arg;
-} ta_cli_arguments_g[] = {{"help", 'h', "Show tangle-accelerator usage", NO_ARG},
-                          {"version", 'v', "tangle-accelerator version", NO_ARG},
-                          {"ta_host", TA_HOST_CLI, "TA listening host", REQUIRED_ARG},
-                          {"ta_port", TA_PORT_CLI, "TA listening port", REQUIRED_ARG},
-                          {"ta_thread", TA_THREAD_COUNT_CLI, "TA executing thread", OPTIONAL_ARG},
-                          {"iri_host", IRI_HOST_CLI, "IRI listening host", REQUIRED_ARG},
-                          {"iri_port", IRI_PORT_CLI, "IRI listening port", REQUIRED_ARG},
-                          {"redis_host", REDIS_HOST_CLI, "Redis server listening host", REQUIRED_ARG},
-                          {"redis_port", REDIS_PORT_CLI, "Redis server listening port", REQUIRED_ARG},
-                          {"db_host", DB_HOST_CLI, "DB server listening host", REQUIRED_ARG},
-                          {"milestone_depth", MILESTONE_DEPTH_CLI, "IRI milestone depth", OPTIONAL_ARG},
-                          {"mwm", MWM_CLI, "minimum weight magnitude", OPTIONAL_ARG},
-                          {"seed", SEED_CLI, "IOTA seed", OPTIONAL_ARG},
-                          {"cache", CACHE, "Enable cache server with Y", REQUIRED_ARG},
-                          {"config", CONF_CLI, "Read configuration file", REQUIRED_ARG},
-                          {"proxy_passthrough", PROXY_API, "Pass proxy API directly to IRI without processing", NO_ARG},
-                          {"verbose", VERBOSE, "Enable logger", NO_ARG},
-                          {NULL, 0, NULL, (ta_cli_arg_requirement_t)0}};
+  const char* desc;
+} ta_cli_arguments_g[] = {
+    {"help", no_argument, NULL, 'h', "Show tangle-accelerator usage"},
+    {"version", no_argument, NULL, 'v', "tangle-accelerator version"},
+    {"ta_host", required_argument, NULL, TA_HOST_CLI, "TA listening host"},
+    {"ta_port", required_argument, NULL, TA_PORT_CLI, "TA listening port"},
+    {"ta_thread", optional_argument, NULL, TA_THREAD_COUNT_CLI, "TA executing thread"},
+    {"iri_host", required_argument, NULL, IRI_HOST_CLI, "IRI listening host"},
+    {"iri_port", required_argument, NULL, IRI_PORT_CLI, "IRI listening port"},
+    {"redis_host", required_argument, NULL, REDIS_HOST_CLI, "Redis server listening host"},
+    {"redis_port", required_argument, NULL, REDIS_PORT_CLI, "Redis server listening port"},
+    {"db_host", required_argument, NULL, DB_HOST_CLI, "DB server listening host"},
+    {"milestone_depth", optional_argument, NULL, MILESTONE_DEPTH_CLI, "IRI milestone depth"},
+    {"mwm", optional_argument, NULL, MWM_CLI, "minimum weight magnitude"},
+    {"seed", optional_argument, NULL, SEED_CLI, "IOTA seed"},
+    {"cache", required_argument, NULL, CACHE, "Enable cache server with Y"},
+    {"config", required_argument, NULL, CONF_CLI, "Read configuration file"},
+    {"proxy_passthrough", no_argument, NULL, PROXY_API, "Pass proxy API directly to IRI without processing"},
+    {"verbose", no_argument, NULL, VERBOSE, "Enable logger"},
+    {NULL, 0, NULL, 0, NULL}};
 
 static const int cli_cmd_num = sizeof(ta_cli_arguments_g) / sizeof(struct ta_cli_argument_s);
 
@@ -82,9 +82,9 @@ static inline void ta_usage() {
   for (int i = 0; i < cli_cmd_num; i++) {
     printf("--%-34s ", ta_cli_arguments_g[i].name);
     printf("     ");
-    if (ta_cli_arguments_g[i].has_arg == REQUIRED_ARG) {
+    if (ta_cli_arguments_g[i].has_arg == required_argument) {
       printf(" arg ");
-    } else if (ta_cli_arguments_g[i].has_arg == OPTIONAL_ARG) {
+    } else if (ta_cli_arguments_g[i].has_arg == optional_argument) {
       printf("[arg]");
     } else {
       printf("     ");

--- a/accelerator/config.c
+++ b/accelerator/config.c
@@ -29,7 +29,7 @@ struct option* cli_build_options() {
   for (int i = 0; i < cli_cmd_num; ++i) {
     long_options[i].name = ta_cli_arguments_g[i].name;
     long_options[i].has_arg = ta_cli_arguments_g[i].has_arg;
-    long_options[i].flag = NULL;
+    long_options[i].flag = ta_cli_arguments_g[i].flag;
     long_options[i].val = ta_cli_arguments_g[i].val;
   }
   return long_options;

--- a/accelerator/config.c
+++ b/accelerator/config.c
@@ -13,8 +13,6 @@
 #define CONFIG_LOGGER "config"
 
 static logger_id_t logger_id;
-// FIXME: We need further improvements without depending on temporary variables
-static int tmp_argc;
 
 int get_conf_key(char const* const key) {
   for (int i = 0; i < cli_cmd_num; ++i) {
@@ -24,19 +22,6 @@ int get_conf_key(char const* const key) {
   }
 
   return 0;
-}
-
-static void remove_nonvalue_dash(int argc, char** argv) {
-  for (int i = 1; i < argc; i++) {
-    if ((strlen(argv[i]) == 2) && (!strncmp(argv[i], "--", 2))) {
-      argc--;
-      if (argc == (i + 1)) {
-        break;
-      }
-      memmove(argv + i, argv + (i + 1), (argc - i) * sizeof(char*));
-    }
-  }
-  tmp_argc = argc;
 }
 
 struct option* cli_build_options() {
@@ -205,9 +190,6 @@ status_t ta_core_file_init(ta_core_t* const core, int argc, char** argv) {
     goto done;
   }
 
-  // remove `--` from argv
-  remove_nonvalue_dash(argc, argv);
-
   // Loop through the CLI arguments for first time to find the configuration file path
   while ((key = getopt_long(argc, argv, "hv", long_options, NULL)) != -1) {
     switch (key) {
@@ -295,10 +277,7 @@ status_t ta_core_cli_init(ta_core_t* const core, int argc, char** argv) {
   status_t ret = SC_OK;
   struct option* long_options = cli_build_options();
 
-  // remove `--` from argv
-  remove_nonvalue_dash(tmp_argc, argv);
-
-  while ((key = getopt_long(tmp_argc, argv, "hv", long_options, NULL)) != -1) {
+  while ((key = getopt_long(argc, argv, "hv", long_options, NULL)) != -1) {
     switch (key) {
       case ':':
         ret = SC_CONF_MISSING_ARGUMENT;


### PR DESCRIPTION
the 4th argument of `getopt_long()` is an array
of `struct option`. And this array should be ended with
a `struct option` filled with zeros.

See man page or [this link](https://linux.die.net/man/3/getopt_long) for more information

fixes #436 