### PR TITLE
Turn off logger after initialization and set verbose mode by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,12 +89,13 @@ Tangle-accelerator is built and launched through Bazel, it also requires Redis t
 
 ## Build from Source
 
-Before running tangle-accelerator, please edit binding address/port of accelerator instance, IRI, and redis server in `accelerator/config.h` unless they are all localhost and/or you don't want to provide external connection. With dependency of [entangled](https://github.com/iotaledger/entangled), IRI address doesn't support https at the moment. Here are some configurations you might need to change:
+Before running tangle-accelerator, please edit binding address/port of accelerator instance, IRI, and redis server in `accelerator/config.h` unless they are all localhost and/or you don't want to provide external connection. With dependency of [entangled](https://github.com/iotaledger/entangled), IRI address doesn't support https at the moment. Here are some configurations and command you might need to change and use:
 
 * `TA_HOST`: binding address of accelerator instance
 * `TA_PORT`: port of accelerator instance
 * `IRI_HOST`: binding address of IRI
 * `IRI_PORT`: port of IRI
+* `quiet`: Turn off logging message
 
 ```
 $ make && bazel run //accelerator

--- a/accelerator/cli_info.h
+++ b/accelerator/cli_info.h
@@ -50,7 +50,7 @@ typedef enum ta_cli_arg_value_e {
   PROXY_API,
 
   /** LOGGER */
-  VERBOSE,
+  QUIET,
 } ta_cli_arg_value_t;
 
 static struct ta_cli_argument_s {
@@ -78,7 +78,7 @@ static struct ta_cli_argument_s {
     {"cache", required_argument, NULL, CACHE, "Enable cache server with Y"},
     {"config", required_argument, NULL, CONF_CLI, "Read configuration file"},
     {"proxy_passthrough", no_argument, NULL, PROXY_API, "Pass proxy API directly to IRI without processing"},
-    {"verbose", no_argument, NULL, VERBOSE, "Enable logger"},
+    {"quiet", no_argument, NULL, QUIET, "Disable logger"},
     {NULL, 0, NULL, 0, NULL}};
 
 static const int cli_cmd_num = sizeof(ta_cli_arguments_g) / sizeof(struct ta_cli_argument_s);

--- a/accelerator/config.c
+++ b/accelerator/config.c
@@ -106,9 +106,9 @@ static status_t cli_core_set(ta_core_t* const core, int key, char* const value) 
       cache->cache_state = (toupper(value[0]) == 'T');
       break;
 
-    // Verbose configuration
-    case VERBOSE:
-      verbose_mode = (toupper(value[0]) == 'T');
+    // Quiet mode configuration
+    case QUIET:
+      quiet_mode = (toupper(value[0]) == 'T');
       break;
 
     case PROXY_API:
@@ -175,8 +175,8 @@ status_t ta_core_default_init(ta_core_t* const core) {
   ta_log_info("Initializing DB connection\n");
   db_service->host = strdup(DB_HOST);
 #endif
-  // Turn off verbose mode default
-  verbose_mode = false;
+  // Turn off quiet mode default
+  quiet_mode = false;
 
   return ret;
 }
@@ -303,9 +303,9 @@ status_t ta_core_cli_init(ta_core_t* const core, int argc, char** argv) {
       case 'v':
         printf("%s\n", TA_VERSION);
         exit(EXIT_SUCCESS);
-      case VERBOSE:
-        // Turn on verbose mode
-        verbose_mode = true;
+      case QUIET:
+        // Turn on quiet mode
+        quiet_mode = true;
 
         // Enable backend_redis logger
         br_logger_init();

--- a/accelerator/core/serializer/serializer.c
+++ b/accelerator/core/serializer/serializer.c
@@ -46,7 +46,7 @@ status_t ta_get_info_serialize(char** obj, ta_config_t* const ta_config, iota_co
   cJSON_AddNumberToObject(json_root, "redis_port", cache->port);
   cJSON_AddNumberToObject(json_root, "milestone_depth", tangle->milestone_depth);
   cJSON_AddNumberToObject(json_root, "mwm", tangle->mwm);
-  cJSON_AddBoolToObject(json_root, "verbose", verbose_mode);
+  cJSON_AddBoolToObject(json_root, "quiet", quiet_mode);
 
   *obj = cJSON_PrintUnformatted(json_root);
   if (*obj == NULL) {

--- a/accelerator/main.c
+++ b/accelerator/main.c
@@ -67,17 +67,17 @@ int main(int argc, char* argv[]) {
 
   log_info(logger_id, "Tangle-accelerator starts running\n");
 
-  // Enable other loggers when verbose mode is on
-  if (verbose_mode) {
+  // Disable loggers when quiet mode is on
+  if (quiet_mode) {
+    // Destroy logger when quiet mode is on
+    logger_helper_release(logger_id);
+    logger_helper_destroy();
+  } else {
     http_logger_init();
     apis_logger_init();
     cc_logger_init();
     pow_logger_init();
     timer_logger_init();
-  } else {
-    // Destroy logger when verbose mode is off
-    logger_helper_release(logger_id);
-    logger_helper_destroy();
   }
 
   /* pause() cause TA to sleep until it catch a signal,
@@ -98,7 +98,7 @@ cleanup:
   log_info(logger_id, "Destroying TA configurations\n");
   ta_core_destroy(&ta_core);
 
-  if (verbose_mode) {
+  if (quiet_mode == false) {
     http_logger_release();
     apis_logger_release();
     cc_logger_release();

--- a/accelerator/main.c
+++ b/accelerator/main.c
@@ -55,6 +55,18 @@ int main(int argc, char* argv[]) {
     return EXIT_FAILURE;
   }
 
+  if (ta_http_init(&ta_http, &ta_core) != SC_OK) {
+    ta_log_error("HTTP initialization failed %s.\n", MAIN_LOGGER);
+    return EXIT_FAILURE;
+  }
+
+  if (ta_http_start(&ta_http) != SC_OK) {
+    ta_log_error("Starting TA failed %s.\n", MAIN_LOGGER);
+    goto cleanup;
+  }
+
+  log_info(logger_id, "Tangle-accelerator starts running\n");
+
   // Enable other loggers when verbose mode is on
   if (verbose_mode) {
     http_logger_init();
@@ -67,18 +79,6 @@ int main(int argc, char* argv[]) {
     logger_helper_release(logger_id);
     logger_helper_destroy();
   }
-
-  if (ta_http_init(&ta_http, &ta_core) != SC_OK) {
-    ta_log_error("HTTP initialization failed %s.\n", MAIN_LOGGER);
-    return EXIT_FAILURE;
-  }
-
-  if (ta_http_start(&ta_http) != SC_OK) {
-    ta_log_error("Starting TA failed %s.\n", MAIN_LOGGER);
-    goto cleanup;
-  }
-
-  log_info(logger_id, "Tangle-accelerator starts running\n");
 
   /* pause() cause TA to sleep until it catch a signal,
    * also the return value and errno should be -1 and EINTR on success.

--- a/accelerator/mqtt_main.c
+++ b/accelerator/mqtt_main.c
@@ -42,7 +42,12 @@ int main(int argc, char *argv[]) {
     return EXIT_FAILURE;
   }
 
-  if (verbose_mode) {
+  // Disable loggers when quiet mode is on
+  if (quiet_mode) {
+    // Destroy logger when quiet mode is on
+    logger_helper_release(logger_id);
+    logger_helper_destroy();
+  } else {
     mqtt_utils_logger_init();
     mqtt_common_logger_init();
     mqtt_callback_logger_init();
@@ -52,10 +57,6 @@ int main(int argc, char *argv[]) {
     cc_logger_init();
     pow_logger_init();
     timer_logger_init();
-  } else {
-    // Destroy logger when verbose mode is off
-    logger_helper_release(logger_id);
-    logger_helper_destroy();
   }
 
   // Initialize `mosq` and `cfg`
@@ -98,7 +99,7 @@ done:
   mosquitto_lib_cleanup();
   mosq_config_free(&cfg);
 
-  if (verbose_mode) {
+  if (quiet_mode == false) {
     mqtt_utils_logger_release();
     mqtt_common_logger_release();
     mqtt_callback_logger_release();

--- a/common/logger.h
+++ b/common/logger.h
@@ -70,7 +70,7 @@ static inline status_t ta_logger_init() {
     fflush(stdout);                                         \
   } while (0)
 
-bool verbose_mode; /**< flag of verbose mode */
+bool quiet_mode; /**< flag of quiet mode */
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
When verbose mode is off, logger would be release after message,
`Tangle-accelerator starts running` has be printed out.

TA was set in quiet mode in default. Now it has been changed to
verbose mode. TA would turn on verbose mode (logging message
would be printed in default). To turn on quiet mode, a user can use
CLI commanf `--quiet`

close #464