### PR TITLE
docs(README): Fix unavailable link

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ Tangle-accelerator supports several different build time options.
 * MQTT connectivity
 * External database
 
-See [docs/build.md](https://github.com/DLTcollab/tangle-accelerator/docs/build.md) for more information.
+See [docs/build.md](docs/build.md) for more information.
 
 ## Developing
 


### PR DESCRIPTION
The link of docs/build.mb was wrong.