### PR TITLE
feat(config): Add CLI command to disable GTTA

### DIFF
--- a/accelerator/cli_info.h
+++ b/accelerator/cli_info.h
@@ -50,6 +50,7 @@ typedef enum ta_cli_arg_value_e {
   CONF_CLI,
   PROXY_API,
   HEALTH_TRACK_PERIOD,
+  NO_GTTA,
 
   /** LOGGER */
   QUIET,
@@ -83,6 +84,7 @@ static struct ta_cli_argument_s {
     {"proxy_passthrough", no_argument, NULL, PROXY_API, "Pass proxy API directly to IRI without processing"},
     {"health_track_period", no_argument, NULL, HEALTH_TRACK_PERIOD,
      "The period for checking IRI host connection status"},
+    {"no-gtta", no_argument, NULL, NO_GTTA, "Disable getTransactionToConfirm (gTTA) when sending transacation"},
     {"quiet", no_argument, NULL, QUIET, "Disable logger"},
     {NULL, 0, NULL, 0, NULL}};
 

--- a/accelerator/config.c
+++ b/accelerator/config.c
@@ -38,7 +38,7 @@ static int get_conf_key(char const* const key) {
 }
 
 status_t cli_core_set(ta_core_t* const core, int key, char* const value) {
-  if (value == NULL && (key != CACHE && key != PROXY_API && key != QUIET)) {
+  if (value == NULL && (key != CACHE && key != PROXY_API && key != QUIET && key != NO_GTTA)) {
     ta_log_error("%s\n", "SC_CONF_NULL");
     return SC_CONF_NULL;
   }
@@ -186,9 +186,11 @@ status_t cli_core_set(ta_core_t* const core, int key, char* const value) {
     case QUIET:
       quiet_mode = true;
       break;
-
     case PROXY_API:
       ta_conf->proxy_passthrough = true;
+      break;
+    case NO_GTTA:
+      ta_conf->gtta = false;
       break;
 
     // File configuration
@@ -225,6 +227,7 @@ status_t ta_core_default_init(ta_core_t* const core) {
   ta_conf->thread_count = TA_THREAD_COUNT;
   ta_conf->proxy_passthrough = false;
   ta_conf->health_track_period = IRI_HEALTH_TRACK_PERIOD;
+  ta_conf->gtta = true;
 #ifdef MQTT_ENABLE
   ta_conf->mqtt_host = MQTT_HOST;
   ta_conf->mqtt_topic_root = TOPIC_ROOT;

--- a/accelerator/config.h
+++ b/accelerator/config.h
@@ -68,20 +68,21 @@ typedef struct ta_config_s {
   int port;                               /**< Binding port of tangle-accelerator */
   char* host_list[MAX_IRI_LIST_ELEMENTS]; /**< List of binding host of tangle-accelerator */
   int port_list[MAX_IRI_LIST_ELEMENTS];   /**< List of binding port of tangle-accelerator */
-  int health_track_period; /**< The period for checking IRI host connection status */
+  int health_track_period;                /**< The period for checking IRI host connection status */
 #ifdef MQTT_ENABLE
   char* mqtt_host;       /**< Address of MQTT broker host */
   char* mqtt_topic_root; /**< The topic root of MQTT topic */
 #endif
-  uint8_t thread_count;    /**< Thread count of tangle-accelerator instance */
-  bool proxy_passthrough;  /**< Pass proxy api directly without processing */
+  uint8_t thread_count;   /**< Thread count of tangle-accelerator instance */
+  bool proxy_passthrough; /**< Pass proxy api directly without processing */
+  bool gtta;              /**< The option to turn on or off GTTA. The default value is true which enabling GTTA */
 } ta_config_t;
 
 /** struct type of iota configuration */
 typedef struct iota_config_s {
-  uint8_t milestone_depth; /**< Depth of API argument */
-  uint8_t mwm;             /**< Minimum weight magnitude of API argument */
-  const char* seed;        /**< Seed to generate address. This does not do any signature yet. */
+  uint8_t milestone_depth;   /**< Depth of API argument */
+  uint8_t mwm;               /**< Minimum weight magnitude of API argument */
+  const char* seed;          /**< Seed to generate address. This does not do any signature yet. */
   const char* mam_file_path; /**< The MAM file which records the mam config */
 } iota_config_t;
 

--- a/accelerator/core/apis.c
+++ b/accelerator/core/apis.c
@@ -401,8 +401,9 @@ done:
   return ret;
 }
 
-status_t api_mam_send_message(const iota_config_t* const iconf, const iota_client_service_t* const service,
-                              char const* const payload, char** json_result) {
+status_t api_mam_send_message(const ta_config_t* const info, const iota_config_t* const iconf,
+                              const iota_client_service_t* const service, char const* const payload,
+                              char** json_result) {
   status_t ret = SC_OK;
   mam_api_t mam;
   tryte_t chid[MAM_CHANNEL_ID_TRYTE_SIZE] = {}, epid[MAM_CHANNEL_ID_TRYTE_SIZE] = {},
@@ -445,7 +446,7 @@ status_t api_mam_send_message(const iota_config_t* const iconf, const iota_clien
 
   // Sending bundle
   lock_handle_lock(&cjson_lock);
-  if (ta_send_bundle(iconf, service, bundle) != SC_OK) {
+  if (ta_send_bundle(info, iconf, service, bundle) != SC_OK) {
     lock_handle_unlock(&cjson_lock);
     ret = SC_MAM_FAILED_RESPONSE;
     ta_log_error("%s\n", "SC_MAM_FAILED_RESPONSE");
@@ -488,7 +489,7 @@ status_t api_mam_send_message(const iota_config_t* const iconf, const iota_clien
     }
 
     lock_handle_lock(&cjson_lock);
-    if (ta_send_bundle(iconf, service, bundle) != SC_OK) {
+    if (ta_send_bundle(info, iconf, service, bundle) != SC_OK) {
       lock_handle_unlock(&cjson_lock);
       ret = SC_MAM_FAILED_RESPONSE;
       ta_log_error("%s\n", "SC_MAM_FAILED_RESPONSE");
@@ -557,7 +558,7 @@ status_t api_send_transfer(const ta_core_t* const core, const char* const obj, c
     goto done;
   }
 
-  ret = ta_send_transfer(&core->iota_conf, &core->iota_service, req, res);
+  ret = ta_send_transfer(&core->ta_conf, &core->iota_conf, &core->iota_service, req, res);
   if (ret == SC_CCLIENT_FAILED_RESPONSE) {
     lock_handle_unlock(&cjson_lock);
     ta_log_info("%s\n", "Caching transaction");
@@ -624,8 +625,8 @@ done:
   return ret;
 }
 
-status_t api_send_trytes(const iota_config_t* const iconf, const iota_client_service_t* const service,
-                         const char* const obj, char** json_result) {
+status_t api_send_trytes(const ta_config_t* const info, const iota_config_t* const iconf,
+                         const iota_client_service_t* const service, const char* const obj, char** json_result) {
   status_t ret = SC_OK;
   hash8019_array_p trytes = hash8019_array_new();
 
@@ -642,7 +643,7 @@ status_t api_send_trytes(const iota_config_t* const iconf, const iota_client_ser
     goto done;
   }
 
-  ret = ta_send_trytes(iconf, service, trytes);
+  ret = ta_send_trytes(info, iconf, service, trytes);
   if (ret != SC_OK) {
     lock_handle_unlock(&cjson_lock);
     goto done;

--- a/accelerator/core/apis.h
+++ b/accelerator/core/apis.h
@@ -153,6 +153,7 @@ status_t api_recv_mam_message(const iota_config_t* const iconf, const iota_clien
  * There is no need to decode the ascii payload to tryte, since the
  * api_mam_send_message() will take this job.
  *
+ * @param[in] info Tangle-accelerator configuration variables
  * @param[in] iconf IOTA API parameter configurations
  * @param[in] service IRI node end point service
  * @param[in] payload message to send undecoded ascii string.
@@ -162,8 +163,9 @@ status_t api_recv_mam_message(const iota_config_t* const iconf, const iota_clien
  * - SC_OK on success
  * - non-zero on error
  */
-status_t api_mam_send_message(const iota_config_t* const iconf, const iota_client_service_t* const service,
-                              char const* const payload, char** json_result);
+status_t api_mam_send_message(const ta_config_t* const info, const iota_config_t* const iconf,
+                              const iota_client_service_t* const service, char const* const payload,
+                              char** json_result);
 
 /**
  * @brief Send transfer to tangle.
@@ -259,6 +261,7 @@ status_t api_find_transactions_obj_by_tag(const iota_client_service_t* const ser
  * This allows for reattachments and prevents key reuse if trytes can't
  * be recovered by querying the network after broadcasting.
  *
+ * @param[in] info Tangle-accelerator configuration variables
  * @param[in] iconf IOTA API parameter configurations
  * @param[in] service IRI node end point service
  * @param[in] obj trytes to attach, store and broadcast in json array
@@ -269,8 +272,8 @@ status_t api_find_transactions_obj_by_tag(const iota_client_service_t* const ser
  * - SC_OK on success
  * - non-zero on error
  */
-status_t api_send_trytes(const iota_config_t* const iconf, const iota_client_service_t* const service,
-                         const char* const obj, char** json_result);
+status_t api_send_trytes(const ta_config_t* const info, const iota_config_t* const iconf,
+                         const iota_client_service_t* const service, const char* const obj, char** json_result);
 
 /**
  * @brief Check the connection status between tangle-accelerator and IRI host.

--- a/accelerator/core/core.h
+++ b/accelerator/core/core.h
@@ -81,6 +81,7 @@ status_t ta_generate_address(const iota_config_t* const iconf, const iota_client
  * fields include address, value, tag, and message. This API would also try to
  * find the transactions after bundle sent.
  *
+ * @param[in] info Tangle-accelerator configuration variables
  * @param[in] iconf IOTA API parameter configurations
  * @param[in] service IRI node end point service
  * @param[in] req Request containing address value, message, tag in
@@ -91,8 +92,9 @@ status_t ta_generate_address(const iota_config_t* const iconf, const iota_client
  * - SC_OK on success
  * - non-zero on error
  */
-status_t ta_send_transfer(const iota_config_t* const iconf, const iota_client_service_t* const service,
-                          const ta_send_transfer_req_t* const req, ta_send_transfer_res_t* res);
+status_t ta_send_transfer(const ta_config_t* const info, const iota_config_t* const iconf,
+                          const iota_client_service_t* const service, const ta_send_transfer_req_t* const req,
+                          ta_send_transfer_res_t* res);
 
 /**
  * @brief Send trytes to tangle.
@@ -101,6 +103,7 @@ status_t ta_send_transfer(const iota_config_t* const iconf, const iota_client_se
  * bundle and do PoW in `ta_attach_to_tangle` and store and broadcast
  * transaction to tangle.
  *
+ * @param[in] info Tangle-accelerator configuration variables
  * @param[in] iconf IOTA API parameter configurations
  * @param[in] service IRI node end point service
  * @param[in] trytes Trytes that will be attached to tangle
@@ -109,8 +112,8 @@ status_t ta_send_transfer(const iota_config_t* const iconf, const iota_client_se
  * - SC_OK on success
  * - non-zero on error
  */
-status_t ta_send_trytes(const iota_config_t* const iconf, const iota_client_service_t* const service,
-                        hash8019_array_p trytes);
+status_t ta_send_trytes(const ta_config_t* const info, const iota_config_t* const iconf,
+                        const iota_client_service_t* const service, hash8019_array_p trytes);
 
 /**
  * @brief Return list of transaction hash with given tag.
@@ -190,6 +193,7 @@ status_t ta_get_bundle(const iota_client_service_t* const service, tryte_t const
  * Send the unpacked bundle which contains transactions. MAM functions should
  * send message with this function.
  *
+ * @param[in] info Tangle-accelerator configuration variables
  * @param[in] service IRI node end point service
  * @param[in] bundle bundle object to send
  * @param[out] bundle Result containing bundle object in bundle_transactions_t
@@ -198,8 +202,8 @@ status_t ta_get_bundle(const iota_client_service_t* const service, tryte_t const
  * - SC_OK on success
  * - non-zero on error
  */
-status_t ta_send_bundle(const iota_config_t* const iconf, const iota_client_service_t* const service,
-                        bundle_transactions_t* const bundle);
+status_t ta_send_bundle(const ta_config_t* const info, const iota_config_t* const iconf,
+                        const iota_client_service_t* const service, bundle_transactions_t* const bundle);
 
 /**
  * @brief Get the bundle that contains assigned address

--- a/connectivity/http/http.c
+++ b/connectivity/http/http.c
@@ -191,13 +191,13 @@ static inline int process_find_transaction_by_id_request(ta_http_t *const http, 
 
 static inline int process_mam_send_msg_request(ta_http_t *const http, char const *const payload, char **const out) {
   status_t ret;
-  ret = api_mam_send_message(&http->core->iota_conf, &http->core->iota_service, payload, out);
+  ret = api_mam_send_message(&http->core->ta_conf, &http->core->iota_conf, &http->core->iota_service, payload, out);
   return set_response_content(ret, out);
 }
 
 static inline int process_send_trytes_request(ta_http_t *const http, char const *const payload, char **const out) {
   status_t ret;
-  ret = api_send_trytes(&http->core->iota_conf, &http->core->iota_service, payload, out);
+  ret = api_send_trytes(&http->core->ta_conf, &http->core->iota_conf, &http->core->iota_service, payload, out);
   return set_response_content(ret, out);
 }
 

--- a/tests/api/driver.c
+++ b/tests/api/driver.c
@@ -166,7 +166,8 @@ void test_send_trytes(void) {
 
   for (size_t count = 0; count < TEST_COUNT; count++) {
     test_time_start(&start_time);
-    TEST_ASSERT_EQUAL_INT32(SC_OK, api_send_trytes(&ta_core.iota_conf, &ta_core.iota_service, json, &json_result));
+    TEST_ASSERT_EQUAL_INT32(
+        SC_OK, api_send_trytes(&ta_core.ta_conf, &ta_core.iota_conf, &ta_core.iota_service, json, &json_result));
     test_time_end(&start_time, &end_time, &sum);
     free(json_result);
   }
@@ -277,7 +278,7 @@ void test_send_mam_message(void) {
 
   for (size_t count = 0; count < TEST_COUNT; count++) {
     test_time_start(&start_time);
-    ret = api_mam_send_message(&ta_core.iota_conf, &ta_core.iota_service, json, &json_result);
+    ret = api_mam_send_message(&ta_core.ta_conf, &ta_core.iota_conf, &ta_core.iota_service, json, &json_result);
     if (ret == SC_OK || ret == SC_MAM_ALL_MSS_KEYS_USED) {
       result = true;
     }


### PR DESCRIPTION
If milestone doesn't work, any transaction which processing GTTA
can't be able to be sent successfully. For a temporary workaround,
we add a new CLI commmand to turn GTTA off.

close #536