### PR TITLE
Hotfix: Allow sending transfer when milestone shutdown

### DIFF
--- a/accelerator/cli_info.h
+++ b/accelerator/cli_info.h
@@ -48,6 +48,7 @@ typedef enum ta_cli_arg_value_e {
   CACHE,
   CONF_CLI,
   PROXY_API,
+  GTTA_DISABLE,
 
   /** LOGGER */
   QUIET,
@@ -78,6 +79,7 @@ static struct ta_cli_argument_s {
     {"cache", required_argument, NULL, CACHE, "Enable cache server with Y"},
     {"config", required_argument, NULL, CONF_CLI, "Read configuration file"},
     {"proxy_passthrough", no_argument, NULL, PROXY_API, "Pass proxy API directly to IRI without processing"},
+    {"gtta_disable", no_argument, NULL, GTTA_DISABLE, "Disable GTTA when sending transacation"},
     {"quiet", no_argument, NULL, QUIET, "Disable logger"},
     {NULL, 0, NULL, 0, NULL}};
 

--- a/accelerator/config.c
+++ b/accelerator/config.c
@@ -36,7 +36,7 @@ struct option* cli_build_options() {
 }
 
 static status_t cli_core_set(ta_core_t* const core, int key, char* const value) {
-  if (value == NULL && key != PROXY_API) {
+  if (value == NULL && (key != PROXY_API && key != GTTA_DISABLE)) {
     ta_log_error("%s\n", "SC_CONF_NULL");
     return SC_CONF_NULL;
   }
@@ -110,9 +110,11 @@ static status_t cli_core_set(ta_core_t* const core, int key, char* const value) 
     case QUIET:
       quiet_mode = (toupper(value[0]) == 'T');
       break;
-
     case PROXY_API:
       ta_conf->proxy_passthrough = true;
+      break;
+    case GTTA_DISABLE:
+      ta_conf->gtta_disable = true;
       break;
 
     // File configuration
@@ -146,6 +148,7 @@ status_t ta_core_default_init(ta_core_t* const core) {
   ta_conf->port = TA_PORT;
   ta_conf->thread_count = TA_THREAD_COUNT;
   ta_conf->proxy_passthrough = false;
+  ta_conf->gtta_disable = false;
 #ifdef MQTT_ENABLE
   ta_conf->mqtt_host = MQTT_HOST;
   ta_conf->mqtt_topic_root = TOPIC_ROOT;

--- a/accelerator/config.h
+++ b/accelerator/config.h
@@ -70,6 +70,7 @@ typedef struct ta_config_s {
   char* mqtt_topic_root; /**< The topic root of MQTT topic */
 #endif
   bool proxy_passthrough; /**< Pass proxy api directly without processing */
+  bool gtta_disable;      /**< Disable GTTA, the default value is false which enabling GTTA */
 } ta_config_t;
 
 /** struct type of iota configuration */

--- a/accelerator/core/apis.c
+++ b/accelerator/core/apis.c
@@ -365,8 +365,9 @@ done:
   return ret;
 }
 
-status_t api_mam_send_message(const iota_config_t* const iconf, const iota_client_service_t* const service,
-                              char const* const payload, char** json_result) {
+status_t api_mam_send_message(const ta_config_t* const info, const iota_config_t* const iconf,
+                              const iota_client_service_t* const service, char const* const payload,
+                              char** json_result) {
   status_t ret = SC_OK;
   mam_api_t mam;
   tryte_t chid[MAM_CHANNEL_ID_TRYTE_SIZE] = {}, epid[MAM_CHANNEL_ID_TRYTE_SIZE] = {},
@@ -409,7 +410,7 @@ status_t api_mam_send_message(const iota_config_t* const iconf, const iota_clien
 
   // Sending bundle
   lock_handle_lock(&cjson_lock);
-  if (ta_send_bundle(iconf, service, bundle) != SC_OK) {
+  if (ta_send_bundle(info, iconf, service, bundle) != SC_OK) {
     lock_handle_unlock(&cjson_lock);
     ret = SC_MAM_FAILED_RESPONSE;
     ta_log_error("%s\n", "SC_MAM_FAILED_RESPONSE");
@@ -452,7 +453,7 @@ status_t api_mam_send_message(const iota_config_t* const iconf, const iota_clien
     }
 
     lock_handle_lock(&cjson_lock);
-    if (ta_send_bundle(iconf, service, bundle) != SC_OK) {
+    if (ta_send_bundle(info, iconf, service, bundle) != SC_OK) {
       lock_handle_unlock(&cjson_lock);
       ret = SC_MAM_FAILED_RESPONSE;
       ta_log_error("%s\n", "SC_MAM_FAILED_RESPONSE");
@@ -520,7 +521,7 @@ status_t api_send_transfer(const ta_core_t* const core, const char* const obj, c
     goto done;
   }
 
-  ret = ta_send_transfer(&core->iota_conf, &core->iota_service, req, res);
+  ret = ta_send_transfer(&core->ta_conf, &core->iota_conf, &core->iota_service, req, res);
   if (ret) {
     lock_handle_unlock(&cjson_lock);
     goto done;
@@ -554,8 +555,8 @@ done:
   return ret;
 }
 
-status_t api_send_trytes(const iota_config_t* const iconf, const iota_client_service_t* const service,
-                         const char* const obj, char** json_result) {
+status_t api_send_trytes(const ta_config_t* const info, const iota_config_t* const iconf,
+                         const iota_client_service_t* const service, const char* const obj, char** json_result) {
   status_t ret = SC_OK;
   hash8019_array_p trytes = hash8019_array_new();
 
@@ -572,7 +573,7 @@ status_t api_send_trytes(const iota_config_t* const iconf, const iota_client_ser
     goto done;
   }
 
-  ret = ta_send_trytes(iconf, service, trytes);
+  ret = ta_send_trytes(info, iconf, service, trytes);
   if (ret != SC_OK) {
     lock_handle_unlock(&cjson_lock);
     goto done;

--- a/accelerator/core/apis.h
+++ b/accelerator/core/apis.h
@@ -148,6 +148,7 @@ status_t api_receive_mam_message(const iota_config_t* const iconf, const iota_cl
  * There is no need to decode the ascii payload to tryte, since the
  * api_mam_send_message() will take this job.
  *
+ * @param[in] info Tangle-accelerator configuration variables
  * @param[in] iconf IOTA API parameter configurations
  * @param[in] service IRI node end point service
  * @param[in] payload message to send undecoded ascii string.
@@ -157,8 +158,9 @@ status_t api_receive_mam_message(const iota_config_t* const iconf, const iota_cl
  * - SC_OK on success
  * - non-zero on error
  */
-status_t api_mam_send_message(const iota_config_t* const iconf, const iota_client_service_t* const service,
-                              char const* const payload, char** json_result);
+status_t api_mam_send_message(const ta_config_t* const info, const iota_config_t* const iconf,
+                              const iota_client_service_t* const service, char const* const payload,
+                              char** json_result);
 
 /**
  * @brief Send transfer to tangle.
@@ -254,6 +256,7 @@ status_t api_find_transactions_obj_by_tag(const iota_client_service_t* const ser
  * This allows for reattachments and prevents key reuse if trytes can't
  * be recovered by querying the network after broadcasting.
  *
+ * @param[in] info Tangle-accelerator configuration variables
  * @param[in] iconf IOTA API parameter configurations
  * @param[in] service IRI node end point service
  * @param[in] obj trytes to attach, store and broadcast in json array
@@ -264,8 +267,8 @@ status_t api_find_transactions_obj_by_tag(const iota_client_service_t* const ser
  * - SC_OK on success
  * - non-zero on error
  */
-status_t api_send_trytes(const iota_config_t* const iconf, const iota_client_service_t* const service,
-                         const char* const obj, char** json_result);
+status_t api_send_trytes(const ta_config_t* const info, const iota_config_t* const iconf,
+                         const iota_client_service_t* const service, const char* const obj, char** json_result);
 #ifdef DB_ENABLE
 /**
  * @brief Return transaction object with given single identity number.

--- a/accelerator/core/core.c
+++ b/accelerator/core/core.c
@@ -75,8 +75,8 @@ done:
   return ret;
 }
 
-status_t ta_send_trytes(const iota_config_t* const iconf, const iota_client_service_t* const service,
-                        hash8019_array_p trytes) {
+status_t ta_send_trytes(const ta_config_t* const info, const iota_config_t* const iconf,
+                        const iota_client_service_t* const service, hash8019_array_p trytes) {
   status_t ret = SC_OK;
   get_transactions_to_approve_req_t* tx_approve_req = get_transactions_to_approve_req_new();
   get_transactions_to_approve_res_t* tx_approve_res = get_transactions_to_approve_res_new();
@@ -87,12 +87,13 @@ status_t ta_send_trytes(const iota_config_t* const iconf, const iota_client_serv
     ta_log_error("%s\n", "SC_CCLIENT_OOM");
     goto done;
   }
-
-  get_transactions_to_approve_req_set_depth(tx_approve_req, iconf->milestone_depth);
-  if (iota_client_get_transactions_to_approve(service, tx_approve_req, tx_approve_res)) {
-    ret = SC_CCLIENT_FAILED_RESPONSE;
-    ta_log_error("%s\n", "SC_CCLIENT_FAILED_RESPONSE");
-    goto done;
+  if (!info->gtta_disable) {
+    get_transactions_to_approve_req_set_depth(tx_approve_req, iconf->milestone_depth);
+    if (iota_client_get_transactions_to_approve(service, tx_approve_req, tx_approve_res)) {
+      ret = SC_CCLIENT_FAILED_RESPONSE;
+      ta_log_error("%s\n", "SC_CCLIENT_FAILED_RESPONSE");
+      goto done;
+    }
   }
 
   // copy trytes to attach_req->trytes
@@ -171,8 +172,9 @@ status_t ta_generate_address(const iota_config_t* const iconf, const iota_client
   return (status_t)rval;
 }
 
-status_t ta_send_transfer(const iota_config_t* const iconf, const iota_client_service_t* const service,
-                          const ta_send_transfer_req_t* const req, ta_send_transfer_res_t* res) {
+status_t ta_send_transfer(const ta_config_t* const info, const iota_config_t* const iconf,
+                          const iota_client_service_t* const service, const ta_send_transfer_req_t* const req,
+                          ta_send_transfer_res_t* res) {
   if (req == NULL || res == NULL) {
     ta_log_error("%s\n", "SC_TA_NULL");
     return SC_TA_NULL;
@@ -231,7 +233,7 @@ status_t ta_send_transfer(const iota_config_t* const iconf, const iota_client_se
     free(serialized_txn);
   }
 
-  ret = ta_send_trytes(iconf, service, raw_tx);
+  ret = ta_send_trytes(info, iconf, service, raw_tx);
   if (ret) {
     goto done;
   }
@@ -454,8 +456,8 @@ done:
   return ret;
 }
 
-status_t ta_send_bundle(const iota_config_t* const iconf, const iota_client_service_t* const service,
-                        bundle_transactions_t* const bundle) {
+status_t ta_send_bundle(const ta_config_t* const info, const iota_config_t* const iconf,
+                        const iota_client_service_t* const service, bundle_transactions_t* const bundle) {
   Kerl kerl;
   kerl_init(&kerl);
   bundle_finalize(bundle, &kerl);
@@ -469,7 +471,7 @@ status_t ta_send_bundle(const iota_config_t* const iconf, const iota_client_serv
     hash_array_push(raw_trytes, trits_8019);
   }
 
-  ta_send_trytes(iconf, service, raw_trytes);
+  ta_send_trytes(info, iconf, service, raw_trytes);
 
   hash_array_free(raw_trytes);
   transaction_array_free(out_tx_objs);

--- a/accelerator/core/core.h
+++ b/accelerator/core/core.h
@@ -78,6 +78,7 @@ status_t ta_generate_address(const iota_config_t* const iconf, const iota_client
  * fields include address, value, tag, and message. This API would also try to
  * find the transactions after bundle sent.
  *
+ * @param[in] info Tangle-accelerator configuration variables
  * @param[in] iconf IOTA API parameter configurations
  * @param[in] service IRI node end point service
  * @param[in] req Request containing address value, message, tag in
@@ -88,8 +89,9 @@ status_t ta_generate_address(const iota_config_t* const iconf, const iota_client
  * - SC_OK on success
  * - non-zero on error
  */
-status_t ta_send_transfer(const iota_config_t* const iconf, const iota_client_service_t* const service,
-                          const ta_send_transfer_req_t* const req, ta_send_transfer_res_t* res);
+status_t ta_send_transfer(const ta_config_t* const info, const iota_config_t* const iconf,
+                          const iota_client_service_t* const service, const ta_send_transfer_req_t* const req,
+                          ta_send_transfer_res_t* res);
 
 /**
  * @brief Send trytes to tangle.
@@ -98,6 +100,7 @@ status_t ta_send_transfer(const iota_config_t* const iconf, const iota_client_se
  * bundle and do PoW in `ta_attach_to_tangle` and store and broadcast
  * transaction to tangle.
  *
+ * @param[in] info Tangle-accelerator configuration variables
  * @param[in] iconf IOTA API parameter configurations
  * @param[in] service IRI node end point service
  * @param[in] trytes Trytes that will be attached to tangle
@@ -106,8 +109,8 @@ status_t ta_send_transfer(const iota_config_t* const iconf, const iota_client_se
  * - SC_OK on success
  * - non-zero on error
  */
-status_t ta_send_trytes(const iota_config_t* const iconf, const iota_client_service_t* const service,
-                        hash8019_array_p trytes);
+status_t ta_send_trytes(const ta_config_t* const info, const iota_config_t* const iconf,
+                        const iota_client_service_t* const service, hash8019_array_p trytes);
 
 /**
  * @brief Return list of transaction hash with given tag.
@@ -187,6 +190,7 @@ status_t ta_get_bundle(const iota_client_service_t* const service, tryte_t const
  * Send the unpacked bundle which contains transactions. MAM functions should
  * send message with this function.
  *
+ * @param[in] info Tangle-accelerator configuration variables
  * @param[in] service IRI node end point service
  * @param[in] bundle bundle object to send
  * @param[out] bundle Result containing bundle object in bundle_transactions_t
@@ -195,8 +199,8 @@ status_t ta_get_bundle(const iota_client_service_t* const service, tryte_t const
  * - SC_OK on success
  * - non-zero on error
  */
-status_t ta_send_bundle(const iota_config_t* const iconf, const iota_client_service_t* const service,
-                        bundle_transactions_t* const bundle);
+status_t ta_send_bundle(const ta_config_t* const info, const iota_config_t* const iconf,
+                        const iota_client_service_t* const service, bundle_transactions_t* const bundle);
 
 /**
  * @brief Get the bundle that contains assigned address

--- a/connectivity/http/http.c
+++ b/connectivity/http/http.c
@@ -238,13 +238,13 @@ static inline int process_find_transaction_by_id_request(ta_http_t *const http, 
 
 static inline int process_mam_send_msg_request(ta_http_t *const http, char const *const payload, char **const out) {
   status_t ret;
-  ret = api_mam_send_message(&http->core->iota_conf, &http->core->iota_service, payload, out);
+  ret = api_mam_send_message(&http->core->ta_conf, &http->core->iota_conf, &http->core->iota_service, payload, out);
   return set_response_content(ret, out);
 }
 
 static inline int process_send_trytes_request(ta_http_t *const http, char const *const payload, char **const out) {
   status_t ret;
-  ret = api_send_trytes(&http->core->iota_conf, &http->core->iota_service, payload, out);
+  ret = api_send_trytes(&http->core->ta_conf, &http->core->iota_conf, &http->core->iota_service, payload, out);
   return set_response_content(ret, out);
 }
 

--- a/tests/driver.c
+++ b/tests/driver.c
@@ -170,7 +170,8 @@ void test_send_trytes(void) {
 
   for (size_t count = 0; count < TEST_COUNT; count++) {
     test_time_start(&start_time);
-    TEST_ASSERT_EQUAL_INT32(SC_OK, api_send_trytes(&ta_core.iota_conf, &ta_core.iota_service, json, &json_result));
+    TEST_ASSERT_EQUAL_INT32(
+        SC_OK, api_send_trytes(&ta_core.ta_conf, &ta_core.iota_conf, &ta_core.iota_service, json, &json_result));
     test_time_end(&start_time, &end_time, &sum);
     free(json_result);
   }
@@ -277,7 +278,7 @@ void test_send_mam_message(void) {
 
   for (size_t count = 0; count < TEST_COUNT; count++) {
     test_time_start(&start_time);
-    ret = api_mam_send_message(&ta_core.iota_conf, &ta_core.iota_service, json, &json_result);
+    ret = api_mam_send_message(&ta_core.ta_conf, &ta_core.iota_conf, &ta_core.iota_service, json, &json_result);
     if (ret == SC_OK || ret == SC_MAM_ALL_MSS_KEYS_USED) {
       result = true;
     }


### PR DESCRIPTION
This is an emergent PR.
If milestone doesn't work, any transaction which processing GTTA
can't be able to be sent successfully. For a temporary workaround,
we add a new CLI commmand to turn GTTA off.