### PR TITLE
feat(core): Broadcast buffered transaction objects

### DIFF
--- a/accelerator/config.c
+++ b/accelerator/config.c
@@ -236,6 +236,8 @@ status_t ta_core_default_init(ta_core_t* const core) {
   cache->host = REDIS_HOST;
   cache->port = REDIS_PORT;
   cache->cache_state = false;
+  cache->buffer_list_name = BUFFER_LIST_NAME;
+  cache->done_list_name = DONE_LIST_NAME;
 
   ta_log_info("Initializing IRI configuration\n");
   iota_conf->milestone_depth = MILESTONE_DEPTH;

--- a/accelerator/config.h
+++ b/accelerator/config.h
@@ -53,6 +53,8 @@ extern "C" {
   "AMRWQP9BUMJALJHBXUCHOD9HFFD9LGTGEAWMJWWXSDVOF9PI9YGJAPBQLQUOMNYEQCZPGCTHGV" \
   "NNAPGHA"
 #define MAM_FILE_PREFIX "/tmp/mam_bin_XXXXXX"
+#define BUFFER_LIST_NAME "txn_buff_list"
+#define DONE_LIST_NAME "done_txn_buff_list"
 #define IRI_HEALTH_TRACK_PERIOD 1800  // Check every half hour in default
 
 /** @name Redis connection config */
@@ -88,9 +90,12 @@ typedef struct iota_config_s {
 
 /** struct type of accelerator cache */
 typedef struct ta_cache_s {
-  char* host;       /**< Binding address of redis server */
-  uint16_t port;    /**< Binding port of redis server */
-  bool cache_state; /**< Set it true to turn on cache server */
+  char* host;             /**< Binding address of redis server */
+  uint64_t timeout;       /**< Timeout for keys in redis */
+  char* buffer_list_name; /**< Name of the list to buffer transactions */
+  char* done_list_name;   /**< Name of the list to store successfully broadcast transactions from buffer */
+  uint16_t port;          /**< Binding port of redis server */
+  bool cache_state;       /**< Set it true to turn on cache server */
 } ta_cache_t;
 
 /** struct type of accelerator core */

--- a/accelerator/core/BUILD
+++ b/accelerator/core/BUILD
@@ -4,7 +4,6 @@ cc_library(
     hdrs = ["apis.h"],
     linkopts = [
         "-lpthread",
-        "-luuid",
     ],
     visibility = ["//visibility:public"],
     deps = [
@@ -35,6 +34,9 @@ cc_library(
     name = "core",
     srcs = ["core.c"],
     hdrs = ["core.h"],
+    linkopts = [
+        "-luuid",
+    ],
     visibility = ["//visibility:public"],
     deps = [
         "//accelerator:ta_config",

--- a/accelerator/core/apis.h
+++ b/accelerator/core/apis.h
@@ -15,11 +15,6 @@
 #include "mam/mam/mam_channel_t_set.h"
 #include "serializer/serializer.h"
 
-// TODO The temporary default timeout in cache server is 1 week. We should investigate the performance of redis to
-// design a better data structure and appropriate timeout period. And we should study the methodology to partially
-// release cached data.
-#define CACHE_FAILED_TXN_TIMEOUT (7 * 24 * 60 * 60)
-
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -54,7 +49,7 @@ int apis_logger_release();
  * @param tangle[in] iota configuration variables
  * @param cache[in] redis configuration variables
  * @param service[in] IRI connection configuration variables
- * @param[out] json_result Result containing tangle accelerator information in json format
+ * @param json_result[out] Result containing tangle accelerator information in json format
  *
  * @return
  * - SC_OK on success

--- a/accelerator/core/core.h
+++ b/accelerator/core/core.h
@@ -84,6 +84,7 @@ status_t ta_generate_address(const iota_config_t* const iconf, const iota_client
  * @param[in] info Tangle-accelerator configuration variables
  * @param[in] iconf IOTA API parameter configurations
  * @param[in] service IRI node end point service
+ * @param[in] cache redis configuration variables
  * @param[in] req Request containing address value, message, tag in
  *                ta_send_transfer_req_t
  * @param[out] res Result containing transaction hash in ta_send_transfer_res_t
@@ -93,8 +94,8 @@ status_t ta_generate_address(const iota_config_t* const iconf, const iota_client
  * - non-zero on error
  */
 status_t ta_send_transfer(const ta_config_t* const info, const iota_config_t* const iconf,
-                          const iota_client_service_t* const service, const ta_send_transfer_req_t* const req,
-                          ta_send_transfer_res_t* res);
+                          const iota_client_service_t* const service, const ta_cache_t* const cache,
+                          const ta_send_transfer_req_t* const req, ta_send_transfer_res_t* res);
 
 /**
  * @brief Send trytes to tangle.
@@ -253,6 +254,37 @@ status_t ta_get_iri_status(const iota_client_service_t* const service);
  * - non-zero on error
  */
 status_t ta_update_iri_conneciton(ta_config_t* const ta_conf, iota_client_service_t* const service);
+
+/**
+ * @brief Push failed transactions in raw trytes into transaction buffer
+ *
+ * Given raw trytes array would be pushed into buffer. An UUID will be returned for client to fetch the information of
+ * their request. The UUIDs are stored in a list, so once reaching the capacity of the buffer, buffered transactions can
+ * be popped from the buffer.
+ *
+ * @param cache[in] Redis configuration variables
+ * @param raw_txn_flex_trit_array[in] Raw transction trytes array in flex_trit_t type
+ * @param uuid[out] Returned UUID for fetching transaction status and information
+ *
+ * @return
+ * - SC_OK on success
+ * - non-zero on error
+ */
+status_t push_txn_to_buffer(const ta_cache_t* const cache, hash8019_array_p raw_txn_flex_trit_array, char* uuid);
+
+/**
+ * @brief Broadcast transactions in transaction buffer
+ *
+ * Failed transactions would be stored in transaciton buffer. Once tangle-accelerator retrieve the connetion with
+ * Tangle, then tangle-accelerator will start to broadcast these failed transaction trytes.
+ *
+ * @param core[in] Pointer to Tangle-accelerator core configuration structure
+ *
+ * @return
+ * - SC_OK on success
+ * - non-zero on error
+ */
+status_t broadcast_buffered_txn(const ta_core_t* const core);
 
 #ifdef __cplusplus
 }

--- a/accelerator/core/response/ta_send_transfer.c
+++ b/accelerator/core/response/ta_send_transfer.c
@@ -11,12 +11,13 @@
 ta_send_transfer_res_t* ta_send_transfer_res_new() {
   ta_send_transfer_res_t* res = (ta_send_transfer_res_t*)malloc(sizeof(ta_send_transfer_res_t));
   res->hash = NULL;
-  memset(res->uuid, 0, UUID_STR_LEN);
+  res->uuid = NULL;
   return res;
 }
 
 void ta_send_transfer_res_free(ta_send_transfer_res_t** res) {
   if ((*res)) {
+    free((*res)->uuid);
     hash243_queue_free(&(*res)->hash);
     free((*res));
     *res = NULL;

--- a/accelerator/core/response/ta_send_transfer.h
+++ b/accelerator/core/response/ta_send_transfer.h
@@ -30,9 +30,7 @@ typedef struct {
   /** Transaction address is a 243 long flex trits hash queue. */
   hash243_queue_t hash;
   transaction_array_t* txn_array;
-  // If the value of `CASS_UUID_STRING_LENGTH` changes, then we may need to modify array length of uuid_string as well,
-  // since UUID_STR_LEN is defined in `uuid/uuid.h`.
-  char uuid[UUID_STR_LEN];
+  char* uuid;
 #ifdef DB_ENABLE
   char uuid_string[DB_UUID_STRING_LENGTH];
 #endif

--- a/accelerator/core/serializer/serializer.c
+++ b/accelerator/core/serializer/serializer.c
@@ -822,7 +822,7 @@ status_t ta_send_transfer_res_serialize(ta_send_transfer_res_t* res, char** obj)
     goto done;
   }
 
-  if (res->uuid[0]) {
+  if (res->uuid) {
     cJSON_AddStringToObject(json_root, "uuid", res->uuid);
   } else {
     ret = iota_transaction_to_json_object(transaction_array_at(res->txn_array, 0), &json_root);

--- a/common/macros.h
+++ b/common/macros.h
@@ -29,10 +29,15 @@ typedef enum mam_protocol_e { MAM_V1 } mam_protocol_t;
 #define NUM_TRYTES_MAM_NTRU_PK_SIZE MAM_NTRU_PK_SIZE / 3
 #define NUM_TRYTES_MAM_PSK_KEY_SIZE MAM_PSK_KEY_SIZE / 3
 
-#define BUILD_BUG_ON_ZERO(e) ((int)(sizeof(struct { int:(-!!(e)); })))
+#define BUILD_BUG_ON_ZERO(e) ((int)(sizeof(struct { int : (-!!(e)); })))
 #define __same_type(a, b) __builtin_types_compatible_p(typeof(a), typeof(b))
 #define __must_be_array(a) BUILD_BUG_ON_ZERO(__same_type((a), &(a)[0]))
 #define ARRAY_SIZE(arr) (sizeof(arr) / sizeof((arr)[0]) + __must_be_array(arr))
+
+// TODO The temporary default timeout in cache server is 1 week. We should investigate the performance of redis to
+// design a better data structure and appropriate timeout period. And we should study the methodology to partially
+// release cached data.
+#define CACHE_FAILED_TXN_TIMEOUT (7 * 24 * 60 * 60)
 
 #ifdef __cplusplus
 }

--- a/tests/api/BUILD
+++ b/tests/api/BUILD
@@ -1,3 +1,13 @@
+cc_library(
+    name = "common",
+    srcs = ["common.c"],
+    hdrs = ["common.h"],
+    deps = [
+        "//accelerator:ta_config",
+        "//common",
+    ],
+)
+
 cc_test(
     name = "driver",
     srcs = [
@@ -7,6 +17,7 @@ cc_test(
         "//accelerator/core:apis",
         "//accelerator/core:proxy_apis",
         "//tests:test_define",
+        "//tests/api:common",
     ],
 )
 
@@ -20,5 +31,18 @@ cc_binary(
         "//accelerator/core:apis",
         "//accelerator/core:proxy_apis",
         "//tests:test_define",
+        "//tests/api:common",
+    ],
+)
+
+cc_test(
+    name = "driver_core",
+    srcs = [
+        "driver_core.c",
+    ],
+    deps = [
+        "//accelerator/core",
+        "//tests:test_define",
+        "//tests/api:common",
     ],
 )

--- a/tests/api/common.c
+++ b/tests/api/common.c
@@ -1,0 +1,81 @@
+#include "common.h"
+#include "accelerator/cli_info.h"
+#include "stdlib.h"
+
+static struct ta_cli_argument_s driver_cli_arguments_g[] = {
+    {"hash", required_argument, NULL, 'H', "testing transaction hashes"},
+    {"tag", required_argument, NULL, 'T', "testing transaction tag"},
+    {NULL, 0, NULL, 0, NULL}};
+
+struct option* driver_cli_build_options() {
+  int driver_cli_arg_size = sizeof(driver_cli_arguments_g) / sizeof(driver_cli_arguments_g[0]);
+  struct option* driver_long_options =
+      (struct option*)realloc(cli_build_options(), (cli_cmd_num + 2) * sizeof(struct option));
+  for (int i = 0; i < driver_cli_arg_size; i++) {
+    driver_long_options[(cli_cmd_num - 1) + i].name = driver_cli_arguments_g[i].name;
+    driver_long_options[(cli_cmd_num - 1) + i].has_arg = driver_cli_arguments_g[i].has_arg;
+    driver_long_options[(cli_cmd_num - 1) + i].flag = driver_cli_arguments_g[i].flag;
+    driver_long_options[(cli_cmd_num - 1) + i].val = driver_cli_arguments_g[i].val;
+  }
+
+  return driver_long_options;
+}
+
+status_t driver_core_cli_init(ta_core_t* const core, int argc, char** argv, driver_test_cases_t* test_cases) {
+  int key = 0;
+  status_t ret = SC_OK;
+  struct option* long_options = driver_cli_build_options();
+
+  while ((key = getopt_long(argc, argv, "hvH:T:", long_options, NULL)) != -1) {
+    switch (key) {
+      case 'h':
+        ta_usage();
+        exit(EXIT_SUCCESS);
+      case 'v':
+        printf("%s\n", TA_VERSION);
+        exit(EXIT_SUCCESS);
+      case 'H':
+        // Take the arguments as testing transaction hashes
+        for (int i = 0; i < TXN_HASH_NUM; i++) {
+          if (!test_cases->txn_hash[i]) {
+            test_cases->txn_hash[i] = optarg;
+          }
+        }
+        break;
+      case 'T':
+        // Take the arguments as testing transaction tag
+        test_cases->tag = optarg;
+        break;
+      default:
+        ret = cli_core_set(core, key, optarg);
+        break;
+    }
+    if (ret != SC_OK) {
+      break;
+    }
+  }
+
+  free(long_options);
+  return ret;
+}
+
+static double diff_time(struct timespec start, struct timespec end) {
+  struct timespec diff;
+  if (end.tv_nsec - start.tv_nsec < 0) {
+    diff.tv_sec = end.tv_sec - start.tv_sec - 1;
+    diff.tv_nsec = end.tv_nsec - start.tv_nsec + 1000000000;
+  } else {
+    diff.tv_sec = end.tv_sec - start.tv_sec;
+    diff.tv_nsec = end.tv_nsec - start.tv_nsec;
+  }
+  return (diff.tv_sec + diff.tv_nsec / 1000000000.0);
+}
+
+void test_time_end(struct timespec* start, struct timespec* end, double* sum) {
+  clock_gettime(CLOCK_REALTIME, end);
+  double difference = diff_time(*start, *end);
+#if defined(ENABLE_STAT)
+  printf("%lf\n", difference);
+#endif
+  *sum += difference;
+}

--- a/tests/api/common.h
+++ b/tests/api/common.h
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2020 BiiLabs Co., Ltd. and Contributors
+ * All Rights Reserved.
+ * This is free software; you can redistribute it and/or modify it under the
+ * terms of the MIT license. A copy of the license can be found in the file
+ * "LICENSE" at the root of this distribution.
+ */
+
+#include <stdio.h>
+#include <time.h>
+#include "accelerator/config.h"
+#include "common/ta_errors.h"
+
+#define TXN_HASH_NUM 2
+
+typedef struct driver_test_cases_s {
+  char* txn_hash[TXN_HASH_NUM];
+  char* tag;
+} driver_test_cases_t;
+
+/**
+ * Set option list for `get_long()`
+ *
+ * @return
+ * - pointer of a `struct option` array on success
+ * - NULL on error
+ */
+struct option* driver_cli_build_options();
+
+/**
+ * Initializes configurations with default values for driver tests
+ *
+ * @param core[in] Pointer to Tangle-accelerator core configuration structure
+ * @param argc[in] Pointer to Tangle-accelerator core configuration structure
+ * @param argv[in] Pointer to Tangle-accelerator core configuration structure
+ * @param test_cases[in] Pointer to Tangle-accelerator core configuration structure
+ *
+ * @return
+ * - SC_OK on success
+ * - non-zero on error
+ */
+status_t driver_core_cli_init(ta_core_t* const core, int argc, char** argv, driver_test_cases_t* test_cases);
+
+/**
+ * Start testing clock
+ *
+ * @param start[out] `struct timespec` object for recording starting time.
+ *
+ */
+static inline void test_time_start(struct timespec* start) { clock_gettime(CLOCK_REALTIME, start); }
+
+/**
+ * Initializes configurations with default values
+ *
+ * @param start[in] `struct timespec` object for recording starting time.
+ * @param end[out] `struct timespec` object for recording ending time.
+ * @param start[out] The total elapsing time.
+ *
+ */
+void test_time_end(struct timespec* start, struct timespec* end, double* sum);

--- a/tests/api/driver.c
+++ b/tests/api/driver.c
@@ -9,20 +9,12 @@
 #include <time.h>
 #include "accelerator/core/apis.h"
 #include "accelerator/core/proxy_apis.h"
+#include "common.h"
 #include "tests/test_define.h"
 
+static driver_test_cases_t test_case;
 static ta_core_t ta_core;
 struct timespec start_time, end_time;
-
-char* test_txn_hash[2] = {NULL, NULL};
-int test_txn_hash_size = sizeof(test_txn_hash) / sizeof(char*);
-char* test_tag = NULL;
-static struct ta_cli_argument_s driver_cli_arguments_g[] = {
-    {"hash", required_argument, NULL, 's', "testing transaction hashes"},
-    {"tag", required_argument, NULL, 'g', "testing transaction tag"},
-    {NULL, 0, NULL, 0, NULL}};
-
-ta_send_mam_res_t* res;
 
 static struct proxy_apis_s {
   const char* name;
@@ -58,29 +50,6 @@ static struct identity_s {
   int8_t status;
 } identities[TEST_COUNT];
 #endif
-
-double diff_time(struct timespec start, struct timespec end) {
-  struct timespec diff;
-  if (end.tv_nsec - start.tv_nsec < 0) {
-    diff.tv_sec = end.tv_sec - start.tv_sec - 1;
-    diff.tv_nsec = end.tv_nsec - start.tv_nsec + 1000000000;
-  } else {
-    diff.tv_sec = end.tv_sec - start.tv_sec;
-    diff.tv_nsec = end.tv_nsec - start.tv_nsec;
-  }
-  return (diff.tv_sec + diff.tv_nsec / 1000000000.0);
-}
-
-void test_time_start(struct timespec* start) { clock_gettime(CLOCK_REALTIME, start); }
-
-void test_time_end(struct timespec* start, struct timespec* end, double* sum) {
-  clock_gettime(CLOCK_REALTIME, end);
-  double difference = diff_time(*start, *end);
-#if defined(ENABLE_STAT)
-  printf("%lf\n", difference);
-#endif
-  *sum += difference;
-}
 
 void test_generate_address(void) {
   char* json_result;
@@ -178,7 +147,7 @@ void test_find_transaction_objects(void) {
   const char* pre_json = "{\"hashes\":[\"%s\",\"%s\"]}";
   int json_len = (NUM_TRYTES_HASH + 1) * 2 + strlen(pre_json) + 1;
   char* json = (char*)malloc(sizeof(char) * json_len);
-  snprintf(json, json_len, pre_json, test_txn_hash[0], test_txn_hash[1]);
+  snprintf(json, json_len, pre_json, test_case.txn_hash[0], test_case.txn_hash[1]);
   char* json_result;
   double sum = 0;
 
@@ -199,7 +168,7 @@ void test_find_transactions_by_tag(void) {
   for (size_t count = 0; count < TEST_COUNT; count++) {
     test_time_start(&start_time);
 
-    TEST_ASSERT_EQUAL_INT32(SC_OK, api_find_transactions_by_tag(&ta_core.iota_service, test_tag, &json_result));
+    TEST_ASSERT_EQUAL_INT32(SC_OK, api_find_transactions_by_tag(&ta_core.iota_service, test_case.tag, &json_result));
     test_time_end(&start_time, &end_time, &sum);
     free(json_result);
   }
@@ -257,56 +226,12 @@ void test_find_transactions_obj_by_tag(void) {
   for (size_t count = 0; count < TEST_COUNT; count++) {
     test_time_start(&start_time);
 
-    TEST_ASSERT_EQUAL_INT32(SC_OK, api_find_transactions_obj_by_tag(&ta_core.iota_service, test_tag, &json_result));
+    TEST_ASSERT_EQUAL_INT32(SC_OK,
+                            api_find_transactions_obj_by_tag(&ta_core.iota_service, test_case.tag, &json_result));
     test_time_end(&start_time, &end_time, &sum);
     free(json_result);
   }
   printf("Average time of find_tx_obj_by_tag: %lf\n", sum / TEST_COUNT);
-}
-
-void test_send_mam_message(void) {
-  double sum = 0;
-  const char* json =
-      "{\"seed\":\"" TRYTES_81_1
-      "\",\"channel_ord\":" STR(TEST_CHANNEL_ORD) ",\"message\":\"" TEST_PAYLOAD "\",\"ch_mss_depth\":" STR(
-          TEST_CH_DEPTH) ",\"ep_mss_depth\":" STR(TEST_EP_DEPTH) ",\"ntru_pk\":\"" TEST_NTRU_PK
-                                                                 "\",\"psk\":\"" TRYTES_81_2 "\"}";
-  char* json_result = NULL;
-  res = send_mam_res_new();
-  status_t ret = SC_OK;
-  bool result = false;
-
-  for (size_t count = 0; count < TEST_COUNT; count++) {
-    test_time_start(&start_time);
-    ret = api_send_mam_message(&ta_core.ta_conf, &ta_core.iota_conf, &ta_core.iota_service, json, &json_result);
-    if (ret == SC_OK || ret == SC_MAM_ALL_MSS_KEYS_USED) {
-      result = true;
-    }
-    TEST_ASSERT_TRUE(result);
-
-    send_mam_res_deserialize(json_result, res);
-
-    test_time_end(&start_time, &end_time, &sum);
-    free(json_result);
-    json_result = NULL;
-  }
-  free(json_result);
-  printf("Average time of send_mam_message: %lf\n", sum / TEST_COUNT);
-}
-
-void test_receive_mam_message(void) {
-  char* json_result;
-  double sum = 0;
-
-  for (size_t count = 0; count < TEST_COUNT; count++) {
-    test_time_start(&start_time);
-
-    TEST_ASSERT_EQUAL_INT32(
-        SC_OK, api_recv_mam_message(&ta_core.iota_conf, &ta_core.iota_service, (char*)res->chid, &json_result));
-    test_time_end(&start_time, &end_time, &sum);
-    free(json_result);
-  }
-  printf("Average time of receive_mam_message: %lf\n", sum / TEST_COUNT);
 }
 
 void test_get_iri_status() {
@@ -338,63 +263,6 @@ void test_proxy_apis() {
     printf("Average time of %s: %lf\n", proxy_apis_g[i].name, sum / TEST_COUNT);
   }
 }
-static inline struct option* driver_cli_build_options() {
-  int driver_cli_arg_size = sizeof(driver_cli_arguments_g) / sizeof(driver_cli_arguments_g[0]);
-  struct option* driver_long_options =
-      (struct option*)realloc(cli_build_options(), (cli_cmd_num + 2) * sizeof(struct option));
-  for (int i = 0; i < driver_cli_arg_size; i++) {
-    driver_long_options[(cli_cmd_num - 1) + i].name = driver_cli_arguments_g[i].name;
-    driver_long_options[(cli_cmd_num - 1) + i].has_arg = driver_cli_arguments_g[i].has_arg;
-    driver_long_options[(cli_cmd_num - 1) + i].flag = driver_cli_arguments_g[i].flag;
-    driver_long_options[(cli_cmd_num - 1) + i].val = driver_cli_arguments_g[i].val;
-  }
-
-  return driver_long_options;
-};
-status_t driver_core_cli_init(ta_core_t* const core, int argc, char** argv) {
-  int key = 0;
-  status_t ret = SC_OK;
-  struct option* long_options = driver_cli_build_options();
-
-  while ((key = getopt_long(argc, argv, "hvs:g:", long_options, NULL)) != -1) {
-    switch (key) {
-      case 'h':
-        ta_usage();
-        exit(EXIT_SUCCESS);
-      case 'v':
-        printf("%s\n", TA_VERSION);
-        exit(EXIT_SUCCESS);
-      case QUIET:
-        // Turn on quiet mode
-        quiet_mode = true;
-
-        // Enable backend_redis logger
-        br_logger_init();
-        break;
-      case 's':
-        // Take the arguments as testing transaction hashes
-        for (int i = 0; i < test_txn_hash_size; i++) {
-          if (!test_txn_hash[i]) {
-            test_txn_hash[i] = optarg;
-          }
-        }
-        break;
-      case 'g':
-        // Take the arguments as testing transaction tag
-        test_tag = optarg;
-        break;
-      default:
-        ret = cli_core_set(core, key, optarg);
-        break;
-    }
-    if (ret != SC_OK) {
-      break;
-    }
-  }
-
-  free(long_options);
-  return ret;
-}
 
 int main(int argc, char* argv[]) {
   UNITY_BEGIN();
@@ -409,11 +277,10 @@ int main(int argc, char* argv[]) {
   timer_logger_init();
 
   ta_core_default_init(&ta_core);
-  driver_core_cli_init(&ta_core, argc, argv);
+  driver_core_cli_init(&ta_core, argc, argv, &test_case);
   ta_core_set(&ta_core);
 
   printf("Total samples for each API test: %d\n", TEST_COUNT);
-
   RUN_TEST(test_generate_address);
   RUN_TEST(test_get_tips_pair);
   RUN_TEST(test_get_tips);

--- a/tests/api/driver_core.c
+++ b/tests/api/driver_core.c
@@ -1,0 +1,126 @@
+/*
+ * Copyright (C) 2020 BiiLabs Co., Ltd. and Contributors
+ * All Rights Reserved.
+ * This is free software; you can redistribute it and/or modify it under the
+ * terms of the MIT license. A copy of the license can be found in the file
+ * "LICENSE" at the root of this distribution.
+ */
+
+#include "accelerator/core/core.h"
+#include "common.h"
+#include "tests/test_define.h"
+
+static ta_core_t ta_core;
+
+status_t prepare_transfer(const iota_config_t* const iconf, const iota_client_service_t* const service,
+                          ta_send_transfer_req_t* req, hash8019_array_p raw_txn_array) {
+  status_t ret = SC_OK;
+  bundle_transactions_t* out_bundle = NULL;
+  bundle_transactions_new(&out_bundle);
+  transfer_array_t* transfers = transfer_array_new();
+  if (transfers == NULL) {
+    ret = SC_CCLIENT_OOM;
+    printf("%s\n", "SC_CCLIENT_OOM");
+    goto done;
+  }
+
+  tryte_t msg_tryte[NUM_TRYTES_SERIALIZED_TRANSACTION];
+  flex_trits_to_trytes(msg_tryte, req->msg_len / 3, req->message, req->msg_len, req->msg_len);
+
+  transfer_t transfer = {.value = 0, .timestamp = current_timestamp_ms(), .msg_len = req->msg_len / 3};
+
+  if (transfer_message_set_trytes(&transfer, msg_tryte, transfer.msg_len) != RC_OK) {
+    ret = SC_CCLIENT_OOM;
+    printf("%s\n", "SC_CCLIENT_OOM");
+    goto done;
+  }
+  memcpy(transfer.address, hash243_queue_peek(req->address), FLEX_TRIT_SIZE_243);
+  memcpy(transfer.tag, hash81_queue_peek(req->tag), FLEX_TRIT_SIZE_81);
+  transfer_array_add(transfers, &transfer);
+
+  // TODO we may need args `remainder_address`, `inputs`, `timestampe` in the
+  // future and declare `security` field in `iota_config_t`
+  flex_trit_t seed[NUM_FLEX_TRITS_ADDRESS];
+  flex_trits_from_trytes(seed, NUM_TRITS_HASH, (tryte_t const*)iconf->seed, NUM_TRYTES_HASH, NUM_TRYTES_HASH);
+  if (iota_client_prepare_transfers(service, seed, 2, transfers, NULL, NULL, false, current_timestamp_ms(),
+                                    out_bundle) != RC_OK) {
+    ret = SC_CCLIENT_FAILED_RESPONSE;
+    printf("%s\n", "SC_CCLIENT_FAILED_RESPONSE");
+    goto done;
+  }
+
+  iota_transaction_t* txn = NULL;
+  BUNDLE_FOREACH(out_bundle, txn) {
+    flex_trit_t* serialized_txn = transaction_serialize(txn);
+    if (serialized_txn == NULL) {
+      ret = SC_CCLIENT_FAILED_RESPONSE;
+      printf("%s\n", "SC_CCLIENT_FAILED_RESPONSE");
+      goto done;
+    }
+    hash_array_push(raw_txn_array, serialized_txn);
+    free(serialized_txn);
+  }
+
+done:
+  bundle_transactions_free(&out_bundle);
+  transfer_message_free(&transfer);
+  transfer_array_free(transfers);
+  return ret;
+}
+
+void test_broadcast_buffered_txn(void) {
+  // Generate transaction trytes, and don't send them
+  const char* json =
+      "{\"value\":100"
+      ",\"tag\":\"" TEST_TAG
+      "\","
+      "\"address\":\"" TRYTES_81_1
+      "\","
+      "\"message\":\"" TEST_TRANSFER_MESSAGE "\"}";
+
+  char uuid[UUID_STR_LEN];
+  int list_len = -1;
+  ta_send_transfer_req_t* req = ta_send_transfer_req_new();
+  hash8019_array_p raw_txn_array = hash8019_array_new();
+
+  TEST_ASSERT_EQUAL_INT32(SC_OK, cache_list_size(ta_core.cache.buffer_list_name, &list_len));
+  const int init_list_len = list_len;
+
+  TEST_ASSERT_EQUAL_INT32(SC_OK, ta_send_transfer_req_deserialize(json, req));
+  TEST_ASSERT_EQUAL_INT32(SC_OK, prepare_transfer(&ta_core.iota_conf, &ta_core.iota_service, req, raw_txn_array));
+
+  // Push transaction trytes to redis server
+  TEST_ASSERT_EQUAL_INT32(SC_OK, push_txn_to_buffer(&ta_core.cache, raw_txn_array, uuid));
+
+  TEST_ASSERT_EQUAL_INT32(SC_OK, cache_list_size(ta_core.cache.buffer_list_name, &list_len));
+  TEST_ASSERT_EQUAL_INT32(init_list_len + 1, list_len);
+
+  // Take action to broadcast transctions in buffer
+  TEST_ASSERT_EQUAL_INT32(SC_OK, broadcast_buffered_txn(&ta_core));
+
+  // The length of the buffer list should be zero, since all the transaction objects have been popped out.
+  TEST_ASSERT_EQUAL_INT32(SC_OK, cache_list_size(ta_core.cache.buffer_list_name, &list_len));
+  TEST_ASSERT_EQUAL_INT32(init_list_len, list_len);
+
+  ta_send_transfer_req_free(&req);
+  hash_array_free(raw_txn_array);
+}
+
+int main(int argc, char* argv[]) {
+  // Initialize logger
+  if (ta_logger_init() != SC_OK) {
+    return EXIT_FAILURE;
+  }
+  cc_logger_init();
+  pow_logger_init();
+  timer_logger_init();
+
+  ta_core_default_init(&ta_core);
+  driver_core_cli_init(&ta_core, argc, argv, NULL);
+  ta_core_set(&ta_core);
+
+  UNITY_BEGIN();
+  RUN_TEST(test_broadcast_buffered_txn);
+  ta_core_destroy(&ta_core);
+  return UNITY_END();
+}

--- a/tests/api/mam_test.c
+++ b/tests/api/mam_test.c
@@ -23,29 +23,6 @@ ta_send_mam_res_t* res;
 #define TEST_COUNT 1
 #endif
 
-double diff_time(struct timespec start, struct timespec end) {
-  struct timespec diff;
-  if (end.tv_nsec - start.tv_nsec < 0) {
-    diff.tv_sec = end.tv_sec - start.tv_sec - 1;
-    diff.tv_nsec = end.tv_nsec - start.tv_nsec + 1000000000;
-  } else {
-    diff.tv_sec = end.tv_sec - start.tv_sec;
-    diff.tv_nsec = end.tv_nsec - start.tv_nsec;
-  }
-  return (diff.tv_sec + diff.tv_nsec / 1000000000.0);
-}
-
-void test_time_start(struct timespec* start) { clock_gettime(CLOCK_REALTIME, start); }
-
-void test_time_end(struct timespec* start, struct timespec* end, double* sum) {
-  clock_gettime(CLOCK_REALTIME, end);
-  double difference = diff_time(*start, *end);
-#if defined(ENABLE_STAT)
-  printf("%lf\n", difference);
-#endif
-  *sum += difference;
-}
-
 void test_receive_mam_message(void) {
   const char* json =
       "{\"data_id\":{\"chid\":\"SYZJOQCGWGOTGGZUCZYQGHWWHQVIVBHJFHNXYXZQSGJXIHL9KMXNOBULIPTPGMBJSMFNBSAGCVVZ9MDMX\"},"

--- a/utils/cache/backend_redis.c
+++ b/utils/cache/backend_redis.c
@@ -41,7 +41,7 @@ int br_logger_release() {
 static status_t redis_del(redisContext* c, const char* const key) {
   status_t ret = SC_OK;
   if (key == NULL) {
-    ta_log_error("%s\n", "SC_CACHE_NULL");
+    ta_log_error("%s\n", ta_error_to_string(SC_CACHE_NULL));
     return SC_CACHE_NULL;
   }
 
@@ -58,7 +58,7 @@ static status_t redis_del(redisContext* c, const char* const key) {
 static status_t redis_get(redisContext* c, const char* const key, char* res) {
   status_t ret = SC_OK;
   if (key == NULL) {
-    ta_log_error("%s\n", "SC_CACHE_NULL");
+    ta_log_error("%s\n", ta_error_to_string(SC_CACHE_NULL));
     return SC_CACHE_NULL;
   }
 
@@ -68,7 +68,7 @@ static status_t redis_get(redisContext* c, const char* const key, char* res) {
     res[reply->len] = 0;
   } else {
     ret = SC_CACHE_FAILED_RESPONSE;
-    ta_log_error("%s\n", "SC_CACHE_FAILED_RESPONSE");
+    ta_log_error("%s\n", ta_error_to_string(ret));
   }
 
   freeReplyObject(reply);
@@ -79,7 +79,7 @@ static status_t redis_set(redisContext* c, const char* const key, const int key_
                           const int value_size, const int timeout) {
   status_t ret = SC_OK;
   if (c == NULL || key == NULL || value == NULL) {
-    ta_log_error("%s\n", "SC_CACHE_NULL");
+    ta_log_error("%s\n", ta_error_to_string(SC_CACHE_NULL));
     return SC_CACHE_NULL;
   }
 
@@ -91,8 +91,7 @@ static status_t redis_set(redisContext* c, const char* const key, const int key_
   }
 
   if (reply->type != REDIS_REPLY_STATUS) {
-    ret = SC_CACHE_FAILED_RESPONSE;
-    ta_log_error("%s\n", "SC_CACHE_FAILED_RESPONSE");
+    ta_log_error("%s\n", ta_error_to_string(ret));
   }
 
   freeReplyObject(reply);
@@ -103,7 +102,7 @@ static status_t redis_list_push(redisContext* c, const char* const key, const in
                                 const int value_size, const int timeout) {
   status_t ret = SC_OK;
   if (c == NULL || key == NULL || value == NULL) {
-    ta_log_error("%s\n", "SC_CACHE_NULL");
+    ta_log_error("%s\n", ta_error_to_string(SC_CACHE_NULL));
     return SC_CACHE_NULL;
   }
 
@@ -111,7 +110,7 @@ static status_t redis_list_push(redisContext* c, const char* const key, const in
   reply = redisCommand(c, "LPUSH %b %b", key, key_size, value, value_size);
   if (reply->type == REDIS_REPLY_ERROR) {
     ret = SC_CACHE_FAILED_RESPONSE;
-    ta_log_error("%s\n", "SC_CACHE_FAILED_RESPONSE");
+    ta_log_error("%s\n", ta_error_to_string(ret));
   }
 
   freeReplyObject(reply);
@@ -121,7 +120,7 @@ static status_t redis_list_push(redisContext* c, const char* const key, const in
 static status_t redis_list_at(redisContext* c, const char* const key, const int index, const int res_len, char* res) {
   status_t ret = SC_OK;
   if (key == NULL) {
-    ta_log_error("%s\n", "SC_CACHE_NULL");
+    ta_log_error("%s\n", ta_error_to_string(SC_CACHE_NULL));
     return SC_CACHE_NULL;
   }
 
@@ -131,7 +130,27 @@ static status_t redis_list_at(redisContext* c, const char* const key, const int 
     res[reply->len] = 0;
   } else {
     ret = SC_CACHE_FAILED_RESPONSE;
-    ta_log_error("%s\n", "SC_CACHE_FAILED_RESPONSE");
+    ta_log_error("%s\n", ta_error_to_string(ret));
+  }
+
+  freeReplyObject(reply);
+  return ret;
+}
+
+static status_t redis_list_peek(redisContext* c, const char* const key, const int res_len, char* res) {
+  status_t ret = SC_OK;
+  if (key == NULL) {
+    ta_log_error("%s\n", ta_error_to_string(SC_CACHE_NULL));
+    return SC_CACHE_NULL;
+  }
+
+  redisReply* reply = redisCommand(c, "LINDEX %s %d", key, 0);
+  if (reply->type == REDIS_REPLY_STRING && reply->len <= res_len) {
+    strncpy(res, reply->str, reply->len);
+    res[reply->len] = 0;
+  } else {
+    ret = SC_CACHE_FAILED_RESPONSE;
+    ta_log_error("%s\n", ta_error_to_string(ret));
   }
 
   freeReplyObject(reply);
@@ -141,7 +160,7 @@ static status_t redis_list_at(redisContext* c, const char* const key, const int 
 static status_t redis_list_size(redisContext* c, const char* const key, int* len) {
   status_t ret = SC_OK;
   if (key == NULL) {
-    ta_log_error("%s\n", "SC_CACHE_NULL");
+    ta_log_error("%s\n", ta_error_to_string(SC_CACHE_NULL));
     return SC_CACHE_NULL;
   }
 
@@ -150,7 +169,7 @@ static status_t redis_list_size(redisContext* c, const char* const key, int* len
     *len = reply->integer;
   } else {
     ret = SC_CACHE_FAILED_RESPONSE;
-    ta_log_error("%s\n", "SC_CACHE_FAILED_RESPONSE");
+    ta_log_error("%s\n", ta_error_to_string(ret));
   }
 
   freeReplyObject(reply);
@@ -160,7 +179,7 @@ static status_t redis_list_size(redisContext* c, const char* const key, int* len
 static status_t redis_list_pop(redisContext* c, const char* const key, char* res) {
   status_t ret = SC_OK;
   if (key == NULL) {
-    ta_log_error("%s\n", "SC_CACHE_NULL");
+    ta_log_error("%s\n", ta_error_to_string(SC_CACHE_NULL));
     return SC_CACHE_NULL;
   }
 
@@ -170,7 +189,7 @@ static status_t redis_list_pop(redisContext* c, const char* const key, char* res
     res[reply->len] = 0;
   } else {
     ret = SC_CACHE_FAILED_RESPONSE;
-    ta_log_error("%s\n", "SC_CACHE_FAILED_RESPONSE");
+    ta_log_error("%s\n", ta_error_to_string(ret));
   }
 
   freeReplyObject(reply);
@@ -246,6 +265,14 @@ status_t cache_list_at(const char* const key, const int index, const int res_len
     return SC_CACHE_OFF;
   }
   return redis_list_at(CONN(cache)->rc, key, index, res_len, res);
+}
+
+status_t cache_list_peek(const char* const key, const int res_len, char* res) {
+  if (!cache_state) {
+    ta_log_info("%s\n", "SC_CACHE_OFF");
+    return SC_CACHE_OFF;
+  }
+  return redis_list_peek(CONN(cache)->rc, key, res_len, res);
 }
 
 status_t cache_list_size(const char* const key, int* len) {

--- a/utils/cache/cache.h
+++ b/utils/cache/cache.h
@@ -136,6 +136,19 @@ status_t cache_list_push(const char* const key, const int key_size, const void* 
 status_t cache_list_at(const char* const key, const int index, const int res_len, char* res);
 
 /**
+ * Get the top element of a list from in-memory cache
+ *
+ * @param[in] key Key string to search
+ * @param[in] res_len Expected length of the respose
+ * @param[out] res The element with assigning index
+ *
+ * @return
+ * - SC_OK on success
+ * - non-zero on error
+ */
+status_t cache_list_peek(const char* const key, const int res_len, char* res);
+
+/**
  * Fetch the length of the list in in-memory cache
  *
  * @param[in] key Key string to store


### PR DESCRIPTION
Once a transction request is failed, since the connection of IRI
or the problems on Tangle, then tangle-accelerator would push
transction object to buffer. We used redis as buffer DB.
Each failed request would have a corresponding UUID. Client can
use this UUID to view the current status of the failed request.

Run function `broadcast_buffered_txn()` in thread `health_track()`
in `main.c` which would broadcast buffered transactions to Tangle.

CI would needs corresponding modifications.