### PR TITLE
fix(test): Allow driver_core_cli_init take NULL args

### DIFF
--- a/tests/api/common.c
+++ b/tests/api/common.c
@@ -36,15 +36,19 @@ status_t driver_core_cli_init(ta_core_t* const core, int argc, char** argv, driv
         exit(EXIT_SUCCESS);
       case 'H':
         // Take the arguments as testing transaction hashes
-        for (int i = 0; i < TXN_HASH_NUM; i++) {
-          if (!test_cases->txn_hash[i]) {
-            test_cases->txn_hash[i] = optarg;
+        if (test_cases) {
+          for (int i = 0; i < TXN_HASH_NUM; i++) {
+            if (!test_cases->txn_hash[i]) {
+              test_cases->txn_hash[i] = optarg;
+            }
           }
         }
         break;
       case 'T':
         // Take the arguments as testing transaction tag
-        test_cases->tag = optarg;
+        if (test_cases) {
+          test_cases->tag = optarg;
+        }
         break;
       default:
         ret = cli_core_set(core, key, optarg);


### PR DESCRIPTION
To integrate driver_core into CI, and using concise CI scripts,
we should allow function `driver_core_cli_init()` to take a NULL
argument. Once a NULL argument of `driver_test_cases_t` is provided,
even though testing command `T` and `H` are assigned, no tags and
hashes will be set.

The updated CI command will be as following:
```
- name: "bazel test asan"
    artifact_paths:
      - "bazel-testlogs/tests/api/driver/*.log"
      - "bazel-testlogs/tests/unit-test/*/*.log"
    command:
      - "make"
      - "python3 tests/api/driver_setting.py <URL> devnet 'bazel test --config=asan //tests/api/...' '--test_arg --iri_host=<HOST> --test_arg --iri_port=<PORT> --test_arg --cache'"
      - "bazel test -c dbg --config asan //tests/unit-test/..."
```