### PR TITLE
fix(logger): Fix wrong logger name

### DIFF
--- a/accelerator/main.c
+++ b/accelerator/main.c
@@ -58,6 +58,10 @@ int main(int argc, char* argv[]) {
   // Enable other loggers when verbose mode is on
   if (verbose_mode) {
     http_logger_init();
+    apis_logger_init();
+    cc_logger_init();
+    pow_logger_init();
+    timer_logger_init();
   } else {
     // Destroy logger when verbose mode is off
     logger_helper_release(logger_id);
@@ -96,6 +100,11 @@ cleanup:
 
   if (verbose_mode) {
     http_logger_release();
+    apis_logger_release();
+    cc_logger_release();
+    serializer_logger_release();
+    pow_logger_release();
+    timer_logger_release();
     logger_helper_release(logger_id);
     if (logger_helper_destroy() != RC_OK) {
       ta_log_error("Destroying logger failed %s.\n", MAIN_LOGGER);

--- a/accelerator/mqtt_main.c
+++ b/accelerator/mqtt_main.c
@@ -43,6 +43,10 @@ int main(int argc, char *argv[]) {
     mqtt_callback_logger_init();
     mqtt_pub_logger_init();
     mqtt_sub_logger_init();
+    apis_logger_init();
+    cc_logger_init();
+    pow_logger_init();
+    timer_logger_init();
   } else {
     // Destroy logger when verbose mode is off
     logger_helper_release(logger_id);
@@ -95,6 +99,11 @@ done:
     mqtt_callback_logger_release();
     mqtt_pub_logger_release();
     mqtt_sub_logger_release();
+    apis_logger_release();
+    cc_logger_release();
+    serializer_logger_release();
+    pow_logger_release();
+    timer_logger_release();
     logger_helper_release(logger_id);
     if (logger_helper_destroy() != RC_OK) {
       return EXIT_FAILURE;

--- a/connectivity/http/http.c
+++ b/connectivity/http/http.c
@@ -5,8 +5,8 @@
 #include <string.h>
 #include <time.h>
 
-#include "utils/macros.h"
 #include "http.h"
+#include "utils/macros.h"
 
 #define HTTP_LOGGER "http"
 


### PR DESCRIPTION
Without initializing logger in different source files, the logger name
would display `main` only.

fixes #460