### PR TITLE
feat(MQTT): Add missing routes

### DIFF
--- a/accelerator/cli_info.h
+++ b/accelerator/cli_info.h
@@ -10,6 +10,7 @@
 #define ACCELERATOR_CLI_INFO_H_
 
 #include <stdio.h>
+#include "common/macros.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -88,7 +89,7 @@ static struct ta_cli_argument_s {
     {"quiet", no_argument, NULL, QUIET, "Disable logger"},
     {NULL, 0, NULL, 0, NULL}};
 
-static const int cli_cmd_num = sizeof(ta_cli_arguments_g) / sizeof(struct ta_cli_argument_s);
+static const int cli_cmd_num = ARRAY_SIZE(ta_cli_arguments_g);
 
 static inline void ta_usage() {
   printf("tangle-accelerator usage:\n");

--- a/accelerator/core/serializer/serializer.h
+++ b/accelerator/core/serializer/serializer.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2019 BiiLabs Co., Ltd. and Contributors
+ * Copyright (C) 2018-2020 BiiLabs Co., Ltd. and Contributors
  * All Rights Reserved.
  * This is free software; you can redistribute it and/or modify it under the
  * terms of the MIT license. A copy of the license can be found in the file

--- a/accelerator/core/serializer/serializer.h
+++ b/accelerator/core/serializer/serializer.h
@@ -283,7 +283,7 @@ status_t send_mam_res_serialize(const ta_send_mam_res_t* const res, char** obj);
 
 #ifdef MQTT_ENABLE
 /**
- * @brief Deserialze device ID from MQTT JSON request.
+ * @brief Deserialize device ID from MQTT JSON request.
  *
  * @param[in] obj Input request in JSON with device ID
  * @param[out] device_id Device ID in string

--- a/common/macros.h
+++ b/common/macros.h
@@ -27,6 +27,11 @@ extern "C" {
 #define NUM_TRYTES_MAM_NTRU_PK_SIZE MAM_NTRU_PK_SIZE / 3
 #define NUM_TRYTES_MAM_PSK_KEY_SIZE MAM_PSK_KEY_SIZE / 3
 
+#define BUILD_BUG_ON_ZERO(e) ((int)(sizeof(struct { int:(-!!(e)); })))
+#define __same_type(a, b) __builtin_types_compatible_p(typeof(a), typeof(b))
+#define __must_be_array(a) BUILD_BUG_ON_ZERO(__same_type((a), &(a)[0]))
+#define ARRAY_SIZE(arr) (sizeof(arr) / sizeof((arr)[0]) + __must_be_array(arr))
+
 #ifdef __cplusplus
 }
 #endif

--- a/common/ta_errors.c
+++ b/common/ta_errors.c
@@ -120,6 +120,8 @@ const char* ta_error_to_string(status_t err) {
       return "Error setting topic in MQTT\n";
     case SC_MQTT_OPT_SET:
       return "Error setting options of mosquitto object\n";
+    case SC_MQTT_INVALID_TAG:
+      return "Received invalid tag length in MQTT\n";
     case SC_CLIENT_CONNECT:
       return "Error in connecting to broker\n";
     case SC_STORAGE_OOM:

--- a/common/ta_errors.h
+++ b/common/ta_errors.h
@@ -202,6 +202,8 @@ typedef enum {
   /**< Error in setting options of `struct mosquitto` object */
   SC_CLIENT_CONNECT = 0x07 | SC_MODULE_MQTT | SC_SEVERITY_MAJOR,
   /**< Error in connecting to broker */
+  SC_MQTT_INVALID_TAG = 0x08 | SC_MODULE_MQTT | SC_SEVERITY_MAJOR,
+  /**< Received invalid tag length in MQTT */
 
   // STORAGE module
   SC_STORAGE_OOM = 0x01 | SC_MODULE_STORAGE | SC_SEVERITY_FATAL,

--- a/connectivity/common.c
+++ b/connectivity/common.c
@@ -63,6 +63,7 @@ status_t set_response_content(status_t ret, char **json_result) {
       break;
     case SC_CCLIENT_JSON_KEY:
     case SC_MAM_NO_PAYLOAD:
+    case SC_HTTP_URL_NOT_MATCH:
       http_ret = SC_HTTP_BAD_REQUEST;
       ta_log_error("%s\n", "SC_HTTP_BAD_REQUEST");
       *json_result = strdup(STR_HTTP_BAD_REQUEST);

--- a/connectivity/mqtt/BUILD
+++ b/connectivity/mqtt/BUILD
@@ -12,6 +12,7 @@ cc_library(
     deps = [
         ":mqtt_common",
         "//accelerator/core:apis",
+        "//common",
         "//common:ta_errors",
         "//connectivity:common",
         "@entangled//common/model:transaction",

--- a/connectivity/mqtt/duplex_callback.c
+++ b/connectivity/mqtt/duplex_callback.c
@@ -65,6 +65,8 @@ static status_t mqtt_request_handler(mosq_config_t *cfg, char *subscribe_topic, 
     ret = api_get_tips(&ta_core.iota_service, &json_result);
   else if (api_path_matcher(api_sub_topic, "/tips/pair") == SC_OK)
     ret = api_get_tips_pair(&ta_core.iota_conf, &ta_core.iota_service, &json_result);
+  else if (api_path_matcher(api_sub_topic, "/tryte") == SC_OK)
+    ret = api_send_trytes(&ta_core.iota_conf, &ta_core.iota_service, req, &json_result);
   else {
     cJSON *json_obj = cJSON_CreateObject();
     cJSON_AddStringToObject(json_obj, "message", api_sub_topic);

--- a/connectivity/mqtt/duplex_callback.c
+++ b/connectivity/mqtt/duplex_callback.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 BiiLabs Co., Ltd. and Contributors
+ * Copyright (C) 2019-2020 BiiLabs Co., Ltd. and Contributors
  * All Rights Reserved.
  * This is free software; you can redistribute it and/or modify it under the
  * terms of the MIT license. A copy of the license can be found in the file
@@ -28,6 +28,23 @@ int mqtt_callback_logger_release() {
   return 0;
 }
 
+status_t check_valid_tag(char *tag) {
+  size_t len = strnlen(tag, NUM_TRYTES_TAG + 1);
+  if (len < 1 || len > NUM_TRYTES_TAG) {
+    ta_log_error("%s", ta_error_to_string(SC_MQTT_INVALID_TAG));
+    return SC_MQTT_INVALID_TAG;
+  }
+
+  for (size_t i = 0; i < len; ++i) {
+    if ((tag[i] > 'Z' || tag[i] < 'A') && tag[i] != '9') {
+      ta_log_error("%s", ta_error_to_string(SC_MQTT_INVALID_TAG));
+      return SC_MQTT_INVALID_TAG;
+    }
+  }
+
+  return SC_OK;
+}
+
 static status_t mqtt_request_handler(mosq_config_t *cfg, char *subscribe_topic, char *req) {
   if (cfg == NULL || subscribe_topic == NULL || req == NULL) {
     return SC_MQTT_NULL;
@@ -50,23 +67,33 @@ static status_t mqtt_request_handler(mosq_config_t *cfg, char *subscribe_topic, 
   else if (api_path_matcher(api_sub_topic, "/tag/hashes") == SC_OK) {
     char tag[NUM_TRYTES_TAG + 1] = {0};
     mqtt_tag_req_deserialize(req, tag);
-    ret = api_find_transactions_by_tag(&ta_core.iota_service, tag, &json_result);
+    if (check_valid_tag(tag) == SC_OK) {
+      ret = api_find_transactions_by_tag(&ta_core.iota_service, tag, &json_result);
+    } else {
+      ret = SC_HTTP_URL_NOT_MATCH;
+    }
   } else if (api_path_matcher(api_sub_topic, "/tag/object") == SC_OK) {
     char tag[NUM_TRYTES_TAG + 1] = {0};
     mqtt_tag_req_deserialize(req, tag);
-    ret = api_find_transactions_obj_by_tag(&ta_core.iota_service, tag, &json_result);
-  } else if (api_path_matcher(api_sub_topic, "/transaction/object") == SC_OK) {
+    if (check_valid_tag(tag) == SC_OK) {
+      ret = api_find_transactions_obj_by_tag(&ta_core.iota_service, tag, &json_result);
+    } else {
+      ret = SC_HTTP_URL_NOT_MATCH;
+    }
+  } else if (api_path_matcher(api_sub_topic, "/transaction") == SC_OK) {
     char hash[NUM_TRYTES_HASH + 1];
     mqtt_transaction_hash_req_deserialize(req, hash);
     ret = api_find_transaction_object_single(&ta_core.iota_service, hash, &json_result);
-  } else if (api_path_matcher(api_sub_topic, "/transaction/send") == SC_OK)
+  } else if (api_path_matcher(api_sub_topic, "/transaction/object") == SC_OK) {
+    ret = api_find_transaction_objects(&ta_core.iota_service, req, &json_result);
+  } else if (api_path_matcher(api_sub_topic, "/transaction/send") == SC_OK) {
     ret = api_send_transfer(&ta_core, req, &json_result);
-  else if (api_path_matcher(api_sub_topic, "/tips/all") == SC_OK)
+  } else if (api_path_matcher(api_sub_topic, "/tips/all") == SC_OK)
     ret = api_get_tips(&ta_core.iota_service, &json_result);
   else if (api_path_matcher(api_sub_topic, "/tips/pair") == SC_OK)
     ret = api_get_tips_pair(&ta_core.iota_conf, &ta_core.iota_service, &json_result);
   else if (api_path_matcher(api_sub_topic, "/tryte") == SC_OK)
-    ret = api_send_trytes(&ta_core.iota_conf, &ta_core.iota_service, req, &json_result);
+    ret = api_send_trytes(&ta_core.ta_conf, &ta_core.iota_conf, &ta_core.iota_service, req, &json_result);
   else {
     cJSON *json_obj = cJSON_CreateObject();
     cJSON_AddStringToObject(json_obj, "message", api_sub_topic);

--- a/connectivity/mqtt/duplex_utils.c
+++ b/connectivity/mqtt/duplex_utils.c
@@ -105,7 +105,7 @@ status_t gossip_api_channels_set(mosq_config_t *channel_cfg, char *host, char *r
   int sub_topic_len, api_name_len;
   int root_path_len = strlen(root_path);
   char *api_names[API_NUM] = {"address",          "tag/hashes", "tag/object", "transaction/object",
-                              "transaction/send", "tips/all",   "tips/pair"};
+                              "transaction/send", "tips/all",   "tips/pair",  "tryte"};
 
   for (int i = 0; i < API_NUM; i++) {
     api_name_len = strlen(api_names[i]);

--- a/connectivity/mqtt/duplex_utils.c
+++ b/connectivity/mqtt/duplex_utils.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 BiiLabs Co., Ltd. and Contributors
+ * Copyright (C) 2019-2020 BiiLabs Co., Ltd. and Contributors
  * All Rights Reserved.
  * This is free software; you can redistribute it and/or modify it under the
  * terms of the MIT license. A copy of the license can be found in the file
@@ -11,6 +11,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include "common/logger.h"
+#include "common/macros.h"
 
 #define MQTT_UTILS_LOGGER "mqtt-utils"
 
@@ -104,10 +105,11 @@ status_t gossip_api_channels_set(mosq_config_t *channel_cfg, char *host, char *r
   char *sub_topic = NULL;
   int sub_topic_len, api_name_len;
   int root_path_len = strlen(root_path);
-  char *api_names[API_NUM] = {"address",          "tag/hashes", "tag/object", "transaction/object",
-                              "transaction/send", "tips/all",   "tips/pair",  "tryte"};
+  char *api_names[] = {"address",     "tag/hashes",       "tag/object", "transaction/object", "tryte",
+                       "transaction", "transaction/send", "tips/all",   "tips/pair"};
 
-  for (int i = 0; i < API_NUM; i++) {
+  const int api_num = ARRAY_SIZE(api_names);
+  for (int i = 0; i < api_num; i++) {
     api_name_len = strlen(api_names[i]);
     sub_topic_len = root_path_len + 1 + api_name_len;
     sub_topic = (char *)malloc(sub_topic_len + 1);

--- a/connectivity/mqtt/mqtt_common.h
+++ b/connectivity/mqtt/mqtt_common.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 BiiLabs Co., Ltd. and Contributors
+ * Copyright (C) 2019-2020 BiiLabs Co., Ltd. and Contributors
  * All Rights Reserved.
  * This is free software; you can redistribute it and/or modify it under the
  * terms of the MIT license. A copy of the license can be found in the file
@@ -23,7 +23,6 @@ extern "C" {
  */
 
 #define ID_LEN 32
-#define API_NUM 8
 
 typedef enum client_type_s { client_pub, client_sub, client_duplex } client_type_t;
 

--- a/connectivity/mqtt/mqtt_common.h
+++ b/connectivity/mqtt/mqtt_common.h
@@ -23,7 +23,7 @@ extern "C" {
  */
 
 #define ID_LEN 32
-#define API_NUM 7
+#define API_NUM 8
 
 typedef enum client_type_s { client_pub, client_sub, client_duplex } client_type_t;
 

--- a/connectivity/mqtt/usage.md
+++ b/connectivity/mqtt/usage.md
@@ -8,7 +8,8 @@ The format of MQTT request is the same as http request, but MQTT request has one
 | address                 | api_generate_address               | GET           |
 | tag/hashes              | api_find_transactions_by_tag       | GET           |
 | tag/object              | api_find_transactions_obj_by_tag   | GET           |
-| transaction/object      | api_find_transaction_object_single | GET           |
+| transaction             | api_find_transaction_object_single | GET           |
+| transaction/object      | api_find_transaction_objects       | POST          |
 | transaction/send        | api_send_transfer                  | POST          |
 | tips/all                | api_get_tips                       | GET           |
 | tips/pair               | api_get_tips_pair                  | GET           |
@@ -19,31 +20,35 @@ APIs in POST method have almost the same format as MQTT requests have, there are
 However, APIs in GET method would in a more different format, so the following are the examples of the requests of these APIs.
 
 ### api_generate_address
-```
+```json
 {"device_id":"<device_id>"}
 ```
 ### api_find_transactions_by_tag
-```
+```json
 {"device_id":"<device_id>", "tag":"<tag>"}
 ```
 ### api_find_transactions_obj_by_tag
-```
+```json
 {"device_id":"<device_id>", "tag":"<tag>"}
 ```
 ### api_find_transaction_object_single
-```
+```json
 {"device_id":"<device_id>", "hash":"<transaction hash>"}
 ```
-### api_get_tips
+### api_find_transaction_objects
+```json
+{"device_id":"<device_id>", "hash":["<transaction hash 1>", "<transaction hash 2>", "..."]}
 ```
+### api_get_tips
+```json
 {"device_id":"<device_id>"}
 ```
 ### api_get_tips_pair
-```
+```json
 {"device_id":"<device_id>"}
 ```
 ### api_send_trytes
-```
+```json
 {"device_id":"<device_id>", "trytes":"<trytes>"}
 ```
 

--- a/connectivity/mqtt/usage.md
+++ b/connectivity/mqtt/usage.md
@@ -12,6 +12,7 @@ The format of MQTT request is the same as http request, but MQTT request has one
 | transaction/send        | api_send_transfer                  | POST          |
 | tips/all                | api_get_tips                       | GET           |
 | tips/pair               | api_get_tips_pair                  | GET           |
+| tryte                   | api_send_trytes                    | POST          |
 
 ## API request format
 APIs in POST method have almost the same format as MQTT requests have, there are one more field, `device_id` in MQTT requests.
@@ -40,6 +41,10 @@ However, APIs in GET method would in a more different format, so the following a
 ### api_get_tips_pair
 ```
 {"device_id":"<device_id>"}
+```
+### api_send_trytes
+```
+{"device_id":"<device_id>", "trytes":"<trytes>"}
 ```
 
 ## Examples


### PR DESCRIPTION
Fixes #529.

The route to `api_send_trytes` is `tryte`.
The route to `api_find_transaction_object` is separated to `transaction` and `transaction/object` to support single and multiple transaction hashes.
