### PR TITLE
chore: add uuid-runtime package to docker image

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -22,7 +22,7 @@ git_repository(
 git_repository(
     name = "io_bazel_rules_docker",
     remote = "https://github.com/bazelbuild/rules_docker.git",
-    tag = "v0.7.0",
+    tag = "v0.9.0",
 )
 
 load("@rules_iota//:defs.bzl", "iota_deps")
@@ -31,6 +31,15 @@ load("@io_bazel_rules_docker//repositories:repositories.bzl", container_reposito
 container_repositories()
 
 load("@io_bazel_rules_docker//cc:image.bzl", _cc_image_repos = "repositories")
+
+load("@io_bazel_rules_docker//container:pull.bzl", "container_pull")
+
+container_pull(
+    name = "ubuntu1804",
+    registry = "l.gcr.io",
+    repository = "google/ubuntu1804",
+    tag = "latest",
+)
 
 iota_deps()
 

--- a/accelerator/BUILD
+++ b/accelerator/BUILD
@@ -1,5 +1,7 @@
 load("@io_bazel_rules_docker//cc:image.bzl", "cc_image")
 load("@io_bazel_rules_docker//container:container.bzl", "container_image")
+load("@io_bazel_rules_docker//docker/package_managers:download_pkgs.bzl", "download_pkgs")
+load("@io_bazel_rules_docker//docker/package_managers:install_pkgs.bzl", "install_pkgs")
 
 cc_binary(
     name = "accelerator",
@@ -52,8 +54,25 @@ cc_library(
     srcs = ["cli_info.h"],
 )
 
+download_pkgs(
+    name = "docker_runtime_pkgs",
+    image_tar = "@ubuntu1804//image",
+    packages = [
+        "uuid-runtime",
+    ],
+)
+
+install_pkgs(
+    name = "docker_runtime_image",
+    image_tar = "@ubuntu1804//image",
+    installables_tar = ":docker_runtime_pkgs.tar",
+    installation_cleanup_commands = "rm -rf /var/lib/apt/lists/*",
+    output_image_name = "docker_runtime_image",
+)
+
 cc_image(
     name = "docker_base_image",
+    base = ":docker_runtime_image",
     binary = ":accelerator",
 )
 


### PR DESCRIPTION
Because docker image could not use the host system's runtime package,
it is necessary to include the runtime package to docker image.

We are upgrade the rules_docker to v0.9.0, and use the "package_managers"
to include runtime package to docker image.