### PR TITLE
fix(http): Report when requested msg too long

### DIFF
--- a/accelerator/core/serializer/serializer.c
+++ b/accelerator/core/serializer/serializer.c
@@ -539,6 +539,13 @@ status_t ta_send_transfer_req_deserialize(const char* const obj, ta_send_transfe
       req->msg_len = msg_len * 3;
       flex_trits_from_trytes(req->message, req->msg_len, (const tryte_t*)json_result->valuestring, msg_len, msg_len);
     }
+
+    if (req->msg_len > NUM_TRYTES_MESSAGE) {
+      ret = SC_SERIALIZER_MESSAGE_OVERRUN;
+      ta_log_error("%s\n", ta_error_to_string(ret));
+      goto done;
+    }
+
   } else {
     // 'message' does not exists, set to DEFAULT_MSG
     req->msg_len = DEFAULT_MSG_LEN * 3;

--- a/common/ta_errors.c
+++ b/common/ta_errors.c
@@ -48,6 +48,8 @@ const char* ta_error_to_string(status_t err) {
       return "Unicode value in JSON\n";
     case SC_SERIALIZER_INVALID_REQ:
       return "Invalid request value in JSON\n";
+    case SC_SERIALIZER_MESSAGE_OVERRUN:
+      return "Message length is out of valid size\n";
     case SC_CACHE_NULL:
       return "NULL object in cache\n";
     case SC_CACHE_FAILED_RESPONSE:

--- a/common/ta_errors.h
+++ b/common/ta_errors.h
@@ -113,6 +113,8 @@ typedef enum {
   /**< Unicode value in JSON */
   SC_SERIALIZER_INVALID_REQ = 0x05 | SC_MODULE_SERIALIZER | SC_SEVERITY_FATAL,
   /**< Invald request value in JSON */
+  SC_SERIALIZER_MESSAGE_OVERRUN = 0x06 | SC_MODULE_SERIALIZER | SC_SEVERITY_FATAL,
+  /**< Message length is out of valid size */
 
   // Cache module
   SC_CACHE_NULL = 0x01 | SC_MODULE_CACHE | SC_SEVERITY_FATAL,

--- a/connectivity/common.c
+++ b/connectivity/common.c
@@ -68,6 +68,11 @@ status_t set_response_content(status_t ret, char **json_result) {
       ta_log_error("%s\n", "SC_HTTP_BAD_REQUEST");
       *json_result = strdup(STR_HTTP_BAD_REQUEST);
       break;
+    case SC_SERIALIZER_MESSAGE_OVERRUN:
+      http_ret = SC_HTTP_BAD_REQUEST;
+      ta_log_error("%s\n", ta_error_to_string(ret));
+      *json_result = strdup(STR_HTTP_BAD_REQUEST_MESSAGE_OVERSIZE);
+      break;
     default:
       http_ret = SC_HTTP_INTERNAL_SERVICE_ERROR;
       ta_log_error("%s\n", "SC_HTTP_INTERNAL_SERVICE_ERROR");

--- a/connectivity/common.h
+++ b/connectivity/common.h
@@ -16,6 +16,7 @@ extern "C" {
 
 #define STR_HTTP_NOT_FOUND "{\"message\": \"Request not found\"}"
 #define STR_HTTP_BAD_REQUEST "{\"message\": \"Invalid request header\"}"
+#define STR_HTTP_BAD_REQUEST_MESSAGE_OVERRUN "{\"message\": \"In body 'message', requested message is too long.\"}"
 #define STR_HTTP_INTERNAL_SERVICE_ERROR "{\"message\": \"Internal service error\"}"
 #define STR_HTTP_REQUEST_SIZE_EXCEED "{\"message\": \"Request size exceed\"}"
 


### PR DESCRIPTION
We currently assume all the size of requests of `api_send_transfer`
in smaller than one transaction. To notify client who sent oversize
message in `send_transfer`, now, tangle-accelerator will report
the error mesage that the size of message is oversize.

The error response would be `{"message": "In body 'message', requested message is too long."}`