### PR TITLE
fix(http): Accept content type encoding UTF-8

### DIFF
--- a/connectivity/http/http.c
+++ b/connectivity/http/http.c
@@ -363,8 +363,12 @@ static int ta_http_header_iter(void *cls, enum MHD_ValueKind kind, const char *k
   UNUSED(kind);
   ta_http_request_t *header = cls;
 
-  if (0 == strcmp(MHD_HTTP_HEADER_CONTENT_TYPE, key)) {
-    header->valid_content_type = !strcmp("application/json", value);
+  if (0 == strncasecmp(MHD_HTTP_HEADER_CONTENT_TYPE, key, strlen(MHD_HTTP_HEADER_CONTENT_TYPE))) {
+    if (ta_http_url_matcher(value, "application/json(;?\\s*charset=(UTF|utf)-8)?") == SC_OK) {
+      header->valid_content_type = true;
+    } else {
+      header->valid_content_type = false;
+    }
   }
   return MHD_YES;
 }


### PR DESCRIPTION
The following content-type are accepeted in tangle-accelerator
* application/json
* application/json;
* application/json; charset=UTF-8
* application/json; charset=utf-8
* application/json;charset=utf-8

And both uppper case and lower case of Content-Type and content-type
are accpeted from this PR.

fixes #503