### PR TITLE
Fix Travis CI and Coverity Scan

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+dist: bionic
+
 env:
   global:
    # The next declaration is the encrypted COVERITY_SCAN_TOKEN, created
@@ -27,4 +29,4 @@ addons:
     build_command: "bash tests/coverity_analysis.sh"
     branch_pattern: develop
 
-script: if [ "${COVERITY_SCAN_BRANCH}" != 1 ]; then make ; fi
+script: if [ "${COVERITY_SCAN_BRANCH}" != 1 ]; then bash -e tests/coverity_analysis.sh; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,13 @@ before_install:
   - sudo apt update && sudo apt install bazel
   # Install UUID library
   - sudo apt install uuid-dev
+  # Install Cassandra C client library
+  - wget https://downloads.datastax.com/cpp-driver/ubuntu/18.04/dependencies/libuv/v1.35.0/libuv1_1.35.0-1_amd64.deb
+  - sudo dpkg -i libuv1_1.35.0-1_amd64.deb
+  - wget https://downloads.datastax.com/cpp-driver/ubuntu/18.04/cassandra/v2.15.1/cassandra-cpp-driver_2.15.1-1_amd64.deb
+  - sudo dpkg -i cassandra-cpp-driver_2.15.1-1_amd64.deb
+  - wget https://downloads.datastax.com/cpp-driver/ubuntu/18.04/cassandra/v2.15.1/cassandra-cpp-driver-dev_2.15.1-1_amd64.deb
+  - sudo dpkg -i cassandra-cpp-driver-dev_2.15.1-1_amd64.deb
 
 addons:
   coverity_scan:


### PR DESCRIPTION
- **Use Ubuntu 18.04 for newer version of UUID library**
In the default environment of Travis CI, it uses Ubuntu 16.04.
The corresponding UUID library is version 2.27.1, which lacks of the
macro UUID_STR_LEN.
Hence we need to use Ubuntu 18.04 and the corresponding UUID library
version 2.31.1 to make the building process work.

- **Install Cassandra C client library on Travis CI**
Install reference:
https://docs.datastax.com/en/developer/cpp-driver/2.15/topics/installation/#ubuntu
