### PR TITLE
test(driver): Remove redundant random seed generation

### DIFF
--- a/tests/api/driver.c
+++ b/tests/api/driver.c
@@ -396,8 +396,6 @@ status_t driver_core_cli_init(ta_core_t* const core, int argc, char** argv) {
 }
 
 int main(int argc, char* argv[]) {
-  srand(time(NULL));
-
   UNITY_BEGIN();
 
   // Initialize logger


### PR DESCRIPTION
We have removed using random trytes to send transfer, so the
random number generation is not necessary here.