### PR TITLE
feat(cache): Implement LIST operations for cache

### DIFF
--- a/tests/test_define.h
+++ b/tests/test_define.h
@@ -298,6 +298,7 @@ extern "C" {
   "EXKAOTLTLEVBMCCFNJMTVAPUCKHNYIU9Z9ZPFYYYFLZCANXNNZPNDWYTBYSXWYCWHPBXFZGEKBOMBSXIJBWVOKGWIHHYRIUMAQZ9UUHEYPOP"
 
 #define TEST_UUID "123e4567-e89b-12d3-a456-426655440000"
+#define TEST_UUID_LIST_NAME "test_uuid_list"
 #define CACHE_VALUE                                                                                     \
   "{\"value\": 0,\"message\": \"ZBCDKDTCFDTCSCEAQCMDEAHDPCBDVC9DTCRAPCRCRCTC9DTCFDPCHDCDFD\",\"tag\": " \
   "\"POWEREDBYTANGLEACCELERATOR9\",\"address\": "                                                       \

--- a/tests/unit-test/test_cache.c
+++ b/tests/unit-test/test_cache.c
@@ -27,17 +27,15 @@ void test_cache_get(void) {
 
 void test_cache_set(void) {
   char* key = test_uuid;
-  const char* value = CACHE_VALUE;
 
-  TEST_ASSERT_EQUAL_INT(SC_OK, cache_set(key, strlen(key), value, strlen(value), 0));
+  TEST_ASSERT_EQUAL_INT(SC_OK, cache_set(key, strlen(key), CACHE_VALUE, strlen(CACHE_VALUE), 0));
 }
 
 void test_cache_timeout(void) {
   char* key = test_uuid;
-  const char* value = CACHE_VALUE;
   char res[strlen(CACHE_VALUE) + 1];
   const int timeout = 2;
-  TEST_ASSERT_EQUAL_INT(SC_OK, cache_set(key, strlen(key), value, strlen(value), timeout));
+  TEST_ASSERT_EQUAL_INT(SC_OK, cache_set(key, strlen(key), CACHE_VALUE, strlen(CACHE_VALUE), timeout));
   TEST_ASSERT_EQUAL_INT(SC_OK, cache_get(key, res));
   sleep(timeout + 1);
   TEST_ASSERT_EQUAL_INT(SC_CACHE_FAILED_RESPONSE, cache_get(key, res));
@@ -51,6 +49,32 @@ void test_generate_uuid(void) {
   TEST_ASSERT_TRUE(test_uuid[0]);
 }
 
+void test_cache_list_push(void) {
+  TEST_ASSERT_EQUAL_INT(
+      SC_OK, cache_list_push(TEST_UUID_LIST_NAME, strlen(TEST_UUID_LIST_NAME), TEST_UUID, strlen(TEST_UUID), 0));
+}
+
+void test_cache_list_at(void) {
+  char res[UUID_STR_LEN];
+
+  TEST_ASSERT_EQUAL_INT(SC_OK, cache_list_at(TEST_UUID_LIST_NAME, -1, UUID_STR_LEN, res));
+  TEST_ASSERT_EQUAL_STRING(TEST_UUID, res);
+}
+
+void test_cache_list_size(void) {
+  int len = 0;
+
+  TEST_ASSERT_EQUAL_INT(SC_OK, cache_list_size(TEST_UUID_LIST_NAME, &len));
+  TEST_ASSERT_EQUAL_INT(1, len);
+}
+
+void test_cache_list_pop(void) {
+  char res[UUID_STR_LEN];
+
+  TEST_ASSERT_EQUAL_INT(SC_OK, cache_list_pop(TEST_UUID_LIST_NAME, res));
+  TEST_ASSERT_EQUAL_STRING(TEST_UUID, res);
+}
+
 int main(void) {
   UNITY_BEGIN();
   cache_init(true, REDIS_HOST, REDIS_PORT);
@@ -59,6 +83,10 @@ int main(void) {
   RUN_TEST(test_cache_get);
   RUN_TEST(test_cache_del);
   RUN_TEST(test_cache_timeout);
+  RUN_TEST(test_cache_list_push);
+  RUN_TEST(test_cache_list_at);
+  RUN_TEST(test_cache_list_size);
+  RUN_TEST(test_cache_list_pop);
   cache_stop();
   return UNITY_END();
 }

--- a/utils/cache/cache.h
+++ b/utils/cache/cache.h
@@ -104,6 +104,61 @@ status_t cache_get(const char* const key, char* res);
 status_t cache_set(const char* const key, const int key_size, const void* const value, const int value_size,
                    const int timeout);
 
+/**
+ * Push a elements to a list into in-memory cache
+ *
+ * @param[in] key Key string to store
+ * @param[in] key_size Size of key string to store
+ * @param[in] value Value string to store
+ * @param[in] value_size Size of value string to store
+ * @param[in] timeout Set the timeout of the key in second. If arg timeout is equal less than 0, then no timeout will be
+ * set.
+ *
+ * @return
+ * - SC_OK on success
+ * - non-zero on error
+ */
+status_t cache_list_push(const char* const key, const int key_size, const void* const value, const int value_size,
+                         const int timeout);
+
+/**
+ * Get an element of a list from in-memory cache
+ *
+ * @param[in] key Key string to search
+ * @param[in] index Assigned index for fetching element
+ * @param[in] res_len Expected length of the respose
+ * @param[out] res The element with assigning index
+ *
+ * @return
+ * - SC_OK on success
+ * - non-zero on error
+ */
+status_t cache_list_at(const char* const key, const int index, const int res_len, char* res);
+
+/**
+ * Fetch the length of the list in in-memory cache
+ *
+ * @param[in] key Key string to store
+ * @param[out] len The returned length of list
+ *
+ * @return
+ * - SC_OK on success
+ * - non-zero on error
+ */
+status_t cache_list_size(const char* const key, int* len);
+
+/**
+ * Pop an element from the list in in-memory cache
+ *
+ * @param[in] key Key for key-value starage
+ * @param[out] res The element with assigning index
+ *
+ * @return
+ * - SC_OK on success
+ * - non-zero on error
+ */
+status_t cache_list_pop(const char* const key, char* res);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
We need a list in cache server to store all the UUIDs
of buffered transactions. When tangle-accelerator reconnect to
IRI, tangle-accelerator would iterate all the elements in the
list, and use the stored UUIDs to fetch the stored transaction
body in cache server.

relates to #522 