### PR TITLE
fix(core): Correct the usage of mutex lock for iota_client_service_t

### DIFF
--- a/accelerator/config.c
+++ b/accelerator/config.c
@@ -217,7 +217,10 @@ status_t ta_core_default_init(ta_core_t* const core) {
 #ifdef DB_ENABLE
   db_client_service_t* const db_service = &core->db_service;
 #endif
-
+  if (lock_handle_init(&core->iota_service_lock)) {
+    ta_log_error("Fail to init IOTA service mutex lock\n");
+    return SC_CONF_LOCK_INIT;
+  }
   ta_log_info("Initializing TA information\n");
   ta_conf->version = TA_VERSION;
   ta_conf->host = TA_HOST;
@@ -436,7 +439,9 @@ exit:
 void ta_core_destroy(ta_core_t* const core) {
   ta_log_info("Destroying IRI connection\n");
   iota_client_extended_destroy();
+  lock_handle_destroy(&core->iota_service_lock);
   iota_client_core_destroy(&core->iota_service);
+
 #ifdef DB_ENABLE
   ta_log_info("Destroying DB connection\n");
   db_client_service_free(&core->db_service);

--- a/accelerator/config.h
+++ b/accelerator/config.h
@@ -21,6 +21,7 @@
 #endif
 #include "common/logger.h"
 #include "utils/cache/cache.h"
+#include "utils/handles/lock.h"
 
 #define FILE_PATH_SIZE 128
 
@@ -99,6 +100,7 @@ typedef struct ta_core_s {
   ta_cache_t cache;                   /**< redis configiuration structure */
   iota_config_t iota_conf;            /**< iota configuration structure */
   iota_client_service_t iota_service; /**< iota connection structure */
+  lock_handle_t iota_service_lock;    /**< mutex lock for iota_service */
 #ifdef DB_ENABLE
   db_client_service_t db_service; /**< db connection structure */
 #endif

--- a/accelerator/core/apis.h
+++ b/accelerator/core/apis.h
@@ -96,7 +96,7 @@ status_t apis_lock_destroy();
  * - non-zero on error
  */
 status_t api_generate_address(const iota_config_t* const iconf, const iota_client_service_t* const service,
-                              char** json_result);
+                              lock_handle_t* service_lock, char** json_result);
 
 /**
  * @brief Get trunk and branch transactions
@@ -113,7 +113,7 @@ status_t api_generate_address(const iota_config_t* const iconf, const iota_clien
  * - non-zero on error
  */
 status_t api_get_tips_pair(const iota_config_t* const iconf, const iota_client_service_t* const service,
-                           char** json_result);
+                           lock_handle_t* service_lock, char** json_result);
 
 /**
  * @brief Get list of all tips from IRI node.
@@ -128,7 +128,7 @@ status_t api_get_tips_pair(const iota_config_t* const iconf, const iota_client_s
  * - SC_OK on success
  * - non-zero on error
  */
-status_t api_get_tips(const iota_client_service_t* const service, char** json_result);
+status_t api_get_tips(const iota_client_service_t* const service, lock_handle_t* service_lock, char** json_result);
 
 /**
  * @brief Receive a MAM message.
@@ -144,7 +144,7 @@ status_t api_get_tips(const iota_client_service_t* const service, char** json_re
  * - non-zero on error
  */
 status_t api_recv_mam_message(const iota_config_t* const iconf, const iota_client_service_t* const service,
-                              const char* const chid, char** json_result);
+                              lock_handle_t* service_lock, const char* const chid, char** json_result);
 
 /**
  * @brief Send a MAM message with given Payload.
@@ -164,8 +164,8 @@ status_t api_recv_mam_message(const iota_config_t* const iconf, const iota_clien
  * - non-zero on error
  */
 status_t api_mam_send_message(const ta_config_t* const info, const iota_config_t* const iconf,
-                              const iota_client_service_t* const service, char const* const payload,
-                              char** json_result);
+                              const iota_client_service_t* const service, lock_handle_t* service_lock,
+                              char const* const payload, char** json_result);
 
 /**
  * @brief Send transfer to tangle.
@@ -198,8 +198,8 @@ status_t api_send_transfer(const ta_core_t* const core, const char* const obj, c
  * - SC_OK on success
  * - non-zero on error
  */
-status_t api_find_transaction_object_single(const iota_client_service_t* const service, const char* const obj,
-                                            char** json_result);
+status_t api_find_transaction_object_single(const iota_client_service_t* const service, lock_handle_t* service_lock,
+                                            const char* const obj, char** json_result);
 
 /**
  * @brief Return transaction object with given transaction hash.
@@ -215,8 +215,8 @@ status_t api_find_transaction_object_single(const iota_client_service_t* const s
  * - SC_OK on success
  * - non-zero on error
  */
