### PR TITLE
refactor(api): Generate address with given seed

### DIFF
--- a/accelerator/core/apis.c
+++ b/accelerator/core/apis.c
@@ -123,7 +123,7 @@ done:
 }
 
 status_t api_generate_address(const iota_config_t* const iconf, const iota_client_service_t* const service,
-                              char** json_result) {
+                              const char* const seed, char** json_result) {
   status_t ret = SC_OK;
   ta_generate_address_res_t* res = ta_generate_address_res_new();
   if (res == NULL) {
@@ -133,7 +133,7 @@ status_t api_generate_address(const iota_config_t* const iconf, const iota_clien
   }
 
   lock_handle_lock(&cjson_lock);
-  ret = ta_generate_address(iconf, service, res);
+  ret = ta_generate_address(iconf, service, seed, res);
   if (ret) {
     lock_handle_unlock(&cjson_lock);
     ta_log_error("%s\n", "Failed in TA core function");

--- a/accelerator/core/apis.h
+++ b/accelerator/core/apis.h
@@ -84,6 +84,7 @@ status_t apis_lock_destroy();
  *
  * @param[in] iconf IOTA API parameter configurations
  * @param[in] service IRI node end point service
+ * @param[in] seed Root seed to generate new address
  * @param[out] json_result Result containing an unused address in json format
  *
  * @return
@@ -91,7 +92,7 @@ status_t apis_lock_destroy();
  * - non-zero on error
  */
 status_t api_generate_address(const iota_config_t* const iconf, const iota_client_service_t* const service,
-                              char** json_result);
+                              const char* const seed, char** json_result);
 
 /**
  * @brief Get trunk and branch transactions

--- a/accelerator/core/core.h
+++ b/accelerator/core/core.h
@@ -53,6 +53,7 @@ int cc_logger_release();
 typedef struct {
   const iota_config_t* iconf;
   const iota_client_service_t* service;
+  char* seed;
   ta_generate_address_res_t* res;
 } ta_generate_address_args_t;
 
@@ -64,6 +65,7 @@ typedef struct {
  *
  * @param[in] iconf IOTA API parameter configurations
  * @param[in] service IRI node end point service
+ * @param[in] seed Root seed to generate new address
  * @param[out] res Result containing an unused address in
  * ta_generate_address_res_t
  *
@@ -72,7 +74,7 @@ typedef struct {
  * - non-zero on error
  */
 status_t ta_generate_address(const iota_config_t* const iconf, const iota_client_service_t* const service,
-                             ta_generate_address_res_t* res);
+                             const char* const seed, ta_generate_address_res_t* res);
 
 /**
  * @brief Send transfer to tangle.

--- a/connectivity/http/http.c
+++ b/connectivity/http/http.c
@@ -146,9 +146,13 @@ static inline int process_find_txns_by_tag_request(ta_http_t *const http, char c
   return set_response_content(ret, out);
 }
 
-static inline int process_generate_address_request(ta_http_t *const http, char **const out) {
+static inline int process_generate_address_request(ta_http_t *const http, char const *const url, char **const out) {
   status_t ret;
-  ret = api_generate_address(&http->core->iota_conf, &http->core->iota_service, out);
+  char *seed = NULL;
+  ret = ta_get_url_parameter(url, 1, &seed);
+  if (ret == SC_OK || ret == SC_HTTP_URL_PARSE_ERROR) {
+    ret = api_generate_address(&http->core->iota_conf, &http->core->iota_service, seed, out);
+  }
   return set_response_content(ret, out);
 }
 
@@ -317,8 +321,8 @@ static int ta_http_process_request(ta_http_t *const http, char const *const url,
     return process_get_tips_pair_request(http, out);
   } else if (ta_http_url_matcher(url, "/tips[/]?") == SC_OK) {
     return process_get_tips_request(http, out);
-  } else if (ta_http_url_matcher(url, "/address[/]?") == SC_OK) {
-    return process_generate_address_request(http, out);
+  } else if (ta_http_url_matcher(url, "/address[/]?([A-Z9]{81})?[/]?") == SC_OK) {
+    return process_generate_address_request(http, url, out);
   } else if (ta_http_url_matcher(url, "/tag/[A-Z9]{1,27}/hashes[/]?") == SC_OK) {
     return process_find_txns_by_tag_request(http, url, out);
   } else if (ta_http_url_matcher(url, "/tag/[A-Z9]{1,27}[/]?") == SC_OK) {

--- a/tests/api/driver.c
+++ b/tests/api/driver.c
@@ -88,7 +88,7 @@ void test_generate_address(void) {
 
   for (size_t count = 0; count < TEST_COUNT; count++) {
     test_time_start(&start_time);
-    TEST_ASSERT_EQUAL_INT32(SC_OK, api_generate_address(&ta_core.iota_conf, &ta_core.iota_service, &json_result));
+    TEST_ASSERT_EQUAL_INT32(SC_OK, api_generate_address(&ta_core.iota_conf, &ta_core.iota_service, NULL, &json_result));
     test_time_end(&start_time, &end_time, &sum);
     free(json_result);
   }

--- a/tests/unit-test/test_core.cc
+++ b/tests/unit-test/test_core.cc
@@ -28,7 +28,7 @@ TEST(GenAdressTest, GetNewAddressTest) {
 
   EXPECT_CALL(APIMockObj, iota_client_get_new_address(_, _, _, _)).Times(AtLeast(1));
 
-  EXPECT_EQ(ta_generate_address(&tangle, &service, res), 0);
+  EXPECT_EQ(ta_generate_address(&tangle, &service, NULL, res), 0);
   CDL_FOREACH(res->addresses, q_iter) {
     EXPECT_FALSE(memcmp(q_iter->hash, hash_trits_1, sizeof(flex_trit_t) * FLEX_TRIT_SIZE_243));
   }


### PR DESCRIPTION
Generate new address with given address.
The API path would look like `localhost:8000/address/<SEED>`
close #508