### PR TITLE
fix(db) : Revise tests for ScyllaDB backend

### DIFF
--- a/storage/scylladb_identity.h
+++ b/storage/scylladb_identity.h
@@ -171,14 +171,14 @@ status_t db_insert_tx_into_identity(db_client_service_t* service, const char* ha
  * @brief connect to ScyllaDB cluster and initialize identity keyspace and table
  *
  * @param[in] service ScyllaDB client service for connection
- * @param[in] need_drop true : drop table, false : keep old table
+ * @param[in] need_truncate true : clear all data, false : keep old data
  * @param[in] keyspace_name keyspace name the session should use
  *
  * @return
  * - SC_OK on success
  * - non-zero on error
  */
-status_t db_init_identity_keyspace(db_client_service_t* service, bool need_drop, const char* keyspace_name);
+status_t db_init_identity_keyspace(db_client_service_t* service, bool need_truncate, const char* keyspace_name);
 
 /**
  * @brief get identity objs with selected status from identity table

--- a/storage/scylladb_permanode.h
+++ b/storage/scylladb_permanode.h
@@ -226,14 +226,14 @@ int64_t ret_transaction_timestamp(scylla_iota_transaction_t* obj);
  * @brief connect to ScyllaDB node and create table
  *
  * @param[in] service ScyllaDB db client service
- * @param[in] need_drop true : drop table
+ * @param[in] need_truncate true : clear all data, false : keep old data
  * @param[in] keyspace_name keyspace name the session should use
  *
  * @return
  * - SC_OK on success
  * - non-zero on error
  */
-status_t db_permanent_keyspace_init(db_client_service_t* service, bool need_drop, const char* keyspace_name);
+status_t db_permanent_keyspace_init(db_client_service_t* service, bool need_truncate, const char* keyspace_name);
 /**
  * @brief insert transactions into bundle table
  *

--- a/storage/scylladb_utils.c
+++ b/storage/scylladb_utils.c
@@ -108,6 +108,22 @@ status_t make_query(char** result, const char* head_desc, const char* position, 
   return SC_OK;
 }
 
+status_t db_truncate_table(CassSession* session, const char* table_name) {
+  status_t ret = SC_OK;
+  char* query = NULL;
+  ret = make_query(&query, "TRUNCATE TABLE ", table_name, "");
+  if (ret != SC_OK) {
+    ta_log_error("Fail to make truncate query\n");
+    return ret;
+  }
+  if (execute_query(session, query) != CASS_OK) {
+    ta_log_error("Fail to truncate table:  %s\n", table_name);
+    ret = SC_STORAGE_CASSANDRA_QUREY_FAIL;
+  }
+  free(query);
+  return ret;
+}
+
 status_t create_keyspace(CassSession* session, const char* keyspace_name) {
   status_t ret = SC_OK;
   char* create_query = NULL;

--- a/storage/scylladb_utils.h
+++ b/storage/scylladb_utils.h
@@ -78,6 +78,17 @@ status_t make_query(char** result, const char* head_desc, const char* position, 
 status_t create_keyspace(CassSession* session, const char* keyspace_name);
 
 /**
+ * @brief clear all data in the specific ScyllaDB table without droping the table
+ *
+ * @param[in] session used to execute queries and maintains cluster state
+ * @param[in] table_name The name of table to be truncated
+ * @return
+ * - SC_OK on success
+ * - non-zero on error
+ */
+status_t db_truncate_table(CassSession* session, const char* table_name);
+
+/**
  * Initialize logger
  */
 void scylladb_logger_init();

--- a/tests/test_scylladb.c
+++ b/tests/test_scylladb.c
@@ -268,7 +268,6 @@ int main(int argc, char** argv) {
   }
   scylladb_logger_init();
   RUN_TEST(test_db_identity_table);
-  RUN_TEST(test_permanode);
   scylladb_logger_release();
   return UNITY_END();
 #else


### PR DESCRIPTION
- Truncate(clear all data) instead of dropping table. 
- Remove tests for permanode. Those functions do not be used currently.

To test the insertion and selection, we need an empty table. The previous method is dropping old tables when performing tests. But dropping tables will change the schema. After schema changement, we need to wait for the ScyllaDB cluster to make an agreement, but we execute the tests concurrently. It is hard to wait enough time among each test. Actually, the schema should not be changed if we do not change the data model.

close #458