-status_t api_find_transaction_objects(const iota_client_service_t* const service, const char* const obj,
-                                      char** json_result);
+status_t api_find_transaction_objects(const iota_client_service_t* const service, lock_handle_t* service_lock,
+                                      const char* const obj, char** json_result);
 
 /**
  * @brief Return list of transaction hash with given tag.
@@ -233,8 +233,8 @@ status_t api_find_transaction_objects(const iota_client_service_t* const service
  * - SC_OK on success
  * - non-zero on error
  */
-status_t api_find_transactions_by_tag(const iota_client_service_t* const service, const char* const obj,
-                                      char** json_result);
+status_t api_find_transactions_by_tag(const iota_client_service_t* const service, lock_handle_t* service_lock,
+                                      const char* const obj, char** json_result);
 
 /**
  * @brief Return list of transaction objects with given tag.
@@ -251,8 +251,8 @@ status_t api_find_transactions_by_tag(const iota_client_service_t* const service
  * - SC_OK on success
  * - non-zero on error
  */
-status_t api_find_transactions_obj_by_tag(const iota_client_service_t* const service, const char* const obj,
-                                          char** json_result);
+status_t api_find_transactions_obj_by_tag(const iota_client_service_t* const service, lock_handle_t* service_lock,
+                                          const char* const obj, char** json_result);
 
 /**
  * @brief Attach trytes to Tangle and return transaction hashes
@@ -273,7 +273,8 @@ status_t api_find_transactions_obj_by_tag(const iota_client_service_t* const ser
  * - non-zero on error
  */
 status_t api_send_trytes(const ta_config_t* const info, const iota_config_t* const iconf,
-                         const iota_client_service_t* const service, const char* const obj, char** json_result);
+                         const iota_client_service_t* const service, lock_handle_t* service_lock, const char* const obj,
+                         char** json_result);
 
 /**
  * @brief Check the connection status between tangle-accelerator and IRI host.
@@ -285,7 +286,8 @@ status_t api_send_trytes(const ta_config_t* const info, const iota_config_t* con
  * - SC_OK on success
  * - non-zero on error
  */
-status_t api_get_iri_status(const iota_client_service_t* const service, char** json_result);
+status_t api_get_iri_status(const iota_client_service_t* const service, lock_handle_t* service_lock,
+                            char** json_result);
 
 #ifdef DB_ENABLE
 /**
@@ -303,7 +305,7 @@ status_t api_get_iri_status(const iota_client_service_t* const service, char** j
  * - SC_OK on success
  * - non-zero on error
  */
