### PR TITLE
feat(config): Add CLI for MQTT configures

### DIFF
--- a/accelerator/cli_info.h
+++ b/accelerator/cli_info.h
@@ -30,6 +30,10 @@ typedef enum ta_cli_arg_value_e {
   IRI_HOST_CLI,
   IRI_PORT_CLI,
 
+  /** MQTT */
+  MQTT_HOST_CLI,
+  MQTT_ROOT_CLI,
+
   /** REDIS */
   REDIS_HOST_CLI,
   REDIS_PORT_CLI,
@@ -63,6 +67,8 @@ static struct ta_cli_argument_s {
     {"ta_thread", optional_argument, NULL, TA_THREAD_COUNT_CLI, "TA executing thread"},
     {"iri_host", required_argument, NULL, IRI_HOST_CLI, "IRI listening host"},
     {"iri_port", required_argument, NULL, IRI_PORT_CLI, "IRI listening port"},
+    {"mqtt_host", required_argument, NULL, MQTT_HOST_CLI, "MQTT listening host"},
+    {"mqtt_root", required_argument, NULL, MQTT_ROOT_CLI, "MQTT listening topic root"},
     {"redis_host", required_argument, NULL, REDIS_HOST_CLI, "Redis server listening host"},
     {"redis_port", required_argument, NULL, REDIS_PORT_CLI, "Redis server listening port"},
     {"db_host", required_argument, NULL, DB_HOST_CLI, "DB server listening host"},

--- a/accelerator/config.c
+++ b/accelerator/config.c
@@ -68,6 +68,16 @@ static status_t cli_core_set(ta_core_t* const core, int key, char* const value) 
       iota_service->http.port = atoi(value);
       break;
 
+#ifdef MQTT_ENABLE
+    // MQTT configuration
+    case MQTT_HOST_CLI:
+      ta_conf->mqtt_host = value;
+      break;
+    case MQTT_ROOT_CLI:
+      ta_conf->mqtt_topic_root = value;
+      break;
+#endif
+
     // Cache configuration
     case REDIS_HOST_CLI:
       cache->host = value;

--- a/accelerator/mqtt_main.c
+++ b/accelerator/mqtt_main.c
@@ -27,6 +27,11 @@ int main(int argc, char *argv[]) {
     return EXIT_FAILURE;
   }
 
+  // Initialize configurations with configuration file
+  if (ta_core_file_init(&ta_core, argc, argv) != SC_OK) {
+    return EXIT_FAILURE;
+  }
+
   // Initialize configurations with CLI value
   if (ta_core_cli_init(&ta_core, argc, argv) != SC_OK) {
     return EXIT_FAILURE;

--- a/docs/build.md
+++ b/docs/build.md
@@ -52,7 +52,7 @@ MQTT connectivity is an optional feature allowing IoT endpoint devices to collab
 make MQTT && bazel run --define mqtt=enable //accelerator
 ```
 
-Note you may need to set up the `MQTT_HOST` and `TOPIC_ROOT` in `config.h` to connect to a MQTT broker.
+Note you may need to set up the `MQTT_HOST` and `TOPIC_ROOT` in `config.h` to connect to a MQTT broker, or you can use CLI option `--mqtt_host`, and  `--mqtt_root` to set MQTT broker address and MQTT topic root, respectively.
 For more information for MQTT connectivity of `tangle-accelerator`, you could read `connectivity/mqtt/usage.md`.
 
 ## Enable external database for transaction reattachment


### PR DESCRIPTION
MQTT host and MQTT subscribe topic root can be assigned with CLI command `--mqtt_host` and `--mqtt_topic_root` respectively

close #294