### PR TITLE
feat(config): Set buffer list name with CLI

### DIFF
--- a/accelerator/cli_info.h
+++ b/accelerator/cli_info.h
@@ -52,6 +52,8 @@ typedef enum ta_cli_arg_value_e {
   PROXY_API,
   HEALTH_TRACK_PERIOD,
   NO_GTTA,
+  BUFFER_LIST,
+  DONE_LIST,
 
   /** LOGGER */
   QUIET,
@@ -86,6 +88,8 @@ static struct ta_cli_argument_s {
     {"health_track_period", no_argument, NULL, HEALTH_TRACK_PERIOD,
      "The period for checking IRI host connection status"},
     {"no-gtta", no_argument, NULL, NO_GTTA, "Disable getTransactionToConfirm (gTTA) when sending transacation"},
+    {"buffer_list", required_argument, NULL, BUFFER_LIST, "Set the value of `buffer_list_name`"},
+    {"done_list", required_argument, NULL, DONE_LIST, "Set the value of `done_list_name`"},
     {"quiet", no_argument, NULL, QUIET, "Disable logger"},
     {NULL, 0, NULL, 0, NULL}};
 

--- a/accelerator/config.c
+++ b/accelerator/config.c
@@ -192,6 +192,12 @@ status_t cli_core_set(ta_core_t* const core, int key, char* const value) {
     case NO_GTTA:
       ta_conf->gtta = false;
       break;
+    case BUFFER_LIST:
+      cache->buffer_list_name = value;
+      break;
+    case DONE_LIST:
+      cache->done_list_name = value;
+      break;
 
     // File configuration
     case CONF_CLI: {


### PR DESCRIPTION
This PR implement the CLI for `buffer_list_name` and `done_list_name`
Assigning different name for different tests in CI can avoid data racing during CI.