### PR TITLE
fix(cli): Fix no argument commands

### DIFF
--- a/accelerator/cli_info.h
+++ b/accelerator/cli_info.h
@@ -75,7 +75,7 @@ static struct ta_cli_argument_s {
     {"milestone_depth", optional_argument, NULL, MILESTONE_DEPTH_CLI, "IRI milestone depth"},
     {"mwm", optional_argument, NULL, MWM_CLI, "minimum weight magnitude"},
     {"seed", optional_argument, NULL, SEED_CLI, "IOTA seed"},
-    {"cache", required_argument, NULL, CACHE, "Enable cache server with Y"},
+    {"cache", no_argument, NULL, CACHE, "Enable cache server"},
     {"config", required_argument, NULL, CONF_CLI, "Read configuration file"},
     {"proxy_passthrough", no_argument, NULL, PROXY_API, "Pass proxy API directly to IRI without processing"},
     {"quiet", no_argument, NULL, QUIET, "Disable logger"},

--- a/accelerator/config.c
+++ b/accelerator/config.c
@@ -25,7 +25,7 @@ int get_conf_key(char const* const key) {
 }
 
 status_t cli_core_set(ta_core_t* const core, int key, char* const value) {
-  if (value == NULL && key != PROXY_API) {
+  if (value == NULL && (key != CACHE && key != PROXY_API && key != QUIET)) {
     ta_log_error("%s\n", "SC_CONF_NULL");
     return SC_CONF_NULL;
   }
@@ -92,12 +92,12 @@ status_t cli_core_set(ta_core_t* const core, int key, char* const value) {
       iota_conf->seed = value;
       break;
     case CACHE:
-      cache->cache_state = (toupper(value[0]) == 'T');
+      cache->cache_state = true;
       break;
 
     // Quiet mode configuration
     case QUIET:
-      quiet_mode = (toupper(value[0]) == 'T');
+      quiet_mode = true;
       break;
 
     case PROXY_API:
@@ -292,12 +292,6 @@ status_t ta_core_cli_init(ta_core_t* const core, int argc, char** argv) {
       case 'v':
         printf("%s\n", TA_VERSION);
         exit(EXIT_SUCCESS);
-      case QUIET:
-        // Turn on quiet mode
-        quiet_mode = true;
-
-        // Enable backend_redis logger
-        br_logger_init();
         break;
       case CONF_CLI:
         /* Already processed in ta_config_file_init() */

--- a/accelerator/main.c
+++ b/accelerator/main.c
@@ -78,6 +78,8 @@ int main(int argc, char* argv[]) {
     cc_logger_init();
     pow_logger_init();
     timer_logger_init();
+    // Enable backend_redis logger
+    br_logger_init();
   }
 
   /* pause() cause TA to sleep until it catch a signal,
@@ -106,6 +108,7 @@ cleanup:
     pow_logger_release();
     timer_logger_release();
     logger_helper_release(logger_id);
+    br_logger_release();
     if (logger_helper_destroy() != RC_OK) {
       ta_log_error("Destroying logger failed %s.\n", MAIN_LOGGER);
       return EXIT_FAILURE;

--- a/accelerator/mqtt_main.c
+++ b/accelerator/mqtt_main.c
@@ -57,6 +57,8 @@ int main(int argc, char *argv[]) {
     cc_logger_init();
     pow_logger_init();
     timer_logger_init();
+    // Enable backend_redis logger
+    br_logger_init();
   }
 
   // Initialize `mosq` and `cfg`
@@ -110,6 +112,7 @@ done:
     serializer_logger_release();
     pow_logger_release();
     timer_logger_release();
+    br_logger_release();
     logger_helper_release(logger_id);
     if (logger_helper_destroy() != RC_OK) {
       return EXIT_FAILURE;


### PR DESCRIPTION
Commands `cache`, `proxy_passthrough` and `quiet` are no
argument commands. We need to do corresponding operations.