-status_t api_find_transactions_by_id(const iota_client_service_t* const iota_service,
+status_t api_find_transactions_by_id(const iota_client_service_t* const iota_service, lock_handle_t* iota_service_lock,
                                      const db_client_service_t* const db_service, const char* const obj,
                                      char** json_result);
 

--- a/accelerator/core/proxy_apis.c
+++ b/accelerator/core/proxy_apis.c
@@ -8,13 +8,11 @@
 
 #include "proxy_apis.h"
 #include "utils/char_buffer_str.h"
-#include "utils/handles/lock.h"
 #include "utils/hash_algo_djb2.h"
 
 #define PROXY_APIS_LOGGER "proxy_apis"
 
 static logger_id_t logger_id;
-static lock_handle_t cjson_lock;
 
 void proxy_apis_logger_init() { logger_id = logger_helper_enable(PROXY_APIS_LOGGER, LOGGER_DEBUG, true); }
 
@@ -28,22 +26,8 @@ int proxy_apis_logger_release() {
   return 0;
 }
 
-status_t proxy_apis_lock_init() {
-  if (lock_handle_init(&cjson_lock)) {
-    return SC_CONF_LOCK_INIT;
-  }
-  return SC_OK;
-}
-
-status_t proxy_apis_lock_destroy() {
-  if (lock_handle_destroy(&cjson_lock)) {
-    return SC_CONF_LOCK_DESTROY;
-  }
-  return SC_OK;
-}
-
-static status_t api_check_consistency(const iota_client_service_t* const service, const char* const obj,
-                                      char** json_result) {
+static status_t api_check_consistency(const iota_client_service_t* const service, lock_handle_t* service_lock,
+                                      const char* const obj, char** json_result) {
   status_t ret = SC_OK;
   check_consistency_req_t* req = check_consistency_req_new();
   check_consistency_res_t* res = check_consistency_res_new();
@@ -54,23 +38,23 @@ static status_t api_check_consistency(const iota_client_service_t* const service
     goto done;
   }
 
-  lock_handle_lock(&cjson_lock);
+  lock_handle_lock(service_lock);
   if (service->serializer.vtable.check_consistency_deserialize_request(obj, req) != RC_OK) {
-    lock_handle_unlock(&cjson_lock);
+    lock_handle_unlock(service_lock);
     ret = SC_CCLIENT_JSON_PARSE;
     ta_log_error("%s\n", "SC_CCLIENT_JSON_PARSE");
     goto done;
   }
-  lock_handle_unlock(&cjson_lock);
+  lock_handle_unlock(service_lock);
 
-  lock_handle_lock(&cjson_lock);
+  lock_handle_lock(service_lock);
   if (iota_client_check_consistency(service, req, res) != RC_OK) {
-    lock_handle_unlock(&cjson_lock);
+    lock_handle_unlock(service_lock);
     ret = SC_CCLIENT_FAILED_RESPONSE;
     ta_log_error("%s\n", "SC_CCLIENT_FAILED_RESPONSE");
     goto done;
   }
-  lock_handle_unlock(&cjson_lock);
+  lock_handle_unlock(service_lock);
 
   if (service->serializer.vtable.check_consistency_serialize_response(res, res_buff) != RC_OK) {
     ret = SC_CCLIENT_JSON_PARSE;
@@ -87,8 +71,8 @@ done:
   return ret;
 }
 
-static status_t api_find_transactions(const iota_client_service_t* const service, const char* const obj,
-                                      char** json_result) {
+static status_t api_find_transactions(const iota_client_service_t* const service, lock_handle_t* service_lock,
+                                      const char* const obj, char** json_result) {
   status_t ret = SC_OK;
   find_transactions_req_t* req = find_transactions_req_new();
   find_transactions_res_t* res = find_transactions_res_new();
@@ -98,23 +82,23 @@ static status_t api_find_transactions(const iota_client_service_t* const service
     ta_log_error("%s\n", "SC_TA_OOM");
     goto done;
   }
-  lock_handle_lock(&cjson_lock);
+  lock_handle_lock(service_lock);
   if (service->serializer.vtable.find_transactions_deserialize_request(obj, req) != RC_OK) {
-    lock_handle_unlock(&cjson_lock);
+    lock_handle_unlock(service_lock);
     ret = SC_CCLIENT_JSON_PARSE;
     ta_log_error("%s\n", "SC_CCLIENT_JSON_PARSE");
     goto done;
   }
-  lock_handle_unlock(&cjson_lock);
+  lock_handle_unlock(service_lock);
 
-  lock_handle_lock(&cjson_lock);
+  lock_handle_lock(service_lock);
   if (iota_client_find_transactions(service, req, res) != RC_OK) {
-    lock_handle_unlock(&cjson_lock);
+    lock_handle_unlock(service_lock);
     ret = SC_CCLIENT_FAILED_RESPONSE;
     ta_log_error("%s\n", "SC_CCLIENT_FAILED_RESPONSE");
     goto done;
   }
-  lock_handle_unlock(&cjson_lock);
+  lock_handle_unlock(service_lock);
 
   if (service->serializer.vtable.find_transactions_serialize_response(res, res_buff) != RC_OK) {
     ret = SC_CCLIENT_JSON_PARSE;
@@ -131,8 +115,8 @@ done:
   return ret;
 }
 
-static status_t api_get_balances(const iota_client_service_t* const service, const char* const obj,
-                                 char** json_result) {
+static status_t api_get_balances(const iota_client_service_t* const service, lock_handle_t* service_lock,
+                                 const char* const obj, char** json_result) {
   status_t ret = SC_OK;
   get_balances_req_t* req = get_balances_req_new();
   get_balances_res_t* res = get_balances_res_new();
@@ -143,23 +127,23 @@ static status_t api_get_balances(const iota_client_service_t* const service, con
     goto done;
   }
 
-  lock_handle_lock(&cjson_lock);
+  lock_handle_lock(service_lock);
   if (service->serializer.vtable.get_balances_deserialize_request(obj, req) != RC_OK) {
-    lock_handle_unlock(&cjson_lock);
+    lock_handle_unlock(service_lock);
     ret = SC_CCLIENT_JSON_PARSE;
     ta_log_error("%s\n", "SC_CCLIENT_JSON_PARSE");
     goto done;
   }
-  lock_handle_unlock(&cjson_lock);
+  lock_handle_unlock(service_lock);
 
-  lock_handle_lock(&cjson_lock);
+  lock_handle_lock(service_lock);
   if (iota_client_get_balances(service, req, res) != RC_OK) {
-    lock_handle_unlock(&cjson_lock);
+    lock_handle_unlock(service_lock);
     ret = SC_CCLIENT_FAILED_RESPONSE;
     ta_log_error("%s\n", "SC_CCLIENT_FAILED_RESPONSE");
     goto done;
   }
-  lock_handle_unlock(&cjson_lock);
+  lock_handle_unlock(service_lock);
 
   if (service->serializer.vtable.get_balances_serialize_response(res, res_buff) != RC_OK) {
     ret = SC_CCLIENT_JSON_PARSE;
@@ -176,8 +160,8 @@ done:
   return ret;
 }
 
-static status_t api_get_inclusion_states(const iota_client_service_t* const service, const char* const obj,
-                                         char** json_result) {
+static status_t api_get_inclusion_states(const iota_client_service_t* const service, lock_handle_t* service_lock,
+                                         const char* const obj, char** json_result) {
   status_t ret = SC_OK;
   get_inclusion_states_req_t* req = get_inclusion_states_req_new();
   get_inclusion_states_res_t* res = get_inclusion_states_res_new();
@@ -188,23 +172,23 @@ static status_t api_get_inclusion_states(const iota_client_service_t* const serv
     goto done;
   }
 
-  lock_handle_lock(&cjson_lock);
+  lock_handle_lock(service_lock);
   if (service->serializer.vtable.get_inclusion_states_deserialize_request(obj, req) != RC_OK) {
-    lock_handle_unlock(&cjson_lock);
+    lock_handle_unlock(service_lock);
     ret = SC_CCLIENT_JSON_PARSE;
     ta_log_error("%s\n", "SC_CCLIENT_JSON_PARSE");
     goto done;
   }
-  lock_handle_unlock(&cjson_lock);
+  lock_handle_unlock(service_lock);
 
-  lock_handle_lock(&cjson_lock);
+  lock_handle_lock(service_lock);
   if (iota_client_get_inclusion_states(service, req, res) != RC_OK) {
-    lock_handle_unlock(&cjson_lock);
+    lock_handle_unlock(service_lock);
     ret = SC_CCLIENT_FAILED_RESPONSE;
     ta_log_error("%s\n", "SC_CCLIENT_FAILED_RESPONSE");
     goto done;
   }
-  lock_handle_unlock(&cjson_lock);
+  lock_handle_unlock(service_lock);
 
   if (service->serializer.vtable.get_inclusion_states_serialize_response(res, res_buff) != RC_OK) {
     ret = SC_CCLIENT_JSON_PARSE;
@@ -221,7 +205,8 @@ done:
   return ret;
 }
 
-static status_t api_get_node_info(const iota_client_service_t* const service, char** json_result) {
+static status_t api_get_node_info(const iota_client_service_t* const service, lock_handle_t* service_lock,
+                                  char** json_result) {
   status_t ret = SC_OK;
   get_node_info_res_t* res = get_node_info_res_new();
   char_buffer_t* res_buff = char_buffer_new();
@@ -231,14 +216,14 @@ static status_t api_get_node_info(const iota_client_service_t* const service, ch
     goto done;
   }
 
-  lock_handle_lock(&cjson_lock);
+  lock_handle_lock(service_lock);
   if (iota_client_get_node_info(service, res) != RC_OK) {
-    lock_handle_unlock(&cjson_lock);
+    lock_handle_unlock(service_lock);
     ret = SC_CCLIENT_FAILED_RESPONSE;
     ta_log_error("%s\n", "SC_CCLIENT_FAILED_RESPONSE");
     goto done;
   }
-  lock_handle_unlock(&cjson_lock);
+  lock_handle_unlock(service_lock);
 
   if (service->serializer.vtable.get_node_info_serialize_response(res, res_buff) != RC_OK) {
     ret = SC_CCLIENT_JSON_PARSE;
@@ -254,7 +239,8 @@ done:
   return ret;
 }
 
-static status_t api_get_trytes(const iota_client_service_t* const service, const char* const obj, char** json_result) {
+static status_t api_get_trytes(const iota_client_service_t* const service, lock_handle_t* service_lock,
+                               const char* const obj, char** json_result) {
   status_t ret = SC_OK;
   get_trytes_req_t* req = get_trytes_req_new();
   get_trytes_res_t* res = get_trytes_res_new();
@@ -265,23 +251,23 @@ static status_t api_get_trytes(const iota_client_service_t* const service, const
     goto done;
   }
 
-  lock_handle_lock(&cjson_lock);
+  lock_handle_lock(service_lock);
   if (service->serializer.vtable.get_trytes_deserialize_request(obj, req) != RC_OK) {
-    lock_handle_unlock(&cjson_lock);
+    lock_handle_unlock(service_lock);
     ret = SC_CCLIENT_JSON_PARSE;
     ta_log_error("%s\n", "SC_CCLIENT_JSON_PARSE");
     goto done;
   }
-  lock_handle_unlock(&cjson_lock);
+  lock_handle_unlock(service_lock);
 
-  lock_handle_lock(&cjson_lock);
+  lock_handle_lock(service_lock);
   if (iota_client_get_trytes(service, req, res) != RC_OK) {
-    lock_handle_unlock(&cjson_lock);
+    lock_handle_unlock(service_lock);
     ret = SC_CCLIENT_FAILED_RESPONSE;
     ta_log_error("%s\n", "SC_CCLIENT_FAILED_RESPONSE");
     goto done;
   }
-  lock_handle_unlock(&cjson_lock);
+  lock_handle_unlock(service_lock);
 
   if (service->serializer.vtable.get_trytes_serialize_response(res, res_buff) != RC_OK) {
     ret = SC_CCLIENT_JSON_PARSE;
@@ -299,7 +285,7 @@ done:
 }
 
 status_t proxy_api_wrapper(const ta_config_t* const iconf, const iota_client_service_t* const service,
-                           const char* const obj, char** json_result) {
+                           lock_handle_t* service_lock, const char* const obj, char** json_result) {
   status_t ret = SC_OK;
   if (iconf->proxy_passthrough) {
     char_buffer_t* res_buff = char_buffer_new();
@@ -335,22 +321,22 @@ status_t proxy_api_wrapper(const ta_config_t* const iconf, const iota_client_ser
     // With DJB2 hash function we could reduce the amount of string comparisons and deterministic execution time
     switch (hash_algo_djb2(command)) {
       case H_checkConsistency:
-        ret = api_check_consistency(service, obj, json_result);
+        ret = api_check_consistency(service, service_lock, obj, json_result);
         break;
       case H_findTransactions:
-        ret = api_find_transactions(service, obj, json_result);
+        ret = api_find_transactions(service, service_lock, obj, json_result);
         break;
       case H_getBalances:
-        ret = api_get_balances(service, obj, json_result);
+        ret = api_get_balances(service, service_lock, obj, json_result);
         break;
       case H_getInclusionStates:
-        ret = api_get_inclusion_states(service, obj, json_result);
+        ret = api_get_inclusion_states(service, service_lock, obj, json_result);
         break;
       case H_getNodeInfo:
-        ret = api_get_node_info(service, json_result);
+        ret = api_get_node_info(service, service_lock, json_result);
         break;
       case H_getTrytes:
-        ret = api_get_trytes(service, obj, json_result);
+        ret = api_get_trytes(service, service_lock, obj, json_result);
         break;
 
       default:

--- a/accelerator/core/proxy_apis.h
+++ b/accelerator/core/proxy_apis.h
@@ -71,7 +71,7 @@ status_t proxy_apis_lock_destroy();
  * - non-zero on error
  */
 status_t proxy_api_wrapper(const ta_config_t* const iconf, const iota_client_service_t* const service,
-                           const char* const obj, char** json_result);
+                           lock_handle_t* service_lock, const char* const obj, char** json_result);
 
 #ifdef __cplusplus
 }

--- a/accelerator/main.c
+++ b/accelerator/main.c
@@ -71,12 +71,6 @@ int main(int argc, char* argv[]) {
   pthread_t thread;
   pthread_create(&thread, NULL, check_iri_connection, &ta_core);
 
-  // Initialize apis cJSON lock
-  if (apis_lock_init() != SC_OK) {
-    ta_log_error("Lock initialization failed %s.\n", MAIN_LOGGER);
-    return EXIT_FAILURE;
-  }
-
   if (ta_http_init(&ta_http, &ta_core) != SC_OK) {
     ta_log_error("HTTP initialization failed %s.\n", MAIN_LOGGER);
     return EXIT_FAILURE;
@@ -115,11 +109,6 @@ int main(int argc, char* argv[]) {
   }
 
 cleanup:
-  log_info(logger_id, "Destroying API lock\n");
-  if (apis_lock_destroy() != SC_OK) {
-    ta_log_error("Destroying api lock failed %s.\n", MAIN_LOGGER);
-    return EXIT_FAILURE;
-  }
   log_info(logger_id, "Destroying TA configurations\n");
   ta_core_destroy(&ta_core);
 

--- a/connectivity/http/http.c
+++ b/connectivity/http/http.c
@@ -75,7 +75,7 @@ static inline int process_find_txns_obj_by_tag_request(ta_http_t *const http, ch
   char *tag = NULL;
   ret = ta_get_url_parameter(url, 1, &tag);
   if (ret == SC_OK) {
-    ret = api_find_transactions_obj_by_tag(&http->core->iota_service, tag, out);
+    ret = api_find_transactions_obj_by_tag(&http->core->iota_service, &http->core->iota_service_lock, tag, out);
   }
   free(tag);
   return set_response_content(ret, out);
@@ -86,7 +86,7 @@ static inline int process_find_txns_by_tag_request(ta_http_t *const http, char c
   char *tag = NULL;
   ret = ta_get_url_parameter(url, 1, &tag);
   if (ret == SC_OK) {
-    ret = api_find_transactions_by_tag(&http->core->iota_service, tag, out);
+    ret = api_find_transactions_by_tag(&http->core->iota_service, &http->core->iota_service_lock, tag, out);
   }
   free(tag);
   return set_response_content(ret, out);
@@ -94,7 +94,7 @@ static inline int process_find_txns_by_tag_request(ta_http_t *const http, char c
 
 static inline int process_generate_address_request(ta_http_t *const http, char **const out) {
   status_t ret;
-  ret = api_generate_address(&http->core->iota_conf, &http->core->iota_service, out);
+  ret = api_generate_address(&http->core->iota_conf, &http->core->iota_service, &http->core->iota_service_lock, out);
   return set_response_content(ret, out);
 }
 
@@ -103,7 +103,7 @@ static inline int process_find_txn_obj_single_request(ta_http_t *const http, cha
   char *hash = NULL;
   ret = ta_get_url_parameter(url, 1, &hash);
   if (ret == SC_OK) {
-    ret = api_find_transaction_object_single(&http->core->iota_service, hash, out);
+    ret = api_find_transaction_object_single(&http->core->iota_service, &http->core->iota_service_lock, hash, out);
   }
   free(hash);
   return set_response_content(ret, out);
@@ -111,19 +111,19 @@ static inline int process_find_txn_obj_single_request(ta_http_t *const http, cha
 
 static inline int process_find_txn_obj_request(ta_http_t *const http, char const *const payload, char **const out) {
   status_t ret;
-  ret = api_find_transaction_objects(&http->core->iota_service, payload, out);
+  ret = api_find_transaction_objects(&http->core->iota_service, &http->core->iota_service_lock, payload, out);
   return set_response_content(ret, out);
 }
 
 static inline int process_get_tips_pair_request(ta_http_t *const http, char **const out) {
   status_t ret;
-  ret = api_get_tips_pair(&http->core->iota_conf, &http->core->iota_service, out);
+  ret = api_get_tips_pair(&http->core->iota_conf, &http->core->iota_service, &http->core->iota_service_lock, out);
   return set_response_content(ret, out);
 }
 
 static inline int process_get_tips_request(ta_http_t *const http, char **const out) {
   status_t ret;
-  ret = api_get_tips(&http->core->iota_service, out);
+  ret = api_get_tips(&http->core->iota_service, &http->core->iota_service_lock, out);
   return set_response_content(ret, out);
 }
 
@@ -138,7 +138,8 @@ static inline int process_recv_mam_msg_request(ta_http_t *const http, char const
   char *bundle = NULL;
   ret = ta_get_url_parameter(url, 1, &bundle);
   if (ret == SC_OK) {
-    ret = api_recv_mam_message(&http->core->iota_conf, &http->core->iota_service, bundle, out);
+    ret = api_recv_mam_message(&http->core->iota_conf, &http->core->iota_service, &http->core->iota_service_lock,
+                               bundle, out);
   }
   free(bundle);
   return set_response_content(ret, out);
@@ -146,7 +147,7 @@ static inline int process_recv_mam_msg_request(ta_http_t *const http, char const
 
 static inline int process_get_iri_status(ta_http_t *const http, char **const out) {
   status_t ret;
-  ret = api_get_iri_status(&http->core->iota_service, out);
+  ret = api_get_iri_status(&http->core->iota_service, &http->core->iota_service_lock, out);
   return set_response_content(ret, out);
 }
 
@@ -182,7 +183,8 @@ static inline int process_find_transaction_by_id_request(ta_http_t *const http, 
   char *buf = NULL;
   ret = ta_get_url_parameter(url, 2, &buf);
   if (ret == SC_OK) {
-    ret = api_find_transactions_by_id(&http->core->iota_service, &http->core->db_service, buf, out);
+    ret = api_find_transactions_by_id(&http->core->iota_service, &http->core->iota_service_lock,
+                                      &http->core->db_service, buf, out);
   }
   free(buf);
   return set_response_content(ret, out);
@@ -191,13 +193,15 @@ static inline int process_find_transaction_by_id_request(ta_http_t *const http, 
 
 static inline int process_mam_send_msg_request(ta_http_t *const http, char const *const payload, char **const out) {
   status_t ret;
-  ret = api_mam_send_message(&http->core->ta_conf, &http->core->iota_conf, &http->core->iota_service, payload, out);
+  ret = api_mam_send_message(&http->core->ta_conf, &http->core->iota_conf, &http->core->iota_service,
+                             &http->core->iota_service_lock, payload, out);
   return set_response_content(ret, out);
 }
 
 static inline int process_send_trytes_request(ta_http_t *const http, char const *const payload, char **const out) {
   status_t ret;
-  ret = api_send_trytes(&http->core->ta_conf, &http->core->iota_conf, &http->core->iota_service, payload, out);
+  ret = api_send_trytes(&http->core->ta_conf, &http->core->iota_conf, &http->core->iota_service,
+                        &http->core->iota_service_lock, payload, out);
   return set_response_content(ret, out);
 }
 
@@ -209,7 +213,8 @@ static inline int process_get_ta_info_request(ta_http_t *const http, char **cons
 
 static inline int process_proxy_api_request(ta_http_t *const http, char const *const payload, char **const out) {
   status_t ret;
-  ret = proxy_api_wrapper(&http->core->ta_conf, &http->core->iota_service, payload, out);
+  ret =
+      proxy_api_wrapper(&http->core->ta_conf, &http->core->iota_service, &http->core->iota_service_lock, payload, out);
   return set_response_content(ret, out);
 }
 

--- a/tests/api/driver.c
+++ b/tests/api/driver.c
@@ -88,7 +88,8 @@ void test_generate_address(void) {
 
   for (size_t count = 0; count < TEST_COUNT; count++) {
     test_time_start(&start_time);
-    TEST_ASSERT_EQUAL_INT32(SC_OK, api_generate_address(&ta_core.iota_conf, &ta_core.iota_service, &json_result));
+    TEST_ASSERT_EQUAL_INT32(SC_OK, api_generate_address(&ta_core.iota_conf, &ta_core.iota_service,
+                                                        &ta_core.iota_service_lock, &json_result));
     test_time_end(&start_time, &end_time, &sum);
     free(json_result);
   }
@@ -101,7 +102,8 @@ void test_get_tips_pair(void) {
 
   for (size_t count = 0; count < TEST_COUNT; count++) {
     test_time_start(&start_time);
-    TEST_ASSERT_EQUAL_INT32(SC_OK, api_get_tips_pair(&ta_core.iota_conf, &ta_core.iota_service, &json_result));
+    TEST_ASSERT_EQUAL_INT32(
+        SC_OK, api_get_tips_pair(&ta_core.iota_conf, &ta_core.iota_service, &ta_core.iota_service_lock, &json_result));
     test_time_end(&start_time, &end_time, &sum);
     free(json_result);
   }
@@ -114,7 +116,7 @@ void test_get_tips(void) {
 
   for (size_t count = 0; count < TEST_COUNT; count++) {
     test_time_start(&start_time);
-    TEST_ASSERT_EQUAL_INT32(SC_OK, api_get_tips(&ta_core.iota_service, &json_result));
+    TEST_ASSERT_EQUAL_INT32(SC_OK, api_get_tips(&ta_core.iota_service, &ta_core.iota_service_lock, &json_result));
     test_time_end(&start_time, &end_time, &sum);
     free(json_result);
   }
@@ -166,8 +168,8 @@ void test_send_trytes(void) {
 
   for (size_t count = 0; count < TEST_COUNT; count++) {
     test_time_start(&start_time);
-    TEST_ASSERT_EQUAL_INT32(
-        SC_OK, api_send_trytes(&ta_core.ta_conf, &ta_core.iota_conf, &ta_core.iota_service, json, &json_result));
+    TEST_ASSERT_EQUAL_INT32(SC_OK, api_send_trytes(&ta_core.ta_conf, &ta_core.iota_conf, &ta_core.iota_service,
+                                                   &ta_core.iota_service_lock, json, &json_result));
     test_time_end(&start_time, &end_time, &sum);
     free(json_result);
   }
@@ -184,7 +186,8 @@ void test_find_transaction_objects(void) {
 
   for (size_t count = 0; count < TEST_COUNT; count++) {
     test_time_start(&start_time);
-    TEST_ASSERT_EQUAL_INT32(SC_OK, api_find_transaction_objects(&ta_core.iota_service, json, &json_result));
+    TEST_ASSERT_EQUAL_INT32(
+        SC_OK, api_find_transaction_objects(&ta_core.iota_service, &ta_core.iota_service_lock, json, &json_result));
     test_time_end(&start_time, &end_time, &sum);
     free(json_result);
   }
@@ -199,7 +202,8 @@ void test_find_transactions_by_tag(void) {
   for (size_t count = 0; count < TEST_COUNT; count++) {
     test_time_start(&start_time);
 
-    TEST_ASSERT_EQUAL_INT32(SC_OK, api_find_transactions_by_tag(&ta_core.iota_service, test_tag, &json_result));
+    TEST_ASSERT_EQUAL_INT32(
+        SC_OK, api_find_transactions_by_tag(&ta_core.iota_service, &ta_core.iota_service_lock, test_tag, &json_result));
     test_time_end(&start_time, &end_time, &sum);
     free(json_result);
   }
@@ -213,8 +217,9 @@ void test_find_transactions_by_id(void) {
   for (size_t count = 0; count < TEST_COUNT; count++) {
     test_time_start(&start_time);
 
-    TEST_ASSERT_EQUAL_INT32(SC_OK, api_find_transactions_by_id(&ta_core.iota_service, &ta_core.db_service,
-                                                               identities[count].uuid_string, &json_result));
+    TEST_ASSERT_EQUAL_INT32(
+        SC_OK, api_find_transactions_by_id(&ta_core.iota_service, &ta_core.iota_service_lock, &ta_core.db_service,
+                                           identities[count].uuid_string, &json_result));
     test_time_end(&start_time, &end_time, &sum);
     free(json_result);
   }
@@ -257,7 +262,8 @@ void test_find_transactions_obj_by_tag(void) {
   for (size_t count = 0; count < TEST_COUNT; count++) {
     test_time_start(&start_time);
 
-    TEST_ASSERT_EQUAL_INT32(SC_OK, api_find_transactions_obj_by_tag(&ta_core.iota_service, test_tag, &json_result));
+    TEST_ASSERT_EQUAL_INT32(SC_OK, api_find_transactions_obj_by_tag(&ta_core.iota_service, &ta_core.iota_service_lock,
+                                                                    test_tag, &json_result));
     test_time_end(&start_time, &end_time, &sum);
     free(json_result);
   }
@@ -278,7 +284,8 @@ void test_send_mam_message(void) {
 
   for (size_t count = 0; count < TEST_COUNT; count++) {
     test_time_start(&start_time);
-    ret = api_mam_send_message(&ta_core.ta_conf, &ta_core.iota_conf, &ta_core.iota_service, json, &json_result);
+    ret = api_mam_send_message(&ta_core.ta_conf, &ta_core.iota_conf, &ta_core.iota_service, &ta_core.iota_service_lock,
+                               json, &json_result);
     if (ret == SC_OK || ret == SC_MAM_ALL_MSS_KEYS_USED) {
       result = true;
     }
@@ -301,8 +308,8 @@ void test_receive_mam_message(void) {
   for (size_t count = 0; count < TEST_COUNT; count++) {
     test_time_start(&start_time);
 
-    TEST_ASSERT_EQUAL_INT32(
-        SC_OK, api_recv_mam_message(&ta_core.iota_conf, &ta_core.iota_service, (char*)res->chid, &json_result));
+    TEST_ASSERT_EQUAL_INT32(SC_OK, api_recv_mam_message(&ta_core.iota_conf, &ta_core.iota_service,
+                                                        &ta_core.iota_service_lock, (char*)res->chid, &json_result));
     test_time_end(&start_time, &end_time, &sum);
     free(json_result);
   }
@@ -316,7 +323,7 @@ void test_get_iri_status() {
   for (size_t count = 0; count < TEST_COUNT; count++) {
     test_time_start(&start_time);
 
-    TEST_ASSERT_EQUAL_INT32(SC_OK, api_get_iri_status(&ta_core.iota_service, &json_result));
+    TEST_ASSERT_EQUAL_INT32(SC_OK, api_get_iri_status(&ta_core.iota_service, &ta_core.iota_service_lock, &json_result));
     test_time_end(&start_time, &end_time, &sum);
     free(json_result);
   }
@@ -330,8 +337,8 @@ void test_proxy_apis() {
 
     for (size_t count = 0; count < TEST_COUNT; count++) {
       test_time_start(&start_time);
-      TEST_ASSERT_EQUAL_INT32(
-          SC_OK, proxy_api_wrapper(&ta_core.ta_conf, &ta_core.iota_service, proxy_apis_g[i].json, &json_result));
+      TEST_ASSERT_EQUAL_INT32(SC_OK, proxy_api_wrapper(&ta_core.ta_conf, &ta_core.iota_service,
+                                                       &ta_core.iota_service_lock, proxy_apis_g[i].json, &json_result));
       test_time_end(&start_time, &end_time, &sum);
       free(json_result);
     }


### PR DESCRIPTION
Fix following three problems of the lock:
  - Two mutex locks for single iota_client_service_t
  - The mutex lock in proxy_apis.c does not even been initialized.
  - Missing necessary lock for some APIs.

Remove locks when using CJSON but not the CJSON in iota_service.serializer.
Add locks when every function call that uses iota_service. (miss to lock before some function calls).

Close #546