### PR TITLE
fix : continue to get cli options after an unknown option

### DIFF
--- a/accelerator/config.c
+++ b/accelerator/config.c
@@ -200,7 +200,7 @@ status_t ta_core_file_init(ta_core_t* const core, int argc, char** argv) {
       case '?':
         ret = SC_CONF_UNKNOWN_OPTION;
         ta_log_error("%s\n", "SC_CONF_UNKNOWN_OPTION");
-        break;
+        continue;
       case CONF_CLI:
         ret = cli_core_set(core, key, optarg);
         break;
@@ -286,7 +286,7 @@ status_t ta_core_cli_init(ta_core_t* const core, int argc, char** argv) {
       case '?':
         ret = SC_CONF_UNKNOWN_OPTION;
         ta_log_error("%s\n", "SC_CONF_UNKNOWN_OPTION");
-        break;
+        continue;
       case 'h':
         ta_usage();
         exit(EXIT_SUCCESS);

--- a/reattacher/reattacher_main.c
+++ b/reattacher/reattacher_main.c
@@ -126,7 +126,7 @@ int main(int argc, char** argv) {
     if (cmdOpt == -1) break;
 
     /* Invalid option */
-    if (cmdOpt == '?') break;
+    if (cmdOpt == '?') continue;
 
     if (cmdOpt == 'h') {
       iota_service.http.host = optarg;

--- a/tests/test_scylladb.c
+++ b/tests/test_scylladb.c
@@ -241,7 +241,7 @@ int main(int argc, char** argv) {
   int cmdOpt;
   int optIdx;
   const struct option longOpt[] = {
-      {"host", required_argument, NULL, 'h'}, {"keyspace", required_argument, NULL, 'k'}, {NULL, 0, NULL, 0}};
+      {"db_host", required_argument, NULL, 'h'}, {"keyspace", required_argument, NULL, 'k'}, {NULL, 0, NULL, 0}};
 
   keyspace_name = "test_scylla";
   /* Parse the command line options */
@@ -251,7 +251,7 @@ int main(int argc, char** argv) {
     if (cmdOpt == -1) break;
 
     /* Invalid option */
-    if (cmdOpt == '?') break;
+    if (cmdOpt == '?') continue;
 
     if (cmdOpt == 'h') {
       host = optarg;


### PR DESCRIPTION
There are some options that are exclusive to certain tests. When we add all required options in our CI pipeline at once, some options would miss after read an unknown option.