### PR TITLE
feat(main): Check IRI connection periodically

### DIFF
--- a/accelerator/cli_info.h
+++ b/accelerator/cli_info.h
@@ -29,6 +29,7 @@ typedef enum ta_cli_arg_value_e {
   /** IRI */
   IRI_HOST_CLI,
   IRI_PORT_CLI,
+  IRI_URL_LIST_CLI,
 
   /** MQTT */
   MQTT_HOST_CLI,
@@ -48,6 +49,7 @@ typedef enum ta_cli_arg_value_e {
   CACHE,
   CONF_CLI,
   PROXY_API,
+  HEALTH_TRACK_PERIOD,
 
   /** LOGGER */
   QUIET,
@@ -69,6 +71,7 @@ static struct ta_cli_argument_s {
     {"iri_port", required_argument, NULL, IRI_PORT_CLI, "IRI listening port"},
     {"mqtt_host", required_argument, NULL, MQTT_HOST_CLI, "MQTT listening host"},
     {"mqtt_root", required_argument, NULL, MQTT_ROOT_CLI, "MQTT listening topic root"},
+    {"iri_url_list", required_argument, NULL, IRI_URL_LIST_CLI, " List of IRI listening URL"},
     {"redis_host", required_argument, NULL, REDIS_HOST_CLI, "Redis server listening host"},
     {"redis_port", required_argument, NULL, REDIS_PORT_CLI, "Redis server listening port"},
     {"db_host", required_argument, NULL, DB_HOST_CLI, "DB server listening host"},
@@ -78,6 +81,7 @@ static struct ta_cli_argument_s {
     {"cache", no_argument, NULL, CACHE, "Enable cache server"},
     {"config", required_argument, NULL, CONF_CLI, "Read configuration file"},
     {"proxy_passthrough", no_argument, NULL, PROXY_API, "Pass proxy API directly to IRI without processing"},
+    {"check_period", no_argument, NULL, HEALTH_TRACK_PERIOD, "The period for checking IRI host connection status"},
     {"quiet", no_argument, NULL, QUIET, "Disable logger"},
     {NULL, 0, NULL, 0, NULL}};
 

--- a/accelerator/cli_info.h
+++ b/accelerator/cli_info.h
@@ -29,7 +29,7 @@ typedef enum ta_cli_arg_value_e {
   /** IRI */
   IRI_HOST_CLI,
   IRI_PORT_CLI,
-  IRI_URL_LIST_CLI,
+  IRI_ADDRESS_CLI,
 
   /** MQTT */
   MQTT_HOST_CLI,
@@ -71,7 +71,7 @@ static struct ta_cli_argument_s {
     {"iri_port", required_argument, NULL, IRI_PORT_CLI, "IRI listening port"},
     {"mqtt_host", required_argument, NULL, MQTT_HOST_CLI, "MQTT listening host"},
     {"mqtt_root", required_argument, NULL, MQTT_ROOT_CLI, "MQTT listening topic root"},
-    {"iri_url_list", required_argument, NULL, IRI_URL_LIST_CLI, " List of IRI listening URL"},
+    {"iri_address", required_argument, NULL, IRI_ADDRESS_CLI, " List of IRI listening URL"},
     {"redis_host", required_argument, NULL, REDIS_HOST_CLI, "Redis server listening host"},
     {"redis_port", required_argument, NULL, REDIS_PORT_CLI, "Redis server listening port"},
     {"db_host", required_argument, NULL, DB_HOST_CLI, "DB server listening host"},
@@ -81,7 +81,8 @@ static struct ta_cli_argument_s {
     {"cache", no_argument, NULL, CACHE, "Enable cache server"},
     {"config", required_argument, NULL, CONF_CLI, "Read configuration file"},
     {"proxy_passthrough", no_argument, NULL, PROXY_API, "Pass proxy API directly to IRI without processing"},
-    {"check_period", no_argument, NULL, HEALTH_TRACK_PERIOD, "The period for checking IRI host connection status"},
+    {"health_track_period", no_argument, NULL, HEALTH_TRACK_PERIOD,
+     "The period for checking IRI host connection status"},
     {"quiet", no_argument, NULL, QUIET, "Disable logger"},
     {NULL, 0, NULL, 0, NULL}};
 

--- a/accelerator/config.c
+++ b/accelerator/config.c
@@ -7,6 +7,8 @@
  */
 
 #include "config.h"
+#include <errno.h>
+#include <limits.h>
 #include "utils/macros.h"
 #include "yaml.h"
 
@@ -48,16 +50,28 @@ status_t cli_core_set(ta_core_t* const core, int key, char* const value) {
 #ifdef DB_ENABLE
   db_client_service_t* const db_service = &core->db_service;
 #endif
+  char* strtol_p = NULL;
+  long int strtol_temp;
   switch (key) {
     // TA configuration
     case TA_HOST_CLI:
       ta_conf->host = value;
       break;
     case TA_PORT_CLI:
-      ta_conf->port = atoi(value);
+      strtol_temp = strtol(value, &strtol_p, 10);
+      if (strtol_p != value && errno != ERANGE && strtol_temp >= INT_MIN && strtol_temp <= INT_MAX) {
+        ta_conf->port = (int)strtol_temp;
+      } else {
+        ta_log_error("Malformed input or illegal input character\n");
+      }
       break;
     case TA_THREAD_COUNT_CLI:
-      ta_conf->thread_count = atoi(value);
+      strtol_temp = strtol(value, &strtol_p, 10);
+      if (strtol_p != value && errno != ERANGE && strtol_temp >= INT_MIN && strtol_temp <= INT_MAX) {
+        ta_conf->thread_count = (int)strtol_temp;
+      } else {
+        ta_log_error("Malformed input or illegal input character\n");
+      }
       break;
 
     // IRI configuration
@@ -65,28 +79,52 @@ status_t cli_core_set(ta_core_t* const core, int key, char* const value) {
       iota_service->http.host = value;
       break;
     case IRI_PORT_CLI:
-      iota_service->http.port = atoi(value);
+      strtol_temp = strtol(value, &strtol_p, 10);
+      if (strtol_p != value && errno != ERANGE && strtol_temp >= INT_MIN && strtol_temp <= INT_MAX) {
+        iota_service->http.port = (int)strtol_temp;
+      } else {
+        ta_log_error("Malformed input or illegal input character\n");
+      }
       break;
-    case IRI_URL_LIST_CLI:
+    case IRI_ADDRESS_CLI:
       for (int i = 0; i < MAX_IRI_LIST_ELEMENTS; i++) {
         if (!ta_conf->host_list[i]) {
           char *host, *port;
           host = strtok(value, ":");
           port = strtok(NULL, "");
+          if (!port) {
+            ta_log_error("Malformed input or illegal input character\n");
+            break;
+          }
 
           if (i == 0) {
             iota_service->http.host = host;
-            iota_service->http.port = atoi(port);
+            strtol_temp = strtol(port, NULL, 10);
+            if (strtol_p != value && errno != ERANGE && strtol_temp >= INT_MIN && strtol_temp <= INT_MAX) {
+              iota_service->http.port = (int)strtol_temp;
+            } else {
+              ta_log_error("Malformed input or illegal input character\n");
+            }
           }
           ta_conf->host_list[i] = host;
-          ta_conf->port_list[i] = atoi(port);
+          strtol_temp = strtol(port, NULL, 10);
+          if (strtol_p != value && errno != ERANGE && strtol_temp >= INT_MIN && strtol_temp <= INT_MAX) {
+            ta_conf->port_list[i] = (int)strtol_temp;
+          } else {
+            ta_log_error("Malformed input or illegal input character\n");
+          }
           break;
         }
       }
       break;
 
     case HEALTH_TRACK_PERIOD:
-      ta_conf->check_period = atoi(value);
+      strtol_temp = strtol(value, NULL, 10);
+      if (strtol_p != value && errno != ERANGE && strtol_temp >= INT_MIN && strtol_temp <= INT_MAX) {
+        ta_conf->health_track_period = (int)strtol_temp;
+      } else {
+        ta_log_error("Malformed input or illegal input character\n");
+      }
       break;
 
 #ifdef MQTT_ENABLE
@@ -104,7 +142,12 @@ status_t cli_core_set(ta_core_t* const core, int key, char* const value) {
       cache->host = value;
       break;
     case REDIS_PORT_CLI:
-      cache->port = atoi(value);
+      strtol_temp = strtol(value, NULL, 10);
+      if (strtol_p != value && errno != ERANGE && strtol_temp >= INT_MIN && strtol_temp <= INT_MAX) {
+        cache->port = (int)strtol_temp;
+      } else {
+        ta_log_error("Malformed input or illegal input character\n");
+      }
       break;
 
 #ifdef DB_ENABLE
@@ -117,10 +160,20 @@ status_t cli_core_set(ta_core_t* const core, int key, char* const value) {
 
     // iota_conf IOTA configuration
     case MILESTONE_DEPTH_CLI:
-      iota_conf->milestone_depth = atoi(value);
+      strtol_temp = strtol(value, NULL, 10);
+      if (strtol_p != value && errno != ERANGE && strtol_temp >= INT_MIN && strtol_temp <= INT_MAX) {
+        iota_conf->milestone_depth = (int)strtol_temp;
+      } else {
+        ta_log_error("Malformed input or illegal input character\n");
+      }
       break;
     case MWM_CLI:
-      iota_conf->mwm = atoi(value);
+      strtol_temp = strtol(value, NULL, 10);
+      if (strtol_p != value && errno != ERANGE && strtol_temp >= INT_MIN && strtol_temp <= INT_MAX) {
+        iota_conf->mwm = (int)strtol_temp;
+      } else {
+        ta_log_error("Malformed input or illegal input character\n");
+      }
       break;
     case SEED_CLI:
       iota_conf->seed = value;
@@ -171,7 +224,7 @@ status_t ta_core_default_init(ta_core_t* const core) {
   memset(ta_conf->port_list, 0, sizeof(ta_conf->port_list));
   ta_conf->thread_count = TA_THREAD_COUNT;
   ta_conf->proxy_passthrough = false;
-  ta_conf->check_period = IRI_HEALTH_TRACK_PERIOD;
+  ta_conf->health_track_period = IRI_HEALTH_TRACK_PERIOD;
 #ifdef MQTT_ENABLE
   ta_conf->mqtt_host = MQTT_HOST;
   ta_conf->mqtt_topic_root = TOPIC_ROOT;

--- a/accelerator/config.c
+++ b/accelerator/config.c
@@ -54,7 +54,7 @@ status_t cli_core_set(ta_core_t* const core, int key, char* const value) {
       ta_conf->host = value;
       break;
     case TA_PORT_CLI:
-      ta_conf->port = value;
+      ta_conf->port = atoi(value);
       break;
     case TA_THREAD_COUNT_CLI:
       ta_conf->thread_count = atoi(value);
@@ -66,6 +66,27 @@ status_t cli_core_set(ta_core_t* const core, int key, char* const value) {
       break;
     case IRI_PORT_CLI:
       iota_service->http.port = atoi(value);
+      break;
+    case IRI_URL_LIST_CLI:
+      for (int i = 0; i < MAX_IRI_LIST_ELEMENTS; i++) {
+        if (!ta_conf->host_list[i]) {
+          char *host, *port;
+          host = strtok(value, ":");
+          port = strtok(NULL, "");
+
+          if (i == 0) {
+            iota_service->http.host = host;
+            iota_service->http.port = atoi(port);
+          }
+          ta_conf->host_list[i] = host;
+          ta_conf->port_list[i] = atoi(port);
+          break;
+        }
+      }
+      break;
+
+    case HEALTH_TRACK_PERIOD:
+      ta_conf->check_period = atoi(value);
       break;
 
 #ifdef MQTT_ENABLE
@@ -85,6 +106,7 @@ status_t cli_core_set(ta_core_t* const core, int key, char* const value) {
     case REDIS_PORT_CLI:
       cache->port = atoi(value);
       break;
+
 #ifdef DB_ENABLE
     // DB configuration
     case DB_HOST_CLI:
@@ -92,6 +114,7 @@ status_t cli_core_set(ta_core_t* const core, int key, char* const value) {
       db_service->host = strdup(value);
       break;
 #endif
+
     // iota_conf IOTA configuration
     case MILESTONE_DEPTH_CLI:
       iota_conf->milestone_depth = atoi(value);
@@ -144,8 +167,11 @@ status_t ta_core_default_init(ta_core_t* const core) {
   ta_conf->version = TA_VERSION;
   ta_conf->host = TA_HOST;
   ta_conf->port = TA_PORT;
+  memset(ta_conf->host_list, 0, sizeof(ta_conf->host_list));
+  memset(ta_conf->port_list, 0, sizeof(ta_conf->port_list));
   ta_conf->thread_count = TA_THREAD_COUNT;
   ta_conf->proxy_passthrough = false;
+  ta_conf->check_period = IRI_HEALTH_TRACK_PERIOD;
 #ifdef MQTT_ENABLE
   ta_conf->mqtt_host = MQTT_HOST;
   ta_conf->mqtt_topic_root = TOPIC_ROOT;

--- a/accelerator/config.h
+++ b/accelerator/config.h
@@ -41,10 +41,11 @@ extern "C" {
 #define TOPIC_ROOT "root/topics"
 #endif
 
-#define TA_PORT "8000"
+#define TA_PORT 8000
 #define TA_THREAD_COUNT 10
 #define IRI_HOST "localhost"
 #define IRI_PORT 14265
+#define MAX_IRI_LIST_ELEMENTS 5
 #define DB_HOST "localhost"
 #define MILESTONE_DEPTH 3
 #define MWM 14
@@ -52,6 +53,7 @@ extern "C" {
   "AMRWQP9BUMJALJHBXUCHOD9HFFD9LGTGEAWMJWWXSDVOF9PI9YGJAPBQLQUOMNYEQCZPGCTHGV" \
   "NNAPGHA"
 #define MAM_FILE_PREFIX "/tmp/mam_bin_XXXXXX"
+#define IRI_HEALTH_TRACK_PERIOD 1800  // Check every half hour in default
 
 /** @name Redis connection config */
 /** @{ */
@@ -61,15 +63,18 @@ extern "C" {
 
 /** struct type of accelerator configuration */
 typedef struct ta_config_s {
-  char* version;        /**< Binding version of tangle-accelerator */
-  char* host;           /**< Binding address of tangle-accelerator */
-  char* port;           /**< Binding port of tangle-accelerator */
-  uint8_t thread_count; /**< Thread count of tangle-accelerator instance */
+  char* version;                          /**< Binding version of tangle-accelerator */
+  char* host;                             /**< Binding address of tangle-accelerator */
+  int port;                               /**< Binding port of tangle-accelerator */
+  char* host_list[MAX_IRI_LIST_ELEMENTS]; /**< List of binding host of tangle-accelerator */
+  int port_list[MAX_IRI_LIST_ELEMENTS];   /**< List of binding port of tangle-accelerator */
+  uint8_t thread_count;                   /**< Thread count of tangle-accelerator instance */
 #ifdef MQTT_ENABLE
   char* mqtt_host;       /**< Address of MQTT broker host */
   char* mqtt_topic_root; /**< The topic root of MQTT topic */
 #endif
   bool proxy_passthrough; /**< Pass proxy api directly without processing */
+  int check_period;       /**< The period for checking IRI host connection status */
 } ta_config_t;
 
 /** struct type of iota configuration */

--- a/accelerator/config.h
+++ b/accelerator/config.h
@@ -73,8 +73,8 @@ typedef struct ta_config_s {
   char* mqtt_host;       /**< Address of MQTT broker host */
   char* mqtt_topic_root; /**< The topic root of MQTT topic */
 #endif
-  bool proxy_passthrough; /**< Pass proxy api directly without processing */
-  int check_period;       /**< The period for checking IRI host connection status */
+  bool proxy_passthrough;  /**< Pass proxy api directly without processing */
+  int health_track_period; /**< The period for checking IRI host connection status */
 } ta_config_t;
 
 /** struct type of iota configuration */

--- a/accelerator/core/core.c
+++ b/accelerator/core/core.c
@@ -584,3 +584,33 @@ done:
 
   return ret;
 }
+
+status_t ta_update_iri_conneciton(ta_config_t* const ta_conf, iota_client_service_t* const service) {
+  status_t ret = SC_OK;
+  for (int i = 0; i < MAX_IRI_LIST_ELEMENTS && ta_conf->host_list[i]; i++) {
+    // update new IRI host
+    ta_conf->host = ta_conf->host_list[i];
+    ta_conf->port = ta_conf->port_list[i];
+    service->http.host = ta_conf->host_list[i];
+    service->http.port = ta_conf->port_list[i];
+    ta_log_info("Try tp connect to %s:%d\n", ta_conf->host, ta_conf->port);
+
+    if (iota_client_core_init(service)) {
+      ta_log_error("Initializing IRI connection failed!\n");
+      return SC_TA_OOM;
+    }
+    iota_client_extended_init();
+
+    // Run from the first one until found a good one.
+    if (ta_get_iri_status(service) == SC_OK) {
+      ta_log_info("Connect to %s:%d\n", ta_conf->host, ta_conf->port);
+      goto done;
+    }
+  }
+  if (ret) {
+    ta_log_error("All IRI host on priority list failed.\n");
+  }
+
+done:
+  return ret;
+}

--- a/accelerator/core/core.c
+++ b/accelerator/core/core.c
@@ -564,15 +564,17 @@ status_t ta_get_iri_status(const iota_client_service_t* const service) {
   str_from_char_buffer(res_buff, &iri_result);
 
   // Check whether IRI host is at the latest milestone
-  char latestMilestone[NUM_TRYTES_ADDRESS + 1], latestSolidSubtangleMilestone[NUM_TRYTES_ADDRESS + 1];
-  ret = get_iri_status_milestone_deserialize(iri_result, latestMilestone, latestSolidSubtangleMilestone);
+  int latestMilestoneIndex, latestSolidSubtangleMilestoneIndex;
+  ret = get_iri_status_milestone_deserialize(iri_result, &latestMilestoneIndex, &latestSolidSubtangleMilestoneIndex);
   if (ret != SC_OK) {
     ta_log_error("check iri connection failed deserialized. status code: %d\n", ret);
     goto done;
   }
 
-  if (strcmp(latestMilestone, latestSolidSubtangleMilestone)) {
+  // The tolerant difference between latestSolidSubtangleMilestoneIndex and latestMilestoneIndex is less equal than 1.
+  if ((latestSolidSubtangleMilestoneIndex - latestMilestoneIndex) > 1) {
     ret = SC_CORE_IRI_UNSYNC;
+    ta_log_error("%s\n", "SC_CORE_IRI_UNSYNC");
   }
 
 done:

--- a/accelerator/core/core.c
+++ b/accelerator/core/core.c
@@ -597,7 +597,7 @@ status_t ta_update_iri_conneciton(ta_config_t* const ta_conf, iota_client_servic
 
     if (iota_client_core_init(service)) {
       ta_log_error("Initializing IRI connection failed!\n");
-      return SC_TA_OOM;
+      return RC_CCLIENT_UNIMPLEMENTED;
     }
     iota_client_extended_init();
 

--- a/accelerator/core/core.h
+++ b/accelerator/core/core.h
@@ -235,6 +235,21 @@ status_t ta_get_bundles_by_addr(const iota_client_service_t* const service, tryt
  */
 status_t ta_get_iri_status(const iota_client_service_t* const service);
 
+/**
+ * @brief Update the binding IRI host to another valid host on priority list
+ *
+ * ta_update_iri_conneciton would check the connection status of all the IRI host on priority list iteratively. Once it
+ * connect to one of the IRI host on the priority list, it would return SC_OK.
+ *
+ * @param ta_conf[in] Tangle-accelerator configuration variables
+ * @param service[in] service IRI node end point service
+ *
+ * @return
+ * - SC_OK on success
+ * - non-zero on error
+ */
+status_t ta_update_iri_conneciton(ta_config_t* const ta_conf, iota_client_service_t* const service);
+
 #ifdef __cplusplus
 }
 #endif

--- a/accelerator/core/serializer/serializer.c
+++ b/accelerator/core/serializer/serializer.c
@@ -40,7 +40,7 @@ status_t ta_get_info_serialize(char** obj, ta_config_t* const ta_config, iota_co
   cJSON_AddStringToObject(json_root, "name", "tangle-accelerator");
   cJSON_AddStringToObject(json_root, "host", ta_config->host);
   cJSON_AddStringToObject(json_root, "version", ta_config->version);
-  cJSON_AddStringToObject(json_root, "port", ta_config->port);
+  cJSON_AddNumberToObject(json_root, "port", ta_config->port);
   cJSON_AddNumberToObject(json_root, "thread", ta_config->thread_count);
   cJSON_AddStringToObject(json_root, "redis_host", cache->host);
   cJSON_AddNumberToObject(json_root, "redis_port", cache->port);

--- a/accelerator/core/serializer/serializer.c
+++ b/accelerator/core/serializer/serializer.c
@@ -1209,13 +1209,14 @@ done:
   return ret;
 }
 
-status_t get_iri_status_milestone_deserialize(char const* const obj, char* const latestMilestone,
-                                              char* const latestSolidSubtangleMilestone) {
+status_t get_iri_status_milestone_deserialize(char const* const obj, int* const latestMilestoneIndex,
+                                              int* const latestSolidSubtangleMilestoneIndex) {
   if (obj == NULL) {
     ta_log_error("%s\n", "SC_SERIALIZER_NULL");
     return SC_SERIALIZER_NULL;
   }
   cJSON* json_obj = cJSON_Parse(obj);
+  cJSON* json_value = NULL;
   status_t ret = SC_OK;
 
   if (json_obj == NULL) {
@@ -1224,14 +1225,19 @@ status_t get_iri_status_milestone_deserialize(char const* const obj, char* const
     goto done;
   }
 
-  if (ta_json_get_string(json_obj, "latestMilestone", (char*)latestMilestone, NUM_TRYTES_ADDRESS + 1) != SC_OK) {
+  json_value = cJSON_GetObjectItemCaseSensitive(json_obj, "latestMilestoneIndex");
+  if (cJSON_IsNumber(json_value)) {
+    *latestMilestoneIndex = json_value->valueint;
+  } else {
     ret = SC_SERIALIZER_NULL;
     ta_log_error("%s\n", "SC_SERIALIZER_NULL");
     goto done;
   }
 
-  if (ta_json_get_string(json_obj, "latestSolidSubtangleMilestone", (char*)latestSolidSubtangleMilestone,
-                         NUM_TRYTES_ADDRESS + 1) != SC_OK) {
+  json_value = cJSON_GetObjectItemCaseSensitive(json_obj, "latestSolidSubtangleMilestoneIndex");
+  if (cJSON_IsNumber(json_value)) {
+    *latestSolidSubtangleMilestoneIndex = json_value->valueint;
+  } else {
     ret = SC_SERIALIZER_NULL;
     ta_log_error("%s\n", "SC_SERIALIZER_NULL");
   }

--- a/accelerator/core/serializer/serializer.h
+++ b/accelerator/core/serializer/serializer.h
@@ -335,15 +335,15 @@ status_t proxy_apis_command_req_deserialize(const char* const obj, char* command
  * @brief Deserialze latestMilestone and latestSolidSubtangleMilestone from IRI core API getNodeInfo
  *
  * @param[in] obj getNodeInfo response in JSON.
- * @param[out] latestMilestone Hash of latestMilestone
- * @param[out] latestSolidSubtangleMilestone Hash of latestSolidSubtangleMilestone
+ * @param[out] latestMilestoneIndex Index of latestMilestone
+ * @param[out] latestSolidSubtangleMilestoneIndex Index of latestSolidSubtangleMilestone
  *
  * @return
  * - SC_OK on success
  * - non-zero on error
  */
-status_t get_iri_status_milestone_deserialize(char const* const obj, char* const latestMilestone,
-                                              char* const latestSolidSubtangleMilestone);
+status_t get_iri_status_milestone_deserialize(char const* const obj, int* const latestMilestone,
+                                              int* const latestSolidSubtangleMilestone);
 
 /**
  * @brief Serialze the response of IRI connection status.

--- a/accelerator/main.c
+++ b/accelerator/main.c
@@ -30,7 +30,7 @@ void check_iri_connection(ta_core_t* const core) {
       }
     }
 
-    sleep(core->ta_conf.check_period);
+    sleep(core->ta_conf.health_track_period);
   }
 }
 

--- a/accelerator/main.c
+++ b/accelerator/main.c
@@ -3,6 +3,8 @@
 #include "common/logger.h"
 #include "common/ta_errors.h"
 #include "connectivity/http/http.h"
+#include "pthread.h"
+#include "time.h"
 #include "utils/handles/signal.h"
 
 #define MAIN_LOGGER "main"
@@ -14,6 +16,21 @@ static logger_id_t logger_id;
 static void ta_stop(int signal) {
   if (signal == SIGINT || signal == SIGTERM) {
     ta_http_stop(&ta_http);
+  }
+}
+
+void check_iri_connection(ta_core_t* const core) {
+  while (true) {
+    status_t ret = ta_get_iri_status(&core->iota_service);
+    if (ret == SC_CORE_IRI_UNSYNC || ret == SC_CCLIENT_FAILED_RESPONSE) {
+      ta_log_error("IRI status error %d. Try to connect to another IRI host on priority list\n", ret);
+      ret = ta_update_iri_conneciton(&core->ta_conf, &core->iota_service);
+      if (ret) {
+        ta_log_error("Update IRI host failed: %d\n", ret);
+      }
+    }
+
+    sleep(core->ta_conf.check_period);
   }
 }
 
@@ -48,6 +65,9 @@ int main(int argc, char* argv[]) {
     ta_log_error("Configure failed %s.\n", MAIN_LOGGER);
     return EXIT_FAILURE;
   }
+
+  pthread_t thread;
+  pthread_create(&thread, NULL, check_iri_connection, &ta_core);
 
   // Initialize apis cJSON lock
   if (apis_lock_init() != SC_OK) {

--- a/connectivity/http/http.c
+++ b/connectivity/http/http.c
@@ -340,13 +340,11 @@ static int ta_http_process_request(ta_http_t *const http, char const *const url,
       return process_send_transfer_request(http, payload, out);
     }
     return process_method_not_allowed_request(out);
-
   } else if (ta_http_url_matcher(url, "/tryte[/]?") == SC_OK) {
     if (payload != NULL) {
       return process_send_trytes_request(http, payload, out);
     }
     return process_method_not_allowed_request(out);
-
   } else if (ta_http_url_matcher(url, "/info[/]?") == SC_OK) {
     return process_get_ta_info_request(http, out);
   } else if (ta_http_url_matcher(url, "/") == SC_OK) {
@@ -354,7 +352,6 @@ static int ta_http_process_request(ta_http_t *const http, char const *const url,
       return process_proxy_api_request(http, payload, out);
     }
     return process_method_not_allowed_request(out);
-
   } else {
     ta_log_error("SC_HTTP_URL_NOT_MATCH : %s\n", url);
     return process_invalid_path_request(out);
@@ -502,7 +499,7 @@ status_t ta_http_start(ta_http_t *const http) {
 
   http->daemon =
       MHD_start_daemon(MHD_USE_AUTO_INTERNAL_THREAD | MHD_USE_THREAD_PER_CONNECTION | MHD_USE_ERROR_LOG | MHD_USE_DEBUG,
-                       atoi(http->core->ta_conf.port), request_log, NULL, ta_http_handler, http, MHD_OPTION_END);
+                       http->core->ta_conf.port, request_log, NULL, ta_http_handler, http, MHD_OPTION_END);
   if (http->daemon == NULL) {
     ta_log_error("%s\n", strerror(errno));
     return SC_HTTP_OOM;

--- a/tests/unit-test/test_serializer.c
+++ b/tests/unit-test/test_serializer.c
@@ -417,15 +417,14 @@ void test_get_iri_status_milestone_deserialize(void) {
       "\"tips\": 9018, \"transactionsToRequest\": 0, \"features\": [  \"snapshotPruning\",  \"dnsRefresher\",  "
       "\"tipSolidification\" ],\"coordinatorAddress\": "
       "\"EQSAUZXULTTYZCLNJNTXQTQHOMOFZERHTCGTXOLTVAHKSA9OGAZDEKECURBRIXIJWNPFCQIOVFVVXJVD9\",\"duration\": 0}";
-  const char latestMilestone[] = "CUOENIPTRCNECMVOXSWKOONGZJICAPH9FIG9F9KYXF9VYXFUKTNDCCLLWRZNUHZIGLJZFWPOVCIZA9999";
-  const char latestSolidSubtangleMilestone[] =
-      "999ENIPTRCNECMVOXSWKOONGZJICAPH9FIG9F9KYXF9VYXFUKTNDCCLLWRZNUHZIGLJZFWPOVCIZA9999";
-  char deserialize_latestMilestone[82], deserialize_latestSolidSubtangleMilestone[82];
+  const int latestMilestoneIndex = 1050373;
+  const int latestSolidSubtangleMilestoneIndex = 1050373;
+  int deserialize_latestMilestoneIndex, deserialize_latestSolidSubtangleMilestoneIndex;
 
-  TEST_ASSERT_EQUAL_INT(SC_OK, get_iri_status_milestone_deserialize(json, deserialize_latestMilestone,
-                                                                    deserialize_latestSolidSubtangleMilestone));
-  TEST_ASSERT_EQUAL_STRING(latestMilestone, deserialize_latestMilestone);
-  TEST_ASSERT_EQUAL_STRING(latestSolidSubtangleMilestone, deserialize_latestSolidSubtangleMilestone);
+  TEST_ASSERT_EQUAL_INT(SC_OK, get_iri_status_milestone_deserialize(json, &deserialize_latestMilestoneIndex,
+                                                                    &deserialize_latestSolidSubtangleMilestoneIndex));
+  TEST_ASSERT_EQUAL_INT(latestMilestoneIndex, deserialize_latestMilestoneIndex);
+  TEST_ASSERT_EQUAL_INT(latestSolidSubtangleMilestoneIndex, deserialize_latestSolidSubtangleMilestoneIndex);
 }
 
 void test_get_iri_status_res_serialize(void) {


### PR DESCRIPTION
Use an extra thread to check the IRI connection status.
If someting is going wrong, then change to another host on
priority list.

The priority of the listed IRI hosts depends on the oder of CLI args.
`tangle-accelerator --iri_address <ADDR1> --iri_address <ADDR2> --iri_address <ADDR3>`
On the example presented above, the priority is `ADDR1` > `ADDR2` > `ADDR3`.

close #452 
