### PR TITLE
feat(core): Handle IOTA-aware HTTP request with threadpool and epoll

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ Before running tangle-accelerator, please edit binding address/port of accelerat
 * `TA_PORT`: port of accelerator instance
 * `IRI_HOST`: binding address of IRI
 * `IRI_PORT`: port of IRI
+* `HTTP_THREADS`: Determine thread pool size to process HTTP connections.
 * `quiet`: Turn off logging message
 
 ```

--- a/accelerator/BUILD
+++ b/accelerator/BUILD
@@ -41,6 +41,7 @@ cc_library(
         "//common",
         ":build_option",
         "//utils/cache",
+        "//utils:cpuinfo",
         "@entangled//cclient/api",
         "@yaml",
     ] + select({

--- a/accelerator/cli_info.h
+++ b/accelerator/cli_info.h
@@ -25,7 +25,6 @@ typedef enum ta_cli_arg_value_e {
   /** TA */
   TA_HOST_CLI = 127,
   TA_PORT_CLI,
-  TA_THREAD_COUNT_CLI,
 
   /** IRI */
   IRI_HOST_CLI,
@@ -54,6 +53,7 @@ typedef enum ta_cli_arg_value_e {
   NO_GTTA,
   BUFFER_LIST,
   DONE_LIST,
+  HTTP_THREADS_CLI,
 
   /** LOGGER */
   QUIET,
@@ -70,7 +70,8 @@ static struct ta_cli_argument_s {
     {"version", no_argument, NULL, 'v', "tangle-accelerator version"},
     {"ta_host", required_argument, NULL, TA_HOST_CLI, "TA listening host"},
     {"ta_port", required_argument, NULL, TA_PORT_CLI, "TA listening port"},
-    {"ta_thread", optional_argument, NULL, TA_THREAD_COUNT_CLI, "TA executing thread"},
+    {"http_threads", required_argument, NULL, HTTP_THREADS_CLI,
+     "Determine thread pool size to process HTTP connections."},
     {"iri_host", required_argument, NULL, IRI_HOST_CLI, "IRI listening host"},
     {"iri_port", required_argument, NULL, IRI_PORT_CLI, "IRI listening port"},
     {"mqtt_host", required_argument, NULL, MQTT_HOST_CLI, "MQTT listening host"},

--- a/accelerator/config.h
+++ b/accelerator/config.h
@@ -16,6 +16,7 @@
 #include "accelerator/core/pow.h"
 #include "cclient/api/core/core_api.h"
 #include "cclient/api/extended/extended_api.h"
+#include "utils/cpuinfo.h"
 #ifdef DB_ENABLE
 #include "storage/ta_storage.h"
 #endif
@@ -42,7 +43,9 @@ extern "C" {
 #endif
 
 #define TA_PORT 8000
-#define TA_THREAD_COUNT 10
+#define DEFAULT_HTTP_TPOOL_SIZE 4 /**< Thread number of MHD thread pool */
+#define MAX_HTTP_TPOOL_SIZE \
+  (get_nprocs_conf() - get_nthds_per_phys_proc()) /** < Preserve at least one physical processor */
 #define IRI_HOST "localhost"
 #define IRI_PORT 14265
 #define MAX_IRI_LIST_ELEMENTS 5
@@ -75,9 +78,9 @@ typedef struct ta_config_s {
   char* mqtt_host;       /**< Address of MQTT broker host */
   char* mqtt_topic_root; /**< The topic root of MQTT topic */
 #endif
-  uint8_t thread_count;   /**< Thread count of tangle-accelerator instance */
-  bool proxy_passthrough; /**< Pass proxy api directly without processing */
-  bool gtta;              /**< The option to turn on or off GTTA. The default value is true which enabling GTTA */
+  uint8_t http_tpool_size; /**< Thread count of tangle-accelerator instance */
+  bool proxy_passthrough;  /**< Pass proxy api directly without processing */
+  bool gtta;               /**< The option to turn on or off GTTA. The default value is true which enabling GTTA */
 } ta_config_t;
 
 /** struct type of iota configuration */
@@ -178,6 +181,19 @@ status_t ta_core_set(ta_core_t* const core);
  *
  */
 void ta_core_destroy(ta_core_t* const core);
+
+/**
+ * Initializes iota_client_service
+ *
+ * @param service[in] IOTA client service
+ * @param host[in] host of connecting service
+ * @param port[in] port of connecting service
+ *
+ * @return
+ * - SC_OK on success
+ * - non-zero on error
+ */
+status_t ta_set_iota_client_service(iota_client_service_t* service, char const* host, uint16_t port);
 
 #ifdef __cplusplus
 }

--- a/accelerator/core/apis.h
+++ b/accelerator/core/apis.h
@@ -83,7 +83,7 @@ status_t apis_lock_destroy();
  * the address does not have any transaction with it yet.
  *
  * @param[in] iconf IOTA API parameter configurations
- * @param[in] service IRI node end point service
+ * @param[in] service IOTA node service
  * @param[out] json_result Result containing an unused address in json format
  *
  * @return
@@ -100,7 +100,7 @@ status_t api_generate_address(const iota_config_t* const iconf, const iota_clien
  * The result is char array in json format:
  *
  * @param[in] iconf IOTA API parameter configurations
- * @param[in] service IRI node end point service
+ * @param[in] service IOTA node service
  * @param[out] json_result Result containing a tips pair in json format
  *
  * @return
@@ -116,7 +116,7 @@ status_t api_get_tips_pair(const iota_config_t* const iconf, const iota_client_s
  * Get list of all tips from IRI node which usually hash thousands of tips in
  * its queue.
  *
- * @param[in] service IRI node end point service
+ * @param[in] service IOTA node service
  * @param[out] json_result Result containing list of all tips in json format
  *
  * @return
@@ -130,7 +130,7 @@ status_t api_get_tips(const iota_client_service_t* const service, char** json_re
  *
  * Receive a MAM message from given bundle hash.
  *
- * @param[in] service IRI node end point service
+ * @param[in] service IOTA node service
  * @param[in] chid channel ID string
  * @param[out] json_result Fetched MAM message in JSON format
  *
@@ -150,7 +150,7 @@ status_t api_recv_mam_message(const iota_config_t* const iconf, const iota_clien
  *
  * @param[in] info Tangle-accelerator configuration variables
  * @param[in] iconf IOTA API parameter configurations
- * @param[in] service IRI node end point service
+ * @param[in] service IOTA node service
  * @param[in] payload message to send undecoded ascii string.
  * @param[out] json_result Result containing channel id and bundle hash
  *
@@ -169,7 +169,8 @@ status_t api_send_mam_message(const ta_config_t* const info, const iota_config_t
  * fields include address, value, tag, and message. This API would also try to
  * find the transactions after bundle sent.
  *
- * @param core[in] Pointer to Tangle-accelerator core configuration structure
+ * @param[in] core Pointer of Tangle-accelerator core configuration structure
+ * @param[in] iota_service IOTA node service
  * @param[in] obj Input data in JSON
  * @param[out] json_result Result containing transaction objects in json format
  *
@@ -177,7 +178,8 @@ status_t api_send_mam_message(const ta_config_t* const info, const iota_config_t
  * - SC_OK on success
  * - non-zero on error
  */
-status_t api_send_transfer(const ta_core_t* const core, const char* const obj, char** json_result);
+status_t api_send_transfer(const ta_core_t* const core, const iota_client_service_t* iota_service,
+                           const char* const obj, char** json_result);
 
 /**
  * @brief Return transaction object with given single transaction hash.
@@ -185,7 +187,7 @@ status_t api_send_transfer(const ta_core_t* const core, const char* const obj, c
  * Explore transaction hash information with given single transaction hash. This would
  * return whole transaction object details in json format instead of raw trytes.
  *
- * @param[in] service IRI node end point service
+ * @param[in] service IOTA node service
  * @param[in] obj transaction hash in trytes
  * @param[out] json_result Result containing the only one transaction object in json format
  *
@@ -202,7 +204,7 @@ status_t api_find_transaction_object_single(const iota_client_service_t* const s
  * Explore transaction hash information with given transaction hash. This would
  * return whole transaction object details in json format instead of raw trytes.
  *
- * @param[in] service IRI node end point service
+ * @param[in] service IOTA node service
  * @param[in] obj transaction hash in trytes
  * @param[out] json_result Result containing transaction objects in json format
  *
@@ -219,7 +221,7 @@ status_t api_find_transaction_objects(const iota_client_service_t* const service
  * Retreive all transactions that have same given tag. The result is a list of
  * transaction hashes in json format.
  *
- * @param[in] service IRI node end point service
+ * @param[in] service IOTA node service
  * @param[in] obj tag in trytes
  * @param[out] json_result Result containing list of transaction hashes in json
  *             format
@@ -237,7 +239,7 @@ status_t api_find_transactions_by_tag(const iota_client_service_t* const service
  * Retreive all transactions that have same given tag. The result is a list of
  * transaction objects in json format.
  *
- * @param[in] service IRI node end point service
+ * @param[in] service IOTA node service
  * @param[in] obj tag in trytes
  * @param[out] json_result Result containing list of transaction objects in json
  * format
@@ -258,7 +260,7 @@ status_t api_find_transactions_obj_by_tag(const iota_client_service_t* const ser
  *
  * @param[in] info Tangle-accelerator configuration variables
  * @param[in] iconf IOTA API parameter configurations
- * @param[in] service IRI node end point service
+ * @param[in] service IOTA node service
  * @param[in] obj trytes to attach, store and broadcast in json array
  * @param[out] json_result Result containing list of attached transaction hashes
  * in json format
@@ -273,7 +275,7 @@ status_t api_send_trytes(const ta_config_t* const info, const iota_config_t* con
 /**
  * @brief Check the connection status between tangle-accelerator and IRI host.
  *
- * @param[in] iota_service IRI node end point service
+ * @param[in] iota_service IOTA node service
  * @param[out] json_result Result containing the current connection status.
  *
  * @return
@@ -302,7 +304,7 @@ status_t api_fetch_txn_with_uuid(const ta_cache_t* const cache, const char* cons
  * Explore transaction hash information with given single identity number. This would
  * return whole transaction object details in json format instead of raw trytes.
  *
- * @param[in] iota_service IRI node end point service
+ * @param[in] iota_service IOTA node service
  * @param[in] db_service db client service
  * @param[in] obj identity number
  * @param[out] json_result Result containing the only one transaction object in json format

--- a/accelerator/core/serializer/serializer.c
+++ b/accelerator/core/serializer/serializer.c
@@ -41,7 +41,7 @@ status_t ta_get_info_serialize(char** obj, ta_config_t* const ta_config, iota_co
   cJSON_AddStringToObject(json_root, "host", ta_config->host);
   cJSON_AddStringToObject(json_root, "version", ta_config->version);
   cJSON_AddNumberToObject(json_root, "port", ta_config->port);
-  cJSON_AddNumberToObject(json_root, "thread", ta_config->thread_count);
+  cJSON_AddNumberToObject(json_root, "thread", ta_config->http_tpool_size);
   cJSON_AddStringToObject(json_root, "redis_host", cache->host);
   cJSON_AddNumberToObject(json_root, "redis_port", cache->port);
   cJSON_AddNumberToObject(json_root, "milestone_depth", tangle->milestone_depth);

--- a/accelerator/main.c
+++ b/accelerator/main.c
@@ -79,12 +79,6 @@ int main(int argc, char* argv[]) {
   pthread_t thread;
   pthread_create(&thread, NULL, health_track, &ta_core);
 
-  // Initialize apis cJSON lock
-  if (apis_lock_init() != SC_OK) {
-    ta_log_error("Lock initialization failed %s.\n", MAIN_LOGGER);
-    return EXIT_FAILURE;
-  }
-
   if (ta_http_init(&ta_http, &ta_core) != SC_OK) {
     ta_log_error("HTTP initialization failed %s.\n", MAIN_LOGGER);
     return EXIT_FAILURE;
@@ -123,11 +117,6 @@ int main(int argc, char* argv[]) {
   }
 
 cleanup:
-  log_info(logger_id, "Destroying API lock\n");
-  if (apis_lock_destroy() != SC_OK) {
-    ta_log_error("Destroying api lock failed %s.\n", MAIN_LOGGER);
-    return EXIT_FAILURE;
-  }
   log_info(logger_id, "Destroying TA configurations\n");
   ta_core_destroy(&ta_core);
 

--- a/connectivity/http/http.c
+++ b/connectivity/http/http.c
@@ -71,83 +71,91 @@ static status_t ta_get_url_parameter(char const *const url, int index, char **pa
   return SC_OK;
 }
 
-static inline int process_find_txns_obj_by_tag_request(ta_http_t *const http, char const *const url, char **const out) {
+static inline int process_find_txns_obj_by_tag_request(iota_client_service_t *const iota_service, char const *const url,
+                                                       char **const out) {
   status_t ret;
   char *tag = NULL;
   ret = ta_get_url_parameter(url, 1, &tag);
   if (ret == SC_OK) {
-    ret = api_find_transactions_obj_by_tag(&http->core->iota_service, tag, out);
+    ret = api_find_transactions_obj_by_tag(iota_service, tag, out);
   }
   free(tag);
   return set_response_content(ret, out);
 }
 
-static inline int process_find_txns_by_tag_request(ta_http_t *const http, char const *const url, char **const out) {
+static inline int process_find_txns_by_tag_request(iota_client_service_t *const iota_service, char const *const url,
+                                                   char **const out) {
   status_t ret;
   char *tag = NULL;
   ret = ta_get_url_parameter(url, 1, &tag);
   if (ret == SC_OK) {
-    ret = api_find_transactions_by_tag(&http->core->iota_service, tag, out);
+    ret = api_find_transactions_by_tag(iota_service, tag, out);
   }
   free(tag);
   return set_response_content(ret, out);
 }
 
-static inline int process_generate_address_request(ta_http_t *const http, char **const out) {
+static inline int process_generate_address_request(ta_http_t *const http, iota_client_service_t *const iota_service,
+                                                   char **const out) {
   status_t ret;
-  ret = api_generate_address(&http->core->iota_conf, &http->core->iota_service, out);
+  ret = api_generate_address(&http->core->iota_conf, iota_service, out);
   return set_response_content(ret, out);
 }
 
-static inline int process_find_txn_obj_single_request(ta_http_t *const http, char const *const url, char **const out) {
+static inline int process_find_txn_obj_single_request(iota_client_service_t *const iota_service, char const *const url,
+                                                      char **const out) {
   status_t ret;
   char *hash = NULL;
   ret = ta_get_url_parameter(url, 1, &hash);
   if (ret == SC_OK) {
-    ret = api_find_transaction_object_single(&http->core->iota_service, hash, out);
+    ret = api_find_transaction_object_single(iota_service, hash, out);
   }
   free(hash);
   return set_response_content(ret, out);
 }
 
-static inline int process_find_txn_obj_request(ta_http_t *const http, char const *const payload, char **const out) {
+static inline int process_find_txn_obj_request(iota_client_service_t *const iota_service, char const *const payload,
+                                               char **const out) {
   status_t ret;
-  ret = api_find_transaction_objects(&http->core->iota_service, payload, out);
+  ret = api_find_transaction_objects(iota_service, payload, out);
   return set_response_content(ret, out);
 }
 
-static inline int process_get_tips_pair_request(ta_http_t *const http, char **const out) {
+static inline int process_get_tips_pair_request(ta_http_t *const http, iota_client_service_t *const iota_service,
+                                                char **const out) {
   status_t ret;
-  ret = api_get_tips_pair(&http->core->iota_conf, &http->core->iota_service, out);
+  ret = api_get_tips_pair(&http->core->iota_conf, iota_service, out);
   return set_response_content(ret, out);
 }
 
-static inline int process_get_tips_request(ta_http_t *const http, char **const out) {
+static inline int process_get_tips_request(iota_client_service_t *const iota_service, char **const out) {
   status_t ret;
-  ret = api_get_tips(&http->core->iota_service, out);
+  ret = api_get_tips(iota_service, out);
   return set_response_content(ret, out);
 }
 
-static inline int process_send_transfer_request(ta_http_t *const http, char const *const payload, char **const out) {
+static inline int process_send_transfer_request(ta_http_t *const http, iota_client_service_t *const iota_service,
+                                                char const *const payload, char **const out) {
   status_t ret;
-  ret = api_send_transfer(http->core, payload, out);
+  ret = api_send_transfer(http->core, iota_service, payload, out);
   return set_response_content(ret, out);
 }
 
-static inline int process_recv_mam_msg_request(ta_http_t *const http, char const *const url, char **const out) {
+static inline int process_recv_mam_msg_request(ta_http_t *const http, iota_client_service_t *const iota_service,
+                                               char const *const url, char **const out) {
   status_t ret;
   char *bundle = NULL;
   ret = ta_get_url_parameter(url, 1, &bundle);
   if (ret == SC_OK) {
-    ret = api_recv_mam_message(&http->core->iota_conf, &http->core->iota_service, bundle, out);
+    ret = api_recv_mam_message(&http->core->iota_conf, iota_service, bundle, out);
   }
   free(bundle);
   return set_response_content(ret, out);
 }
 
-static inline int process_get_iri_status(ta_http_t *const http, char **const out) {
+static inline int process_get_iri_status(iota_client_service_t *const iota_service, char **const out) {
   status_t ret;
-  ret = api_get_iri_status(&http->core->iota_service, out);
+  ret = api_get_iri_status(iota_service, out);
   return set_response_content(ret, out);
 }
 
@@ -177,28 +185,31 @@ static inline int process_get_identity_info_by_id_request(ta_http_t *const http,
   return set_response_content(ret, out);
 }
 
-static inline int process_find_transaction_by_id_request(ta_http_t *const http, char const *const url,
-                                                         char **const out) {
+static inline int process_find_transaction_by_id_request(ta_http_t *const http,
+                                                         iota_client_service_t *const iota_service,
+                                                         char const *const url, char **const out) {
   status_t ret;
   char *buf = NULL;
   ret = ta_get_url_parameter(url, 2, &buf);
   if (ret == SC_OK) {
-    ret = api_find_transactions_by_id(&http->core->iota_service, &http->core->db_service, buf, out);
+    ret = api_find_transactions_by_id(iota_service, &http->core->db_service, buf, out);
   }
   free(buf);
   return set_response_content(ret, out);
 }
 #endif
 
-static inline int process_send_mam_msg_request(ta_http_t *const http, char const *const payload, char **const out) {
+static inline int process_send_mam_msg_request(ta_http_t *const http, iota_client_service_t *const iota_service,
+                                               char const *const payload, char **const out) {
   status_t ret;
-  ret = api_send_mam_message(&http->core->ta_conf, &http->core->iota_conf, &http->core->iota_service, payload, out);
+  ret = api_send_mam_message(&http->core->ta_conf, &http->core->iota_conf, iota_service, payload, out);
   return set_response_content(ret, out);
 }
 
-static inline int process_send_trytes_request(ta_http_t *const http, char const *const payload, char **const out) {
+static inline int process_send_trytes_request(ta_http_t *const http, iota_client_service_t *const iota_service,
+                                              char const *const payload, char **const out) {
   status_t ret;
-  ret = api_send_trytes(&http->core->ta_conf, &http->core->iota_conf, &http->core->iota_service, payload, out);
+  ret = api_send_trytes(&http->core->ta_conf, &http->core->iota_conf, iota_service, payload, out);
   return set_response_content(ret, out);
 }
 
@@ -208,9 +219,10 @@ static inline int process_get_ta_info_request(ta_http_t *const http, char **cons
   return set_response_content(ret, out);
 }
 
-static inline int process_proxy_api_request(ta_http_t *const http, char const *const payload, char **const out) {
+static inline int process_proxy_api_request(ta_http_t *const http, iota_client_service_t *const iota_service,
+                                            char const *const payload, char **const out) {
   status_t ret;
-  ret = proxy_api_wrapper(&http->core->ta_conf, &http->core->iota_service, payload, out);
+  ret = proxy_api_wrapper(&http->core->ta_conf, iota_service, payload, out);
   return set_response_content(ret, out);
 }
 
@@ -238,40 +250,40 @@ static inline int process_options_request(char **const out) {
   return MHD_HTTP_OK;
 }
 
-static int ta_http_process_request(ta_http_t *const http, char const *const url, char const *const payload,
-                                   char **const out, int options) {
+static int ta_http_process_request(ta_http_t *const http, iota_client_service_t *const iota_service,
+                                   char const *const url, char const *const payload, char **const out, int options) {
   if (options) {
     return process_options_request(out);
   }
 
   if (api_path_matcher(url, "/mam/[A-Z9]{81}[/]?") == SC_OK) {
-    return process_recv_mam_msg_request(http, url, out);
+    return process_recv_mam_msg_request(http, iota_service, url, out);
   } else if (api_path_matcher(url, "/mam[/]?") == SC_OK) {
     if (payload != NULL) {
-      return process_send_mam_msg_request(http, payload, out);
+      return process_send_mam_msg_request(http, iota_service, payload, out);
     }
     return process_method_not_allowed_request(out);
 
   } else if (api_path_matcher(url, "/transaction/[A-Z9]{81}[/]?") == SC_OK) {
-    return process_find_txn_obj_single_request(http, url, out);
+    return process_find_txn_obj_single_request(iota_service, url, out);
   } else if (api_path_matcher(url, "/transaction/object[/]?") == SC_OK) {
     if (payload != NULL) {
-      return process_find_txn_obj_request(http, payload, out);
+      return process_find_txn_obj_request(iota_service, payload, out);
     }
     return process_method_not_allowed_request(out);
 
   } else if (api_path_matcher(url, "/tips/pair[/]?") == SC_OK) {
-    return process_get_tips_pair_request(http, out);
+    return process_get_tips_pair_request(http, iota_service, out);
   } else if (api_path_matcher(url, "/tips[/]?") == SC_OK) {
-    return process_get_tips_request(http, out);
+    return process_get_tips_request(iota_service, out);
   } else if (api_path_matcher(url, "/address[/]?") == SC_OK) {
-    return process_generate_address_request(http, out);
+    return process_generate_address_request(http, iota_service, out);
   } else if (api_path_matcher(url, "/tag/[A-Z9]{1,27}/hashes[/]?") == SC_OK) {
-    return process_find_txns_by_tag_request(http, url, out);
+    return process_find_txns_by_tag_request(iota_service, url, out);
   } else if (api_path_matcher(url, "/tag/[A-Z9]{1,27}[/]?") == SC_OK) {
-    return process_find_txns_obj_by_tag_request(http, url, out);
+    return process_find_txns_obj_by_tag_request(iota_service, url, out);
   } else if (api_path_matcher(url, "/status[/]?") == SC_OK) {
-    return process_get_iri_status(http, out);
+    return process_get_iri_status(iota_service, out);
   }
 #ifdef DB_ENABLE
   else if (api_path_matcher(url, "/identity/hash/[A-Z9]{81}[/]?") == SC_OK) {
@@ -279,24 +291,24 @@ static int ta_http_process_request(ta_http_t *const http, char const *const url,
   } else if (api_path_matcher(url, "/identity/id/[a-z0-9-]{36}[/]?") == SC_OK) {
     return process_get_identity_info_by_id_request(http, url, out);
   } else if (api_path_matcher(url, "/transaction/id/[a-z0-9-]{36}[/]?") == SC_OK) {
-    return process_find_transaction_by_id_request(http, url, out);
+    return process_find_transaction_by_id_request(http, iota_service, url, out);
   }
 #endif
   else if (api_path_matcher(url, "/transaction[/]?") == SC_OK) {
     if (payload != NULL) {
-      return process_send_transfer_request(http, payload, out);
+      return process_send_transfer_request(http, iota_service, payload, out);
     }
     return process_method_not_allowed_request(out);
   } else if (api_path_matcher(url, "/tryte[/]?") == SC_OK) {
     if (payload != NULL) {
-      return process_send_trytes_request(http, payload, out);
+      return process_send_trytes_request(http, iota_service, payload, out);
     }
     return process_method_not_allowed_request(out);
   } else if (api_path_matcher(url, "/info[/]?") == SC_OK) {
     return process_get_ta_info_request(http, out);
   } else if (api_path_matcher(url, "/") == SC_OK) {
     if (payload != NULL) {
-      return process_proxy_api_request(http, payload, out);
+      return process_proxy_api_request(http, iota_service, payload, out);
     }
     return process_method_not_allowed_request(out);
   } else {
@@ -431,7 +443,10 @@ static int ta_http_handler(void *cls, struct MHD_Connection *connection, const c
 
   if (http_req->answer_code == MHD_NO) {
     /* decide which API function should be called */
-    http_req->answer_code = ta_http_process_request(api, url, http_req->request, &http_req->answer_string, options);
+    iota_client_service_t iota_service;
+    ta_set_iota_client_service(&iota_service, api->core->iota_service.http.host, api->core->iota_service.http.port);
+    http_req->answer_code =
+        ta_http_process_request(api, &iota_service, url, http_req->request, &http_req->answer_string, options);
   }
   response =
       MHD_create_response_from_buffer(strlen(http_req->answer_string), http_req->answer_string, MHD_RESPMEM_MUST_COPY);
@@ -478,9 +493,9 @@ status_t ta_http_start(ta_http_t *const http) {
     return SC_HTTP_NULL;
   }
 
-  http->daemon =
-      MHD_start_daemon(MHD_USE_AUTO_INTERNAL_THREAD | MHD_USE_THREAD_PER_CONNECTION | MHD_USE_ERROR_LOG | MHD_USE_DEBUG,
-                       http->core->ta_conf.port, request_log, NULL, ta_http_handler, http, MHD_OPTION_END);
+  http->daemon = MHD_start_daemon(MHD_USE_EPOLL_INTERNAL_THREAD | MHD_USE_ERROR_LOG | MHD_USE_DEBUG,
+                                  http->core->ta_conf.port, request_log, NULL, ta_http_handler, http,
+                                  MHD_OPTION_THREAD_POOL_SIZE, http->core->ta_conf.http_tpool_size, MHD_OPTION_END);
   if (http->daemon == NULL) {
     ta_log_error("%s\n", strerror(errno));
     return SC_HTTP_OOM;

--- a/tests/api/driver.c
+++ b/tests/api/driver.c
@@ -56,8 +56,10 @@ void test_generate_address(void) {
   double sum = 0;
 
   for (size_t count = 0; count < TEST_COUNT; count++) {
+    iota_client_service_t iota_service;
+    ta_set_iota_client_service(&iota_service, ta_core.iota_service.http.host, ta_core.iota_service.http.port);
     test_time_start(&start_time);
-    TEST_ASSERT_EQUAL_INT32(SC_OK, api_generate_address(&ta_core.iota_conf, &ta_core.iota_service, &json_result));
+    TEST_ASSERT_EQUAL_INT32(SC_OK, api_generate_address(&ta_core.iota_conf, &iota_service, &json_result));
     test_time_end(&start_time, &end_time, &sum);
     free(json_result);
   }
@@ -69,8 +71,10 @@ void test_get_tips_pair(void) {
   double sum = 0;
 
   for (size_t count = 0; count < TEST_COUNT; count++) {
+    iota_client_service_t iota_service;
+    ta_set_iota_client_service(&iota_service, ta_core.iota_service.http.host, ta_core.iota_service.http.port);
     test_time_start(&start_time);
-    TEST_ASSERT_EQUAL_INT32(SC_OK, api_get_tips_pair(&ta_core.iota_conf, &ta_core.iota_service, &json_result));
+    TEST_ASSERT_EQUAL_INT32(SC_OK, api_get_tips_pair(&ta_core.iota_conf, &iota_service, &json_result));
     test_time_end(&start_time, &end_time, &sum);
     free(json_result);
   }
@@ -82,8 +86,10 @@ void test_get_tips(void) {
   double sum = 0;
 
   for (size_t count = 0; count < TEST_COUNT; count++) {
+    iota_client_service_t iota_service;
+    ta_set_iota_client_service(&iota_service, ta_core.iota_service.http.host, ta_core.iota_service.http.port);
     test_time_start(&start_time);
-    TEST_ASSERT_EQUAL_INT32(SC_OK, api_get_tips(&ta_core.iota_service, &json_result));
+    TEST_ASSERT_EQUAL_INT32(SC_OK, api_get_tips(&iota_service, &json_result));
     test_time_end(&start_time, &end_time, &sum);
     free(json_result);
   }
@@ -106,8 +112,10 @@ void test_send_transfer(void) {
   double sum = 0;
 
   for (size_t count = 0; count < TEST_COUNT; count++) {
+    iota_client_service_t iota_service;
+    ta_set_iota_client_service(&iota_service, ta_core.iota_service.http.host, ta_core.iota_service.http.port);
     test_time_start(&start_time);
-    TEST_ASSERT_EQUAL_INT32(SC_OK, api_send_transfer(&ta_core, json, &json_result));
+    TEST_ASSERT_EQUAL_INT32(SC_OK, api_send_transfer(&ta_core, &iota_service, json, &json_result));
     test_time_end(&start_time, &end_time, &sum);
 #ifdef DB_ENABLE
     cJSON* json_obj = cJSON_Parse(json_result);
@@ -139,9 +147,11 @@ void test_send_trytes(void) {
   double sum = 0;
 
   for (size_t count = 0; count < TEST_COUNT; count++) {
+    iota_client_service_t iota_service;
+    ta_set_iota_client_service(&iota_service, ta_core.iota_service.http.host, ta_core.iota_service.http.port);
     test_time_start(&start_time);
-    TEST_ASSERT_EQUAL_INT32(
-        SC_OK, api_send_trytes(&ta_core.ta_conf, &ta_core.iota_conf, &ta_core.iota_service, json, &json_result));
+    TEST_ASSERT_EQUAL_INT32(SC_OK,
+                            api_send_trytes(&ta_core.ta_conf, &ta_core.iota_conf, &iota_service, json, &json_result));
     test_time_end(&start_time, &end_time, &sum);
     free(json_result);
   }
@@ -157,8 +167,10 @@ void test_find_transaction_objects(void) {
   double sum = 0;
 
   for (size_t count = 0; count < TEST_COUNT; count++) {
+    iota_client_service_t iota_service;
+    ta_set_iota_client_service(&iota_service, ta_core.iota_service.http.host, ta_core.iota_service.http.port);
     test_time_start(&start_time);
-    TEST_ASSERT_EQUAL_INT32(SC_OK, api_find_transaction_objects(&ta_core.iota_service, json, &json_result));
+    TEST_ASSERT_EQUAL_INT32(SC_OK, api_find_transaction_objects(&iota_service, json, &json_result));
     test_time_end(&start_time, &end_time, &sum);
     free(json_result);
   }
@@ -172,8 +184,10 @@ void test_find_transactions_by_tag(void) {
 
   for (size_t count = 0; count < TEST_COUNT; count++) {
     test_time_start(&start_time);
+    iota_client_service_t iota_service;
+    ta_set_iota_client_service(&iota_service, ta_core.iota_service.http.host, ta_core.iota_service.http.port);
 
-    TEST_ASSERT_EQUAL_INT32(SC_OK, api_find_transactions_by_tag(&ta_core.iota_service, test_case.tag, &json_result));
+    TEST_ASSERT_EQUAL_INT32(SC_OK, api_find_transactions_by_tag(&iota_service, test_case.tag, &json_result));
     test_time_end(&start_time, &end_time, &sum);
     free(json_result);
   }
@@ -186,8 +200,10 @@ void test_find_transactions_by_id(void) {
   double sum = 0;
   for (size_t count = 0; count < TEST_COUNT; count++) {
     test_time_start(&start_time);
+    iota_client_service_t iota_service;
+    ta_set_iota_client_service(&iota_service, ta_core.iota_service.http.host, ta_core.iota_service.http.port);
 
-    TEST_ASSERT_EQUAL_INT32(SC_OK, api_find_transactions_by_id(&ta_core.iota_service, &ta_core.db_service,
+    TEST_ASSERT_EQUAL_INT32(SC_OK, api_find_transactions_by_id(&iota_service, &ta_core.db_service,
                                                                identities[count].uuid_string, &json_result));
     test_time_end(&start_time, &end_time, &sum);
     free(json_result);
@@ -231,8 +247,10 @@ void test_find_transactions_obj_by_tag(void) {
   for (size_t count = 0; count < TEST_COUNT; count++) {
     test_time_start(&start_time);
 
-    TEST_ASSERT_EQUAL_INT32(SC_OK,
-                            api_find_transactions_obj_by_tag(&ta_core.iota_service, test_case.tag, &json_result));
+    iota_client_service_t iota_service;
+    ta_set_iota_client_service(&iota_service, ta_core.iota_service.http.host, ta_core.iota_service.http.port);
+
+    TEST_ASSERT_EQUAL_INT32(SC_OK, api_find_transactions_obj_by_tag(&iota_service, test_case.tag, &json_result));
     test_time_end(&start_time, &end_time, &sum);
     free(json_result);
   }
@@ -260,7 +278,10 @@ void test_get_iri_status(void) {
   for (size_t count = 0; count < TEST_COUNT; count++) {
     test_time_start(&start_time);
 
-    TEST_ASSERT_EQUAL_INT32(SC_OK, api_get_iri_status(&ta_core.iota_service, &json_result));
+    iota_client_service_t iota_service;
+    ta_set_iota_client_service(&iota_service, ta_core.iota_service.http.host, ta_core.iota_service.http.port);
+
+    TEST_ASSERT_EQUAL_INT32(SC_OK, api_get_iri_status(&iota_service, &json_result));
     test_time_end(&start_time, &end_time, &sum);
     free(json_result);
   }
@@ -274,8 +295,10 @@ void test_proxy_apis(void) {
 
     for (size_t count = 0; count < TEST_COUNT; count++) {
       test_time_start(&start_time);
-      TEST_ASSERT_EQUAL_INT32(
-          SC_OK, proxy_api_wrapper(&ta_core.ta_conf, &ta_core.iota_service, proxy_apis_g[i].json, &json_result));
+      iota_client_service_t iota_service;
+      ta_set_iota_client_service(&iota_service, ta_core.iota_service.http.host, ta_core.iota_service.http.port);
+      TEST_ASSERT_EQUAL_INT32(SC_OK,
+                              proxy_api_wrapper(&ta_core.ta_conf, &iota_service, proxy_apis_g[i].json, &json_result));
       test_time_end(&start_time, &end_time, &sum);
       free(json_result);
     }

--- a/utils/BUILD
+++ b/utils/BUILD
@@ -77,3 +77,8 @@ cc_library(
     hdrs = ["tryte_byte_conv.h"],
     deps = ["//common:defined_error"],
 )
+
+cc_library(
+    name = "cpuinfo",
+    hdrs = ["cpuinfo.h"],
+)

--- a/utils/cpuinfo.h
+++ b/utils/cpuinfo.h
@@ -1,0 +1,87 @@
+/*
+ * Copyright (C) 2018-2020 BiiLabs Co., Ltd. and Contributors
+ * All Rights Reserved.
+ * This is free software; you can redistribute it and/or modify it under the
+ * terms of the MIT license. A copy of the license can be found in the file
+ * "LICENSE" at the root of this distribution.
+ */
+
+#include <errno.h>
+#include <limits.h>
+#include <stdlib.h>
+
+/* Required for get_nprocs_conf() on Linux */
+#if defined(__linux__)
+#include <sys/sysinfo.h>
+#endif
+
+/**
+ * @file cpu-utils.h
+ * @brief Utility functions for acquiring CPU information.
+ */
+
+/* On Mac OS X, define our own get_nprocs_conf() */
+#if defined(__APPLE__) || defined(__FreeBSD__)
+#include <sys/sysctl.h>
+static unsigned int get_nprocs_conf() {
+  int num_proc = 0;
+  size_t size = sizeof(num_proc);
+  if (sysctlbyname("hw.ncpu", &num_proc, &size, NULL, 0)) return 1;
+  return (unsigned int)num_proc;
+}
+#endif
+
+/**
+ * @brief Get the thread number per physical processor.
+ *
+ * - GNU/Linux: Acquire the thread number by parsing the CPU information.
+ * - macOS: Acquire the thread number by doing the calculation of
+ * (logical processor number / physical processor number).
+ * @return The thread number per physical processor.
+ * @retval 1 Hyperthreading disabled.
+ * @retval 2 Hyperthreading enabled.
+ * @retval -1 Unexpected error.
+ */
+static inline int get_nthds_per_phys_proc() {
+  int nthread;
+#if defined(__linux__)
+  FILE *fd;
+  char nthd[4];
+
+  fd = popen("LC_ALL=C lscpu | grep 'Thread(s) per core' | awk '{printf $4}'", "r");
+  if (fd == NULL) return -1;
+  if (fgets(nthd, sizeof(nthd), fd) == NULL) return -1;
+  nthread = (int)strtol(nthd, NULL, 10);
+  if (errno == ERANGE || nthread == 0) {
+    return -1;
+  }
+
+  if (pclose(fd) == -1) return -1;
+#elif defined(__APPLE__)
+  FILE *fd;
+  char p_proc[4], l_proc[4];
+  int phys_proc, logic_proc;
+
+  fd = popen("sysctl hw.physicalcpu | awk '{printf $2}'", "r");
+  if (fd == NULL) return -1;
+  if (fgets(p_proc, sizeof(p_proc), fd) == NULL) return -1;
+  fd = popen("sysctl hw.logicalcpu | awk '{printf $2}'", "r");
+  if (fd == NULL) return -1;
+  if (fgets(l_proc, sizeof(l_proc), fd) == NULL) return -1;
+  phys_proc = (int)strtol(p_proc, NULL, 10);
+  if (errno == ERANGE || phys_proc == 0) {
+    return -1;
+  }
+  logic_proc = (int)strtol(l_proc, NULL, 10);
+  if (errno == ERANGE || logic_proc == 0) {
+    return -1;
+  }
+
+  nthread = logic_proc / phys_proc;
+
+  if (pclose(fd) == -1) return -1;
+#else
+  nthread = 1;
+#endif
+  return nthread;
+}


### PR DESCRIPTION
Run MHD by using internal thread (or thread pool) doing  `epoll()`
Set the size of thread pool by cli option
--ta_thread <value>

Create new `iota_client_serivce_t` for each HTTP request to avoid race condition and lock contention.

Correct cli option ta_thread to required argument

close #569

To preserve a least one physical processor, set the limit of threads number to logical processor number - 1(2) (According to whether CPUs support HyperThreading or not)

close #592