### PR TITLE
refactor(mam): Send mam message on channel keys 

### DIFF
--- a/accelerator/config.c
+++ b/accelerator/config.c
@@ -429,7 +429,6 @@ void ta_core_destroy(ta_core_t* const core) {
   ta_log_info("Destroying DB connection\n");
   db_client_service_free(&core->db_service);
 #endif
-  free(core->iota_conf.mam_file_path);
   pow_destroy();
   cache_stop();
   logger_helper_release(logger_id);

--- a/accelerator/core/mam_core.c
+++ b/accelerator/core/mam_core.c
@@ -10,16 +10,16 @@
 #include "common/model/transfer.h"
 #include "utils/containers/hash/hash_array.h"
 
-#define MODE_LOGGER "mode"
+#define MAM_LOGGER "mam_core"
 
 static logger_id_t logger_id;
 
-void ta_mam_logger_init() { logger_id = logger_helper_enable(MODE_LOGGER, LOGGER_DEBUG, true); }
+void ta_mam_logger_init() { logger_id = logger_helper_enable(MAM_LOGGER, LOGGER_DEBUG, true); }
 
 int ta_mam_logger_release() {
   logger_helper_release(logger_id);
   if (logger_helper_destroy() != RC_OK) {
-    ta_log_error("Destroying logger failed %s.\n", MODE_LOGGER);
+    ta_log_error("Destroying logger failed %s.\n", MAM_LOGGER);
     return EXIT_FAILURE;
   }
 
@@ -30,33 +30,27 @@ int ta_mam_logger_release() {
  * Internal functions
  ***********************************************************************************************************/
 
-static void bundle_transactions_renew(bundle_transactions_t **bundle) {
-  bundle_transactions_free(bundle);
-  bundle_transactions_new(bundle);
-}
-
-static retcode_t ta_mam_write_header(mam_api_t *const api, tryte_t const *const channel_id,
-                                     tryte_t const *const endpoint_id, mam_psk_t_set_t psks,
+static retcode_t ta_mam_write_header(mam_api_t *const api, tryte_t const *const channel_id, mam_psk_t_set_t psks,
                                      mam_ntru_pk_t_set_t ntru_pks, bundle_transactions_t *const bundle,
                                      trit_t *const msg_id) {
   retcode_t ret = RC_OK;
 
   // In TA we only write header on endpoint, since in our architecture we only post Message on signatures owned by
   // endpoint, but not the signatures owned by channel.
-  ret = mam_api_bundle_write_header_on_endpoint(api, channel_id, endpoint_id, psks, ntru_pks, bundle, msg_id);
+  ret = mam_api_bundle_write_header_on_channel(api, channel_id, psks, ntru_pks, bundle, msg_id);
   if (ret) {
-    ta_log_error("%d\n", ret);
+    ta_log_error("ret: %d, %s\n", ret, error_2_string(ret));
   }
   return ret;
 }
 
 /**
- * Writes a packet on a bundle
+ * @brief Writes a packet on a bundle
  *
- * @param api - The API [in,out]
- * @param bundle - The bundle that the packet will be written into [out]
- * @param payload - The payload to write [in]
- * @param msg_id - The msg_id [in]
+ * @param api[in] The MAM API object
+ * @param bundle[out] The bundle that the packet will be written into
+ * @param payload[in] The payload to write
+ * @param msg_id[in] The msg_id
  *
  * @return return code
  */
@@ -76,17 +70,16 @@ static retcode_t ta_mam_write_packet(mam_api_t *const api, bundle_transactions_t
 }
 
 /**
- * Find whether the tag of the first transaction of the bundle already has existed on Tangle, which means this current
- * Header has been published.
+ * @brief Find whether the tag of the first transaction of the bundle has already existed on Tangle, which means this
+ * current Header has been published.
  *
- * @param tag_array - An tag array contains all the tag under the given Channel ID[in,out]
- * @param bundle - The bundle contains the Header may be used[out]
+ * @param tag_array[in,out] A tag array contains all the tags under the given Channel ID
+ * @param bundle[out] The bundle contains the Header may be used
  *
  * @return Return true is the tags exist in tag array
  */
-static bool msg_id_exist(hash81_array_p tag_array, bundle_transactions_t **bundle) {
+static bool msg_id_exist(hash81_array_p tag_array, flex_trit_t *tag) {
   bool existed = false;
-  flex_trit_t *tag = transaction_tag((iota_transaction_t *)utarray_front(*bundle));
   tryte_t tag_tryte[NUM_TRYTES_TAG + 1], tag_cursor_tryte[NUM_TRYTES_TAG + 1];
   tag_tryte[NUM_TRYTES_TAG] = 0;
   tag_cursor_tryte[NUM_TRYTES_TAG] = 0;
@@ -97,7 +90,7 @@ static bool msg_id_exist(hash81_array_p tag_array, bundle_transactions_t **bundl
   for (tag_cursor = (flex_trit_t *)utarray_front(tag_array); tag_cursor != NULL;
        tag_cursor = (flex_trit_t *)utarray_next(tag_array, tag_cursor)) {
     flex_trits_to_trytes(tag_cursor_tryte, NUM_TRYTES_TAG, tag_cursor, NUM_FLEX_TRITS_TAG, NUM_FLEX_TRITS_TAG);
-    if (!memcmp(tag_cursor_tryte, tag_tryte, NUM_TRYTES_TAG)) {
+    if (!memcmp(tag_cursor_tryte, tag_tryte, NUM_TRYTES_MAM_MSG_ID)) {
       existed = true;
       break;
     }
@@ -107,41 +100,10 @@ static bool msg_id_exist(hash81_array_p tag_array, bundle_transactions_t **bundl
 }
 
 /**
- * Append Pre-Shared Key or NTRU public key into Pre-Shared Key set or NTRU public key set, respectively.
+ * @brief Get a channel from its id
  *
- * @param psks - Pre-Shared Key set[in]
- * @param ntru_pks - NTRU public key set[in]
- * @param psk - Pre-Shared Key[in]
- * @param ntru_pk - NTRU public key[in]
- *
- * @return return code
- */
-static status_t key_set_setup(mam_psk_t_set_t *const psks, mam_ntru_pk_t_set_t *const ntru_pks,
-                              tryte_t const *const psk, tryte_t const *const ntru_pk) {
-  if (psk) {
-    mam_psk_t psk_obj;
-    trytes_to_trits(psk, psk_obj.key, MAM_PSK_KEY_SIZE / 3);
-    if (mam_psk_t_set_add(psks, &psk_obj) != RC_OK) {
-      ta_log_error("%s\n", "SC_MAM_FAILED_INIT");
-      return SC_MAM_FAILED_INIT;
-    }
-  } else if (ntru_pk) {
-    mam_ntru_pk_t ntru_pk_obj;
-    trytes_to_trits(ntru_pk, ntru_pk_obj.key, MAM_NTRU_PK_SIZE / 3);
-    if (mam_ntru_pk_t_set_add(ntru_pks, &ntru_pk_obj) != RC_OK) {
-      ta_log_error("%s\n", "SC_MAM_FAILED_INIT");
-      return SC_MAM_FAILED_INIT;
-    }
-  }
-
-  return SC_OK;
-}
-
-/**
- * Gets a channel from its id
- *
- * @param api - The API [in]
- * @param channel_id - The channel id [in]
+ * @param api[in] MAM API instance
+ * @param channel_id[in] Channel id
  *
  * @return a pointer to the channel or NULL if not found
  */
@@ -165,11 +127,11 @@ static mam_channel_t *mam_api_channel_get(mam_api_t const *const api, tryte_t co
 }
 
 /**
- * Gets an endpoint from its id
+ * @brief Get an endpoint from its id
  *
- * @param api - The API [in]
- * @param channel_id - The associated channel id [in]
- * @param endpoint_id - The endpoint id [in]
+ * @param api[in] MAM API instance
+ * @param channel_id[in] Associated channel id
+ * @param endpoint_id[in] Associated endpoint id
  *
  * @return a pointer to the endpoint or NULL if not found
  */
@@ -198,10 +160,12 @@ static mam_endpoint_t *mam_api_endpoint_get(mam_api_t const *const api, tryte_t 
  * External functions
  ***********************************************************************************************************/
 
-status_t ta_mam_init(mam_api_t *const api, const iota_config_t *const iconf, tryte_t const *const seed,
-                     mam_psk_t_set_t *const psks, mam_ntru_pk_t_set_t *const ntru_pks, tryte_t const *const psk,
-                     tryte_t const *const ntru_pk) {
-  status_t ret = SC_OK;
+void bundle_transactions_renew(bundle_transactions_t **bundle) {
+  bundle_transactions_free(bundle);
+  bundle_transactions_new(bundle);
+}
+
+status_t ta_mam_init(mam_api_t *const api, const iota_config_t *const iconf, tryte_t const *const seed) {
   if (!api || (!iconf && !seed)) {
     return SC_MAM_NULL;
   }
@@ -225,42 +189,54 @@ status_t ta_mam_init(mam_api_t *const api, const iota_config_t *const iconf, try
     }
   }
 
-  ret = key_set_setup(psks, ntru_pks, psk, ntru_pk);
-  if (ret) {
-    ta_log_error("%d\n", ret);
-    return ret;
-  }
-
   return SC_OK;
 }
 
-status_t ta_mam_written_msg_to_bundle(const iota_client_service_t *const service, mam_api_t *const api,
-                                      const size_t channel_depth, const size_t endpoint_depth, tryte_t *const chid,
-                                      tryte_t *const epid, mam_psk_t_set_t psks, mam_ntru_pk_t_set_t ntru_pks,
-                                      char const *const payload, bundle_transactions_t **bundle, tryte_t *msg_id,
-                                      uint32_t *ch_remain_sk, uint32_t *ep_remain_sk) {
-  status_t ret = SC_OK;
-  if (!service || !api || !chid || !epid || channel_depth < 1 || endpoint_depth < 1) {
-    ta_log_error("%s\n", "SC_MAM_NULL");
-    return SC_MAM_NULL;
+status_t ta_set_mam_key(mam_psk_t_set_t *const psks, mam_ntru_pk_t_set_t *const ntru_pks, UT_array const *const psk,
+                        UT_array const *const ntru_pk) {
+  char **p = NULL;
+  if (psk) {
+    mam_psk_t psk_obj;
+    while ((p = (char **)utarray_next(psk, p))) {
+      trytes_to_trits((tryte_t *)*p, psk_obj.key, NUM_TRYTES_MAM_PSK_KEY_SIZE);
+      if (mam_psk_t_set_add(psks, &psk_obj) != RC_OK) {
+        ta_log_error("%s\n", "SC_MAM_FAILED_INIT");
+        return SC_MAM_FAILED_INIT;
+      }
+    }
   }
+
+  if (ntru_pk) {
+    mam_ntru_pk_t ntru_pk_obj;
+    while ((p = (char **)utarray_next(ntru_pk, p))) {
+      trytes_to_trits((tryte_t *)*p, ntru_pk_obj.key, NUM_TRYTES_MAM_NTRU_PK_SIZE);
+      if (mam_ntru_pk_t_set_add(ntru_pks, &ntru_pk_obj) != RC_OK) {
+        ta_log_error("%s\n", "SC_MAM_FAILED_INIT");
+        return SC_MAM_FAILED_INIT;
+      }
+    }
+  }
+  return SC_OK;
+}
+
+status_t create_channel_fetch_all_transactions(const iota_client_service_t *const service, mam_api_t *const api,
+                                               const size_t channel_depth, tryte_t *const chid,
+                                               hash81_array_p tag_array) {
+  status_t ret = SC_OK;
   find_transactions_req_t *txn_req = find_transactions_req_new();
   transaction_array_t *obj_res = transaction_array_new();
-  hash81_array_p tag_array = hash81_array_new();
+
   if (mam_api_channel_create(api, channel_depth, chid) != RC_OK) {
     ret = SC_MAM_FAILED_CREATE_OR_GET_ID;
     ta_log_error("%s\n", "SC_MAM_FAILED_CREATE_OR_GET_ID");
     goto done;
   }
 
-  // Step 1. find all Messages ordinal under the current channel.
-  // TODO fix NUM_FLEX_TRITS_ADDRESS is 81 not 243
-  // TODO use `ta_find_transaction_objects(service, obj_req, obj_res)` instead of the original entangled function
   flex_trit_t chid_flex_trit[NUM_TRITS_ADDRESS];
   flex_trits_from_trytes(chid_flex_trit, NUM_TRITS_ADDRESS, chid, NUM_TRYTES_ADDRESS, NUM_TRYTES_ADDRESS);
   hash243_queue_push(&txn_req->addresses, chid_flex_trit);
-  retcode_t ret_rc = RC_OK;
-  ret_rc = iota_client_find_transaction_objects(service, txn_req, obj_res);
+  // TODO use `ta_find_transaction_objects(service, obj_req, obj_res)` instead of the original entangled function
+  retcode_t ret_rc = iota_client_find_transaction_objects(service, txn_req, obj_res);
   if (ret_rc && ret_rc != RC_NULL_PARAM) {
     ret = SC_MAM_FAILED_DESTROYED;
     ta_log_error("%s\n", "SC_MAM_FAILED_DESTROYED");
@@ -268,48 +244,85 @@ status_t ta_mam_written_msg_to_bundle(const iota_client_service_t *const service
   }
 
   iota_transaction_t *tx = NULL;
-  TX_OBJS_FOREACH(obj_res, tx) { hash_array_push(tag_array, transaction_tag(tx)); }
+  TX_OBJS_FOREACH(obj_res, tx) {
+    if (!msg_id_exist(tag_array, transaction_tag(tx))) {
+      hash_array_push(tag_array, transaction_tag(tx));
+    }
+  }
 
-  // Step 2. Calculate the smallest available ep_ord and msg_ord
-  uint32_t ch_remain_sk_local = 1 << channel_depth, ep_remain_sk_local = 1 << endpoint_depth;
+done:
+  find_transactions_req_free(&txn_req);
+  transaction_array_free(obj_res);
+  return ret;
+}
+
+status_t ta_mam_written_msg_to_bundle(const iota_client_service_t *const service, mam_api_t *const api,
+                                      const size_t channel_depth, tryte_t *const chid, mam_psk_t_set_t psks,
+                                      mam_ntru_pk_t_set_t ntru_pks, char const *const payload,
+                                      bundle_transactions_t **bundle, tryte_t *msg_id,
+                                      mam_mss_key_status_t *key_status) {
+  status_t ret = SC_OK;
+  if (!service || !api || !chid || channel_depth < 1) {
+    ret = SC_MAM_NULL;
+    ta_log_error("%s\n", ta_error_to_string(ret));
+    return ret;
+  }
   trit_t msg_id_trits[MAM_MSG_ID_SIZE];
-  while (true) {
-    if (ch_remain_sk_local < 1) {
-      ret = SC_MAM_ALL_MSS_KEYS_USED;
-      ta_log_error("%s\n", "SC_MAM_ALL_MSS_KEYS_USED");
+  hash81_array_p tag_array = hash81_array_new();
+  for (;;) {
+    hash_array_free(tag_array);
+    tag_array = hash81_array_new();
+
+    ret = create_channel_fetch_all_transactions(service, api, channel_depth, chid, tag_array);
+    if (ret) {
+      ta_log_error("%s\n", ta_error_to_string(ret));
       goto done;
     }
 
-    if (mam_api_endpoint_create(api, endpoint_depth, chid, epid) != RC_OK) {
-      ret = SC_MAM_FAILED_CREATE_OR_GET_ID;
-      ta_log_error("%s\n", "SC_MAM_FAILED_CREATE_OR_GET_ID");
-      goto done;
-    }
+    /*
+     * Three cases should be considered:
+     * 1. Unused key exists in the current channel
+     * 2. Unused key exists in the next channel
+     * 3. Unused key exists in the channel after the next channel
+     */
 
-    ep_remain_sk_local = 1 << endpoint_depth;
-    while (ep_remain_sk_local) {
-      if (ta_mam_write_header(api, chid, epid, psks, ntru_pks, *bundle, msg_id_trits)) {
+    // Calculate the smallest available msg_ord
+    const int ch_leaf_num = 1 << channel_depth;
+    int ch_remain_key_num = ch_leaf_num;
+    int used_key_num = hash_array_len(tag_array);
+    do {
+      bundle_transactions_renew(bundle);
+      used_key_num--;
+      ch_remain_key_num--;
+
+      if (ta_mam_write_header(api, chid, psks, ntru_pks, *bundle, msg_id_trits)) {
         ret = SC_MAM_FAILED_WRITE;
         ta_log_error("%s\n", "SC_MAM_FAILED_WRITE");
         goto done;
       }
 
-      if (!msg_id_exist(tag_array, bundle)) {
-        bundle_transactions_renew(bundle);
-        goto end_loop;
+      if (!msg_id_exist(tag_array, transaction_tag((iota_transaction_t *)utarray_front(*bundle)))) {
+        ta_log_debug("%s\n", "Found avialable msg_id");
+        break;
       }
 
-      bundle_transactions_renew(bundle);
+      mam_mss_next(&mam_api_channel_get(api, chid)->mss);
+    } while (ch_remain_key_num > 0);
 
-      ep_remain_sk_local--;
-      mam_mss_next(&mam_api_endpoint_get(api, chid, epid)->mss);
+    if (ch_remain_key_num == 1) {
+      // Publish announcement, when there is only one mss key available.
+      ta_log_debug("%s\n", "Publish announcement for the next channel.");
+      *key_status = ANNOUNCE_CHID;
+      break;
+    } else if (ch_remain_key_num == 0 && used_key_num == 0) {
+      // Check the next channel, since all the mss key are used in current channel
+      continue;
+    } else {
+      *key_status = KEY_AVAILABLE;
+      break;
     }
-
-    ch_remain_sk_local--;
-    mam_mss_next(&mam_api_channel_get(api, chid)->mss);
   }
 
-end_loop:
   // Writing packet to bundle
   if (ta_mam_write_packet(api, *bundle, payload, msg_id_trits)) {
     ret = SC_MAM_FAILED_WRITE;
@@ -320,25 +333,18 @@ end_loop:
   trits_to_trytes(msg_id_trits, msg_id, MAM_MSG_ID_SIZE);
 
 done:
-  *ch_remain_sk = ch_remain_sk_local;
-  *ep_remain_sk = ep_remain_sk_local;
-  find_transactions_req_free(&txn_req);
-  transaction_array_free(obj_res);
   hash_array_free(tag_array);
   return ret;
 }
 
-status_t ta_mam_announce_next_mss_private_key_to_bundle(mam_api_t *const api, const size_t channel_depth,
-                                                        const size_t endpoint_depth, tryte_t *const chid,
-                                                        uint32_t *ch_remain_sk, uint32_t *ep_remain_sk,
-                                                        mam_psk_t_set_t psks, mam_ntru_pk_t_set_t ntru_pks,
-                                                        tryte_t *const chid1, bundle_transactions_t **bundle) {
+status_t ta_mam_write_announce_to_bundle(mam_api_t *const api, const size_t channel_depth,
+                                         mam_mss_key_status_t key_status, tryte_t *const chid, mam_psk_t_set_t psks,
+                                         mam_ntru_pk_t_set_t ntru_pks, tryte_t *const chid1,
+                                         bundle_transactions_t **bundle) {
   status_t ret = SC_OK;
-  tryte_t epid1[NUM_TRYTES_ADDRESS];
   trit_t msg_id[MAM_MSG_ID_SIZE];
 
-  if (*ch_remain_sk == 1) {
-    // TODO uncomment the following code if we want to send chid1 once we run out all available private keys.
+  if (key_status == ANNOUNCE_CHID) {
     if (mam_api_channel_create(api, channel_depth, chid1) != RC_OK) {
       ret = SC_MAM_FAILED_CREATE_OR_GET_ID;
       ta_log_error("%s\n", "SC_MAM_FAILED_CREATE_OR_GET_ID");
@@ -350,48 +356,36 @@ status_t ta_mam_announce_next_mss_private_key_to_bundle(mam_api_t *const api, co
       ta_log_error("%s\n", "SC_MAM_FAILED_WRITE_HEADER");
       goto done;
     }
-
-  } else if (*ep_remain_sk == 1) {
-    // Send announcement when there are more they 2 available endpoint MSS private key existing
-    if (mam_api_endpoint_create(api, endpoint_depth, chid, epid1) != RC_OK) {
-      ret = SC_MAM_FAILED_CREATE_OR_GET_ID;
-      ta_log_error("%s\n", "SC_MAM_FAILED_CREATE_OR_GET_ID");
-      goto done;
-    }
-
-    if (mam_api_bundle_announce_endpoint(api, chid, epid1, psks, ntru_pks, *bundle, msg_id) != RC_OK) {
-      ret = SC_MAM_FAILED_WRITE_HEADER;
-      ta_log_error("%s\n", "SC_MAM_FAILED_WRITE_HEADER");
-      goto done;
-    }
-  } else if (*ch_remain_sk == 0) {
-    ret = SC_MAM_ALL_MSS_KEYS_USED;
-    ta_log_error("%s\n", "SC_MAM_ALL_MSS_KEYS_USED");
-    goto done;
+    tryte_t msg_id_tryte[NUM_TRYTES_MAM_MSG_ID + 1] = {};
+    trits_to_trytes(msg_id, msg_id_tryte, NUM_TRYTES_MAM_MSG_ID);
   }
 
 done:
   return ret;
 }
 
-retcode_t ta_mam_api_bundle_read(mam_api_t *const api, bundle_transactions_t *bundle, char **payload_out) {
-  retcode_t ret = RC_OK;
+status_t ta_mam_api_bundle_read(mam_api_t *const api, bundle_transactions_t *bundle, char **payload_out) {
+  status_t ret = SC_OK;
   tryte_t *payload_trytes = NULL;
   size_t payload_size = 0;
   bool is_last_packet = false;
-
-  ret = mam_api_bundle_read(api, bundle, &payload_trytes, &payload_size, &is_last_packet);
-  if (ret == RC_OK) {
+  retcode_t rc = mam_api_bundle_read(api, bundle, &payload_trytes, &payload_size, &is_last_packet);
+  if (rc == RC_OK) {
     if (payload_trytes == NULL || payload_size == 0) {
-      ret = RC_MAM_MESSAGE_NOT_FOUND;
+      ret = SC_MAM_NO_PAYLOAD;
+      ta_log_error("%s\n", ta_error_to_string(ret));
     } else {
       *payload_out = calloc(payload_size * 2 + 1, sizeof(char));
       if (*payload_out == NULL) {
-        ret = RC_OOM;
+        ret = SC_TA_OOM;
+        ta_log_error("%s\n", ta_error_to_string(ret));
         goto done;
       }
       trytes_to_ascii(payload_trytes, payload_size, *payload_out);
     }
+  } else {
+    ret = SC_MAM_MESSAGE_NOT_FOUND;
+    ta_log_error("entangled retcode_t:%d, %s\n", rc, error_2_string(rc));
   }
 
 done:

--- a/accelerator/core/mam_core.h
+++ b/accelerator/core/mam_core.h
@@ -25,17 +25,52 @@ extern "C" {
  */
 
 /**
- * Initialize a mam_api_t object
+ * Initialize logger for 'mam_core'
+ */
+void ta_mam_logger_init();
+
+/**
+ * Release logger
  *
- * @param api - The API [in,out]
- * @param[in] iconf IOTA API parameter configurations[in]
- * @param seed - MAM channels seed. It is an optional choice[in]
+ * @return
+ * - zero on success
+ * - EXIT_FAILURE on error
+ */
+int ta_mam_logger_release();
+
+typedef enum mam_mss_key_status_e { ANNOUNCE_CHID, KEY_AVAILABLE } mam_mss_key_status_t;
+
+/**
+ * @brief Renew the given bundle
+ *
+ * @param bundle[in,out] The bundle that will be renewed
+ *
+ */
+void bundle_transactions_renew(bundle_transactions_t** bundle);
+
+/**
+ * @brief Initialize a mam_api_t object
+ *
+ * @param api[in,out] The MAM API object
+ * @param iconf[in] IOTA API parameter configurations
+ * @param seed[in] Seed of MAM channels. It is an optional choice
  *
  * @return return code
  */
-status_t ta_mam_init(mam_api_t* const api, const iota_config_t* const iconf, tryte_t const* const seed,
-                     mam_psk_t_set_t* const psks, mam_ntru_pk_t_set_t* const ntru_pks, tryte_t const* const psk,
-                     tryte_t const* const ntru_pk);
+status_t ta_mam_init(mam_api_t* const api, const iota_config_t* const iconf, tryte_t const* const seed);
+
+/**
+ * @brief Append Pre-Shared Key or NTRU public key into Pre-Shared Key set or NTRU public key set, respectively.
+ *
+ * @param psks[in] Pre-Shared Key set
+ * @param ntru_pks[in] NTRU public key set
+ * @param psk[in] List of Pre-Shared Key
+ * @param ntru_pk[in] List of NTRU public key
+ *
+ * @return status code
+ */
+status_t ta_set_mam_key(mam_psk_t_set_t* const psks, mam_ntru_pk_t_set_t* const ntru_pks, UT_array const* const psk,
+                        UT_array const* const ntru_pk);
 
 /**
  * @brief Write payload to bundle on the smallest secret key.
@@ -43,27 +78,23 @@ status_t ta_mam_init(mam_api_t* const api, const iota_config_t* const iconf, try
  * With given channel_depth and endpoint_depth, generate the corresponding Channel ID and Endpoint ID, and write the
  * payload to a bundle. The payload is signed with secret key which has the smallest ordinal number.
  *
- * @param service - IRI node end point service[in]
- * @param api - The API [in,out]
- * @param channel_depth - Depth of channel merkle tree[in]
- * @param endpoint_depth - Depth of endpoint merkle tree[in]
- * @param psks - Pre-Shared Key set[in]
- * @param ntru_pks - NTRU public key set[in]
- * @param payload - The message that is going to send with MAM[in]
- * @param chid - Channel ID[out]
- * @param epid - Endpoint ID[out]
- * @param bundle - The bundle contains the Header and Packets of the current Message[out]
- * @param msg_id - Unique Message identifier under each channel[out]
- * @param ch_remain_sk - The number of MSS channel secret keys that haven't been used[out]
- * @param ep_remain_sk - The number of MSS endpoint secret keys of that haven't been used[out]
+ * @param service[in] IRI node end point service
+ * @param api[in,out] The MAM API object
+ * @param channel_depth[in] Depth of channel merkle tree
+ * @param psks[in] Pre-Shared Key set
+ * @param ntru_pks[in] NTRU public key set
+ * @param payload[in] The message that is going to send with MAM
+ * @param chid[out] Channel ID
+ * @param bundle[out] The bundle contains the Header and Packets of the current Message
+ * @param msg_id[out] Unique Message identifier under each channel
  *
  * @return return code
  */
 status_t ta_mam_written_msg_to_bundle(const iota_client_service_t* const service, mam_api_t* const api,
-                                      const size_t channel_depth, const size_t endpoint_depth, tryte_t* const chid,
-                                      tryte_t* const epid, mam_psk_t_set_t psks, mam_ntru_pk_t_set_t ntru_pks,
-                                      char const* const payload, bundle_transactions_t** bundle, tryte_t* msg_id,
-                                      uint32_t* ch_remain_sk, uint32_t* ep_remain_sk);
+                                      const size_t channel_depth, tryte_t* const chid, mam_psk_t_set_t psks,
+                                      mam_ntru_pk_t_set_t ntru_pks, char const* const payload,
+                                      bundle_transactions_t** bundle, tryte_t* msg_id,
+                                      mam_mss_key_status_t* key_status);
 
 /**
  * @brief Write an announcement to bundle.
@@ -71,35 +102,32 @@ status_t ta_mam_written_msg_to_bundle(const iota_client_service_t* const service
  * Write the announcement of the next Channel ID (chid1) or Endpoint ID (epid1). This function would
  * automatically determine which one is going to be generated.
  *
- * @param api - The API [in,out]
- * @param channel_depth - Depth of channel merkle tree[in]
- * @param endpoint_depth - Depth of endpoint merkle tree[in]
- * @param chid - Channel ID[in]
- * @param ch_remain_sk - The number of MSS channel secret keys that haven't been used[in]
- * @param ep_remain_sk - The number of MSS endpoint secret keys of that haven't been used[in]
- * @param psks - Pre-Shared Key set[in]
- * @param ntru_pks - NTRU public key set[in]
- * @param chid1 - The next Channel ID[in]
- * @param bundle - The bundle contains the Header and Packets of the current Message[out]
+ * @param api[in,out] The MAM API object
+ * @param channel_depth[in] Depth of channel merkle tree
+ * @param chid[in] Channel ID
+ * @param ch_remain_sk[in] The number of MSS channel secret keys that haven't been used
+ * @param psks[in] Pre-Shared Key set
+ * @param ntru_pks[in] NTRU public key set
+ * @param chid1[in] The next Channel ID
+ * @param bundle[out] The bundle contains the Header and Packets of the current Message
  *
  * @return return code
  */
-status_t ta_mam_announce_next_mss_private_key_to_bundle(mam_api_t* const api, const size_t channel_depth,
-                                                        const size_t endpoint_depth, tryte_t* const chid,
-                                                        uint32_t* ch_remain_sk, uint32_t* ep_remain_sk,
-                                                        mam_psk_t_set_t psks, mam_ntru_pk_t_set_t ntru_pks,
-                                                        tryte_t* const chid1, bundle_transactions_t** bundle);
+status_t ta_mam_write_announce_to_bundle(mam_api_t* const api, const size_t channel_depth,
+                                         mam_mss_key_status_t key_status, tryte_t* const chid, mam_psk_t_set_t psks,
+                                         mam_ntru_pk_t_set_t ntru_pks, tryte_t* const chid1,
+                                         bundle_transactions_t** bundle);
 
 /**
- * Read the MAM message from a bundle
+ * @brief Read the MAM message from a bundle
  *
- * @param api - The API [in,out]
- * @param bundle - The bundle that contains the message [in]
- * @param payload_out - The output playload in ascii [out]
+ * @param api[in] The MAM API object
+ * @param bundle[in] The bundle that contains the message
+ * @param payload_out[out] The output playload in ascii
  *
- * @return return code
+ * @return status code
  */
-retcode_t ta_mam_api_bundle_read(mam_api_t* const api, bundle_transactions_t* bundle, char** payload_out);
+status_t ta_mam_api_bundle_read(mam_api_t* const api, bundle_transactions_t* bundle, char** payload_out);
 
 #ifdef __cplusplus
 }

--- a/accelerator/core/request/ta_recv_mam.c
+++ b/accelerator/core/request/ta_recv_mam.c
@@ -23,11 +23,9 @@ static void recv_mam_req_v1_free(ta_recv_mam_req_t** req) {
     recv_mam_data_id_mam_v1_t* data_id = (*req)->data_id;
     free(data_id->bundle_hash);
     free(data_id->chid);
-    free(data_id->epid);
     free(data_id->msg_id);
     data_id->bundle_hash = NULL;
     data_id->chid = NULL;
-    data_id->epid = NULL;
     data_id->msg_id = NULL;
 
     free((*req)->data_id);
@@ -60,8 +58,8 @@ void recv_mam_req_free(ta_recv_mam_req_t** req) {
   *req = NULL;
 }
 
-status_t recv_mam_set_mam_v1_data_id(ta_recv_mam_req_t* req, char* bundle_hash, char* chid, char* epid, char* msg_id) {
-  if (req == NULL || (!bundle_hash && !chid && !epid && !msg_id)) {
+status_t recv_mam_set_mam_v1_data_id(ta_recv_mam_req_t* req, char* bundle_hash, char* chid, char* msg_id) {
+  if (req == NULL || (!bundle_hash && !chid && !msg_id)) {
     return SC_TA_NULL;
   }
   status_t ret = SC_OK;
@@ -74,7 +72,6 @@ status_t recv_mam_set_mam_v1_data_id(ta_recv_mam_req_t* req, char* bundle_hash, 
   recv_mam_data_id_mam_v1_t* data_id = (recv_mam_data_id_mam_v1_t*)req->data_id;
   data_id->bundle_hash = NULL;
   data_id->chid = NULL;
-  data_id->epid = NULL;
   data_id->msg_id = NULL;
   if (bundle_hash) {
     data_id->bundle_hash = (tryte_t*)strdup(bundle_hash);
@@ -86,13 +83,6 @@ status_t recv_mam_set_mam_v1_data_id(ta_recv_mam_req_t* req, char* bundle_hash, 
   if (chid) {
     data_id->chid = (tryte_t*)strdup(chid);
     if (!data_id->chid) {
-      ret = SC_TA_OOM;
-      goto error;
-    }
-  }
-  if (epid) {
-    data_id->epid = (tryte_t*)strdup(epid);
-    if (!data_id->epid) {
       ret = SC_TA_OOM;
       goto error;
     }

--- a/accelerator/core/request/ta_recv_mam.h
+++ b/accelerator/core/request/ta_recv_mam.h
@@ -55,8 +55,6 @@ typedef struct recv_mam_data_id_mam_v1_s {
   tryte_t* bundle_hash;
   /** channel id in trytes */
   tryte_t* chid;
-  /** endpoint id in trytes */
-  tryte_t* epid;
   /** message id in trytes */
   tryte_t* msg_id;
 } recv_mam_data_id_mam_v1_t;
@@ -73,14 +71,13 @@ typedef struct recv_mam_key_mam_v1_s {
  * @param[in] req Response data in type of ta_recv_mam_req_t object
  * @param[in] bundle_hash Bundle hash of the message
  * @param[in] chid Channel ID of the messages
- * @param[in] epid Endpoint ID of the messages
  * @param[in] msg_id Message ID of the message
  *
  * @return
  * - struct of ta_recv_mam_req_t on success
  * - NULL on error
  */
-status_t recv_mam_set_mam_v1_data_id(ta_recv_mam_req_t* req, char* bundle_hash, char* chid, char* epid, char* msg_id);
+status_t recv_mam_set_mam_v1_data_id(ta_recv_mam_req_t* req, char* bundle_hash, char* chid, char* msg_id);
 
 /**
  * Set the key for MAMv1

--- a/accelerator/core/response/ta_send_mam.c
+++ b/accelerator/core/response/ta_send_mam.c
@@ -10,8 +10,11 @@
 
 ta_send_mam_res_t* send_mam_res_new() {
   ta_send_mam_res_t* res = (ta_send_mam_res_t*)malloc(sizeof(ta_send_mam_res_t));
-  res->announcement_bundle_hash[0] = 0;
-  res->chid1[0] = 0;
+  memset(res->chid, 0, NUM_TRYTES_ADDRESS + 1);
+  memset(res->chid1, 0, NUM_TRYTES_ADDRESS + 1);
+  memset(res->bundle_hash, 0, NUM_TRYTES_BUNDLE + 1);
+  memset(res->msg_id, 0, NUM_TRYTES_MAM_MSG_ID + 1);
+  memset(res->announcement_bundle_hash, 0, NUM_TRYTES_BUNDLE + 1);
   return res;
 }
 
@@ -32,16 +35,6 @@ status_t send_mam_res_set_channel_id(ta_send_mam_res_t* res, const tryte_t* chan
 
   memcpy(res->chid, channel_id, NUM_TRYTES_HASH);
   res->chid[NUM_TRYTES_HASH] = '\0';
-  return SC_OK;
-}
-
-status_t send_mam_res_set_endpoint_id(ta_send_mam_res_t* res, const tryte_t* endpoint_id) {
-  if (!endpoint_id || !res) {
-    return SC_RES_NULL;
-  }
-
-  memcpy(res->epid, endpoint_id, NUM_TRYTES_HASH);
-  res->epid[NUM_TRYTES_HASH] = '\0';
   return SC_OK;
 }
 

--- a/accelerator/core/response/ta_send_mam.h
+++ b/accelerator/core/response/ta_send_mam.h
@@ -29,8 +29,6 @@ typedef struct send_mam_res_s {
   char bundle_hash[NUM_TRYTES_HASH + 1];
   /** ascii string channel id */
   char chid[NUM_TRYTES_HASH + 1];
-  /** ascii string endpoint id */
-  char epid[NUM_TRYTES_HASH + 1];
   /** channel ordinal which is the number of channel we generated */
   char msg_id[NUM_TRYTES_MAM_MSG_ID + 1];
   /** bundle hash of announcement bundle */
@@ -79,18 +77,6 @@ status_t send_mam_res_set_bundle_hash(ta_send_mam_res_t* res, const tryte_t* bun
  * - non-zero on error
  */
 status_t send_mam_res_set_channel_id(ta_send_mam_res_t* res, const tryte_t* channel_id);
-
-/**
- * @brief Set the endpoint_id field of send_mam_res object.
- *
- * @param[in] res ta_send_mam_res_t struct object
- * @param[in] endpoint_id endpoint id decoded in trytes string
- *
- * @return
- * - SC_OK on success
- * - non-zero on error
- */
-status_t send_mam_res_set_endpoint_id(ta_send_mam_res_t* res, const tryte_t* endpoint_id);
 
 /**
  * @brief Set the msgl_id field of send_mam_res object.

--- a/common/ta_errors.h
+++ b/common/ta_errors.h
@@ -136,7 +136,7 @@ typedef enum {
   SC_MAM_FAILED_DESTROYED = 0x05 | SC_MODULE_MAM | SC_SEVERITY_FATAL,
   /**< Error in mam destroy */
   SC_MAM_NO_PAYLOAD = 0x06 | SC_MODULE_MAM | SC_SEVERITY_FATAL,
-  /**< No payload or no chid in MAM */
+  /**< No payload in the MAM message with assigning IDs */
   SC_MAM_FAILED_WRITE = 0x07 | SC_MODULE_MAM | SC_SEVERITY_FATAL,
   /**< Failed to write in MAM */
   SC_MAM_FILE_SAVE = 0x08 | SC_MODULE_MAM | SC_SEVERITY_FATAL,
@@ -147,6 +147,10 @@ typedef enum {
   /**< Failed to created/get chid or epid or msg_id in MAM */
   SC_MAM_FAILED_WRITE_HEADER = 0x0B | SC_MODULE_MAM | SC_SEVERITY_FATAL,
   /**< Failed to write header in MAM */
+  SC_MAM_MESSAGE_NOT_FOUND = 0x0C | SC_MODULE_MAM | SC_SEVERITY_FATAL,
+  /**< Can't find message in the assign bundle */
+  SC_MAM_INVAID_CHID_OR_EPID = 0x0E | SC_MODULE_MAM | SC_SEVERITY_FATAL,
+  /**< Failed to add trusted channel ID or endpoint ID */
 
   // response module
   SC_RES_NULL = 0x01 | SC_MODULE_RES | SC_SEVERITY_FATAL,

--- a/tests/api/BUILD
+++ b/tests/api/BUILD
@@ -46,3 +46,17 @@ cc_test(
         "//tests/api:common",
     ],
 )
+
+cc_test(
+    name = "mam_test",
+    srcs = [
+        "mam_test.c",
+    ],
+    deps = [
+        ":common",
+        "//accelerator/core:apis",
+        "//accelerator/core:proxy_apis",
+        "//common",
+        "//tests:test_define",
+    ],
+)

--- a/tests/api/driver.c
+++ b/tests/api/driver.c
@@ -301,8 +301,6 @@ int main(int argc, char* argv[]) {
   RUN_TEST(test_send_transfer);
   RUN_TEST(test_send_trytes);
   RUN_TEST(test_find_transaction_objects);
-  // RUN_TEST(test_send_mam_message);
-  // RUN_TEST(test_receive_mam_message);
   RUN_TEST(test_find_transactions_by_tag);
   RUN_TEST(test_find_transactions_obj_by_tag);
 #ifdef DB_ENABLE

--- a/tests/api/mam_test.c
+++ b/tests/api/mam_test.c
@@ -1,21 +1,24 @@
 /*
- * Copyright (C) 2019 BiiLabs Co., Ltd. and Contributors
+ * Copyright (C) 2019-2020 BiiLabs Co., Ltd. and Contributors
  * All Rights Reserved.
  * This is free software; you can redistribute it and/or modify it under the
  * terms of the MIT license. A copy of the license can be found in the file
  * "LICENSE" at the root of this distribution.
  */
 
+#include <sys/types.h>
 #include <time.h>
+#include <unistd.h>
 #include "accelerator/core/apis.h"
-#include "accelerator/core/proxy_apis.h"
-#include "test_define.h"
+#include "accelerator/core/mam_core.h"
+#include "common.h"
+#include "tests/test_define.h"
 
 static ta_core_t ta_core;
 struct timespec start_time, end_time;
 
 char driver_tag_msg[NUM_TRYTES_TAG];
-ta_send_mam_res_t* res;
+ta_send_mam_res_t res;
 
 #if defined(ENABLE_STAT)
 #define TEST_COUNT 100
@@ -23,40 +26,192 @@ ta_send_mam_res_t* res;
 #define TEST_COUNT 1
 #endif
 
-void test_receive_mam_message(void) {
-  const char* json =
-      "{\"data_id\":{\"chid\":\"SYZJOQCGWGOTGGZUCZYQGHWWHQVIVBHJFHNXYXZQSGJXIHL9KMXNOBULIPTPGMBJSMFNBSAGCVVZ9MDMX\"},"
-      "\"protocol\":\"MAM_V1\"}";
-  char* json_result = NULL;
-  double sum = 0;
+// FIXME Use a common "gen_rand_seed()" function to replace a static function
+static void rand_seed_init() {
+  // We use ASLR which stands for Address Space Layout Randomization, and we can assume each address of functions inside
+  // loaded program is randomized.
+  srand(getpid() ^ ((int)&rand_seed_init));
+}
 
+static void gen_rand_seed(char* trytes) {
+  const char tryte_alphabet[] = "NOPQRSTUVWXYZ9ABCDEFGHIJKLM";
+
+  for (int i = 0; i < NUM_TRYTES_HASH; i++) {
+    trytes[i] = tryte_alphabet[rand() % 27];
+  }
+}
+
+void test_send_mam_message(void) {
+  const char* json_template = "{\"x-api-key\":\"" TEST_TOKEN "\",\"data\":{\"seed\":\"%s\",\"ch_mss_depth\":" STR(
+      TEST_CH_DEPTH) ",\"message\":\"" TEST_PAYLOAD "\"}, \"protocol\":\"MAM_V1\"}";
+  char seed[NUM_TRYTES_ADDRESS + 1] = {};
+  gen_rand_seed(seed);
+  const int len = strlen(json_template) + NUM_TRYTES_ADDRESS;
+  char* json_result = NULL;
+  char* json = (char*)malloc(sizeof(char) * len);
+  snprintf(json, len, json_template, seed);
+  double sum = 0;
   for (size_t count = 0; count < TEST_COUNT; count++) {
     test_time_start(&start_time);
+    TEST_ASSERT_EQUAL_INT32(
+        SC_OK, api_send_mam_message(&ta_core.ta_conf, &ta_core.iota_conf, &ta_core.iota_service, json, &json_result));
+    send_mam_res_deserialize(json_result, &res);
+    test_time_end(&start_time, &end_time, &sum);
+    free(json_result);
+  }
+  free(json);
+  printf("Average time of receive_mam_message: %lf\n", sum / TEST_COUNT);
+}
 
+void test_receive_mam_message(void) {
+  const char* json_template = "{\"data_id\":{\"chid\":\"%s\"},\"protocol\":\"MAM_V1\"}";
+  char *json = NULL, *json_result = NULL;
+  double sum = 0;
+  const int json_size = sizeof(char) * (strlen(json_template) + NUM_TRYTES_ADDRESS);
+  json = (char*)malloc(json_size);
+  snprintf(json, json_size, json_template, res.chid);
+  for (size_t count = 0; count < TEST_COUNT; count++) {
+    test_time_start(&start_time);
     TEST_ASSERT_EQUAL_INT32(SC_OK, api_recv_mam_message(&ta_core.iota_conf, &ta_core.iota_service, json, &json_result));
     test_time_end(&start_time, &end_time, &sum);
     free(json_result);
   }
   printf("Average time of receive_mam_message: %lf\n", sum / TEST_COUNT);
+  free(json);
+}
+
+void test_send_read_mam_bundle(void) {
+  mam_api_t mam;
+  tryte_t chid[MAM_CHANNEL_ID_TRYTE_SIZE] = {}, msg_id[NUM_TRYTES_MAM_MSG_ID] = {};
+  mam_psk_t_set_t psks = NULL;
+  mam_ntru_pk_t_set_t ntru_pks = NULL;
+
+  bundle_transactions_t* bundle = NULL;
+  bundle_transactions_new(&bundle);
+
+  ta_send_mam_req_t* req = send_mam_req_new();
+  const char* json_template = "{\"x-api-key\":\"" TEST_TOKEN "\",\"data\":{\"seed\":\"%s\",\"ch_mss_depth\":" STR(
+      TEST_CH_DEPTH) ",\"message\":\"" TEST_PAYLOAD "\"}, \"protocol\":\"MAM_V1\"}";
+  char seed[NUM_TRYTES_ADDRESS + 1] = {};
+  gen_rand_seed(seed);
+  const int len = strlen(json_template) + NUM_TRYTES_ADDRESS;
+  char* json_result = NULL;
+  char* json = (char*)malloc(sizeof(char) * len);
+  snprintf(json, len, json_template, seed);
+  TEST_ASSERT_EQUAL_INT32(SC_OK, send_mam_req_deserialize(json, req));
+
+  send_mam_data_mam_v1_t* data = (send_mam_data_mam_v1_t*)req->data;
+
+  // Creating MAM API
+  TEST_ASSERT_EQUAL_INT32(SC_OK, ta_mam_init(&mam, &ta_core.iota_conf, data->seed));
+  mam_mss_key_status_t key_status;
+  // Create epid merkle tree and find the smallest unused secret key.
+  // Write both Header and Pakcet into one single bundle.
+  TEST_ASSERT_EQUAL_INT32(
+      SC_OK, ta_mam_written_msg_to_bundle(&ta_core.iota_service, &mam, data->ch_mss_depth, chid, psks, ntru_pks,
+                                          data->message, &bundle, msg_id, &key_status));
+
+  TEST_ASSERT_EQUAL_INT32(SC_OK, ta_mam_api_bundle_read(&mam, bundle, &json_result));
+
+  TEST_ASSERT_EQUAL_STRING(TEST_PAYLOAD, json_result);
+
+  free(json_result);
+  send_mam_req_free(&req);
+  bundle_transactions_free(&bundle);
+  TEST_ASSERT_EQUAL_INT32(RC_OK, mam_api_destroy(&mam));
+  free(json);
+}
+
+void test_write_until_next_channel(void) {
+  const int channel_leaf_msg_num = (1 << TEST_CH_DEPTH) - 1;
+  const int complete_ch_num = 1, dangling_msg_num = 1;
+  const int msg_num = complete_ch_num * channel_leaf_msg_num + dangling_msg_num;
+  ta_send_mam_res_t* mam_res_array[msg_num];
+  char seed[NUM_TRYTES_ADDRESS + 1] = {};
+  const char* json_template_send = "{\"x-api-key\":\"" TEST_TOKEN "\",\"data\":{\"seed\":\"%s\",\"ch_mss_depth\":" STR(
+      TEST_CH_DEPTH) ",\"message\":\"%s:%d\"}, \"protocol\":\"MAM_V1\"}";
+  const char payload[] = "This is test payload number";
+  const int len = strlen(json_template_send) + NUM_TRYTES_ADDRESS + strlen(payload) + 2;
+  gen_rand_seed(seed);
+  for (int i = 0; i < msg_num; i++) {
+    char* json_result;
+    mam_res_array[i] = send_mam_res_new();
+    char* json = (char*)malloc(sizeof(char) * len);
+    snprintf(json, len, json_template_send, seed, payload, i);
+    TEST_ASSERT_EQUAL_INT32(
+        SC_OK, api_send_mam_message(&ta_core.ta_conf, &ta_core.iota_conf, &ta_core.iota_service, json, &json_result));
+    send_mam_res_deserialize(json_result, mam_res_array[i]);
+    free(json);
+    free(json_result);
+  }
+
+  // The current chid1 should be equal to the chid of next channel. Element with index `channel_leaf_msg_num` is the
+  // last element of the current channel.
+  TEST_ASSERT_EQUAL_STRING(mam_res_array[channel_leaf_msg_num]->chid, mam_res_array[channel_leaf_msg_num - 1]->chid1);
+
+  const char* json_template_recv = "{\"data_id\":{\"chid\":\"%s\"},\"protocol\":\"MAM_V1\"}";
+  const int json_size = sizeof(char) * (strlen(json_template_recv) + NUM_TRYTES_ADDRESS);
+  for (int i = 0; i < complete_ch_num + 1; i++) {
+    char *json = NULL, *json_result = NULL;
+    json = (char*)malloc(json_size);
+    snprintf(json, json_size, json_template_recv, mam_res_array[i * channel_leaf_msg_num]->chid);
+    TEST_ASSERT_EQUAL_INT32(SC_OK, api_recv_mam_message(&ta_core.iota_conf, &ta_core.iota_service, json, &json_result));
+    for (int j = i * channel_leaf_msg_num; j < ((i + 1) * channel_leaf_msg_num) && (j < msg_num); j++) {
+      // Check whether a message exist under assigning channel ID.
+      char substr[strlen(payload) + 3];
+      snprintf(substr, strlen(payload) + 3, "%s:%d", payload, j);
+      TEST_ASSERT_TRUE(strstr(json_result, substr));
+    }
+
+    // Deserialize the response, and compare whether the payload list contains correct number of message under a certain
+    // channel ID.
+    int len = 0;
+    cJSON *json_obj = cJSON_Parse(json_result), *current_obj = NULL;
+    cJSON* json_item = cJSON_GetObjectItemCaseSensitive(json_obj, "payload");
+    TEST_ASSERT_TRUE(cJSON_IsArray(json_item));
+    cJSON_ArrayForEach(current_obj, json_item) {
+      if (current_obj->valuestring != NULL) {
+        len++;
+      }
+    }
+    if (i == complete_ch_num) {
+      TEST_ASSERT_EQUAL_INT16(dangling_msg_num, len);
+    } else {
+      TEST_ASSERT_EQUAL_INT16(channel_leaf_msg_num, len);
+    }
+    cJSON_Delete(json_obj);
+    free(json);
+    free(json_result);
+  }
+
+  for (int i = 0; i < msg_num; i++) {
+    send_mam_res_free(&(mam_res_array[i]));
+  }
 }
 
 int main(int argc, char* argv[]) {
-  srand(time(NULL));
-
   UNITY_BEGIN();
+  rand_seed_init();
 
   // Initialize logger
   if (ta_logger_init() != SC_OK) {
     return EXIT_FAILURE;
   }
+  apis_logger_init();
+  ta_mam_logger_init();
+  cc_logger_init();
+  pow_logger_init();
+  timer_logger_init();
 
   ta_core_default_init(&ta_core);
   ta_core_cli_init(&ta_core, argc, argv);
   ta_core_set(&ta_core);
 
   printf("Total samples for each API test: %d\n", TEST_COUNT);
+  RUN_TEST(test_send_mam_message);
   RUN_TEST(test_receive_mam_message);
-
+  RUN_TEST(test_send_read_mam_bundle);
+  RUN_TEST(test_write_until_next_channel);
   ta_core_destroy(&ta_core);
   return UNITY_END();
 }

--- a/tests/unit-test/test_serializer.c
+++ b/tests/unit-test/test_serializer.c
@@ -227,7 +227,6 @@ void test_recv_mam_message_request_psk_deserialize(void) {
   recv_mam_data_id_mam_v1_t* data_id = (recv_mam_data_id_mam_v1_t*)req->data_id;
   TEST_ASSERT_NULL(data_id->bundle_hash);
   TEST_ASSERT_EQUAL_STRING(TEST_CHID, data_id->chid);
-  TEST_ASSERT_EQUAL_STRING(TEST_EPID, data_id->epid);
   TEST_ASSERT_EQUAL_STRING(TEST_MSG_ID, data_id->msg_id);
 
   recv_mam_key_mam_v1_t* key = (recv_mam_key_mam_v1_t*)req->key;
@@ -247,7 +246,6 @@ void test_recv_mam_message_request_ntru_deserialize(void) {
   recv_mam_data_id_mam_v1_t* data_id = (recv_mam_data_id_mam_v1_t*)req->data_id;
   TEST_ASSERT_EQUAL_STRING(TEST_BUNDLE_HASH, data_id->bundle_hash);
   TEST_ASSERT_NULL(data_id->chid);
-  TEST_ASSERT_NULL(data_id->epid);
   TEST_ASSERT_NULL(data_id->msg_id);
 
   recv_mam_key_mam_v1_t* key = (recv_mam_key_mam_v1_t*)req->key;
@@ -284,8 +282,6 @@ void test_send_mam_message_response_serialize(void) {
                      "\","
                      "\"chid\":\"" TRYTES_81_2
                      "\","
-                     "\"epid\":\"" TRYTES_81_3
-                     "\","
                      "\"msg_id\":\"" TEST_MSG_ID
                      "\","
                      "\"announcement_bundle_hash\":\"" ADDRESS_1
@@ -296,7 +292,6 @@ void test_send_mam_message_response_serialize(void) {
 
   send_mam_res_set_bundle_hash(res, (tryte_t*)TRYTES_81_1);
   send_mam_res_set_channel_id(res, (tryte_t*)TRYTES_81_2);
-  send_mam_res_set_endpoint_id(res, (tryte_t*)TRYTES_81_3);
   send_mam_res_set_msg_id(res, (tryte_t*)TEST_MSG_ID);
   send_mam_res_set_announcement_bundle_hash(res, (tryte_t*)ADDRESS_1);
   send_mam_res_set_chid1(res, (tryte_t*)ADDRESS_2);
@@ -313,8 +308,6 @@ void test_send_mam_message_response_deserialize(void) {
                      "\","
                      "\"chid\":\"" TRYTES_81_2
                      "\","
-                     "\"epid\":\"" TRYTES_81_3
-                     "\","
                      "\"msg_id\":\"" TEST_MSG_ID
                      "\","
                      "\"announcement_bundle_hash\":\"" ADDRESS_1
@@ -326,7 +319,6 @@ void test_send_mam_message_response_deserialize(void) {
 
   TEST_ASSERT_EQUAL_MEMORY(TRYTES_81_1, res->bundle_hash, NUM_TRYTES_HASH);
   TEST_ASSERT_EQUAL_MEMORY(TRYTES_81_2, res->chid, NUM_TRYTES_HASH);
-  TEST_ASSERT_EQUAL_MEMORY(TRYTES_81_3, res->epid, NUM_TRYTES_HASH);
   TEST_ASSERT_EQUAL_MEMORY(TEST_MSG_ID, res->msg_id, MAM_MSG_ID_SIZE / 3);
   TEST_ASSERT_EQUAL_MEMORY(ADDRESS_1, res->announcement_bundle_hash, NUM_TRYTES_HASH);
   TEST_ASSERT_EQUAL_MEMORY(ADDRESS_2, res->chid1, NUM_TRYTES_HASH);
@@ -511,9 +503,9 @@ int main(void) {
   RUN_TEST(test_serialize_ta_find_transactions_obj_by_tag);
   RUN_TEST(test_recv_mam_message_request_psk_deserialize);
   RUN_TEST(test_recv_mam_message_request_ntru_deserialize);
+  RUN_TEST(test_send_mam_message_request_deserialize);
   RUN_TEST(test_send_mam_message_response_serialize);
   RUN_TEST(test_send_mam_message_response_deserialize);
-  RUN_TEST(test_send_mam_message_request_deserialize);
   RUN_TEST(test_deserialize_ta_send_trytes_req);
   RUN_TEST(test_serialize_ta_send_trytes_res);
 #ifdef MQTT_ENABLE


### PR DESCRIPTION
We planned to send mam message on mam endpoint private keys.
However, sending with channel private keys are much easier to
implement, so `api_send_mam_message()` has been refactored.
It would send message with channel private keys.
Once there is only one private left, then this API will automatically
send the announcemnet for the next channel. Related tests have been
implemented as well.

Fix #513