### PR TITLE
fix(regression): Fix command line option

### DIFF
--- a/tests/regression/common.sh
+++ b/tests/regression/common.sh
@@ -8,7 +8,7 @@ setup_build_opts() {
         "|--iri_port ${IRI_PORT}"
         "|--ta_host ${TA_HOST}"
         "|--db_host ${DB_HOST}"
-        "|--verbose"
+        "|--quiet"
         "|--proxy_passthrough"
         "--define db=enable|"
         "--define build_type=debug|"

--- a/tests/regression/run-api.sh
+++ b/tests/regression/run-api.sh
@@ -17,8 +17,8 @@ redis-server &
 # Iterate over all available build options
 for (( i = 0; i < ${#OPTIONS[@]}; i++ )); do
     option=${OPTIONS[${i}]}
-    cli_arg=${option} | cut -d '|' -f 1
-    build_arg=${option} | cut -d '|' -f 2
+    cli_arg=$(echo ${option} | cut -d '|' -f 2)
+    build_arg=$(echo ${option} | cut -d '|' -f 1)
 
     bazel run accelerator ${build_arg} -- --ta_port=${TA_PORT} ${cli_arg} &
     TA=$!


### PR DESCRIPTION
Fixes #464.

Changed the option name from `verbose` to `quiet`.

I've also changed the order to parse `cli_arg` and `build_arg`,
which was placed incorrectly and regarded as empty argument before.