### PR TITLE
fix(core): integrate conflicting IOTA conf and fix incorrect TA conf

### DIFF
--- a/accelerator/config.h
+++ b/accelerator/config.h
@@ -65,12 +65,12 @@ extern "C" {
 
 /** struct type of accelerator configuration */
 typedef struct ta_config_s {
-  char* version;                          /**< Binding version of tangle-accelerator */
-  char* host;                             /**< Binding address of tangle-accelerator */
-  int port;                               /**< Binding port of tangle-accelerator */
-  char* host_list[MAX_IRI_LIST_ELEMENTS]; /**< List of binding host of tangle-accelerator */
-  int port_list[MAX_IRI_LIST_ELEMENTS];   /**< List of binding port of tangle-accelerator */
-  int health_track_period;                /**< The period for checking IRI host connection status */
+  char* version;                                  /**< Binding version of tangle-accelerator */
+  char* host;                                     /**< Binding address of tangle-accelerator */
+  int port;                                       /**< Binding port of tangle-accelerator */
+  char* iota_host_list[MAX_IRI_LIST_ELEMENTS];    /**< List of binding hosts of IOTA services */
+  uint16_t iota_port_list[MAX_IRI_LIST_ELEMENTS]; /**< List of binding ports of IOTA services */
+  int health_track_period;                        /**< The period for checking IRI host connection status */
 #ifdef MQTT_ENABLE
   char* mqtt_host;       /**< Address of MQTT broker host */
   char* mqtt_topic_root; /**< The topic root of MQTT topic */

--- a/accelerator/core/core.c
+++ b/accelerator/core/core.c
@@ -574,23 +574,16 @@ done:
 
 status_t ta_update_iri_conneciton(ta_config_t* const ta_conf, iota_client_service_t* const service) {
   status_t ret = SC_OK;
-  for (int i = 0; i < MAX_IRI_LIST_ELEMENTS && ta_conf->host_list[i]; i++) {
+  for (int i = 0; i < MAX_IRI_LIST_ELEMENTS && ta_conf->iota_host_list[i]; i++) {
     // update new IRI host
-    ta_conf->host = ta_conf->host_list[i];
-    ta_conf->port = ta_conf->port_list[i];
-    service->http.host = ta_conf->host_list[i];
-    service->http.port = ta_conf->port_list[i];
-    ta_log_info("Try tp connect to %s:%d\n", ta_conf->host, ta_conf->port);
 
-    if (iota_client_core_init(service)) {
-      ta_log_error("Initializing IRI connection failed!\n");
-      return RC_CCLIENT_UNIMPLEMENTED;
-    }
-    iota_client_extended_init();
+    service->http.host = ta_conf->iota_host_list[i];
+    service->http.port = ta_conf->iota_port_list[i];
+    ta_log_info("Try to connect to %s:%d\n", service->http.host, service->http.port);
 
     // Run from the first one until found a good one.
     if (ta_get_iri_status(service) == SC_OK) {
-      ta_log_info("Connect to %s:%d\n", ta_conf->host, ta_conf->port);
+      ta_log_info("Connect to %s:%d\n", service->http.host, service->http.port);
       goto done;
     }
   }

--- a/accelerator/main.c
+++ b/accelerator/main.c
@@ -36,7 +36,7 @@ void health_track(void* arg) {
     if (ret == SC_OK) {
       ret = broadcast_buffered_txn(core);
       if (ret) {
-        ta_log_error("Broadcast buffered transactions fialed. %s\n", ta_error_to_string(ret));
+        ta_log_error("Broadcast buffered transactions failed. %s\n", ta_error_to_string(ret));
       }
     }
 


### PR DESCRIPTION
Remove CLI option `iri_address` that will overwrite options `iri_host` and `iri_port`.

Make options  `iri_host` and  `iri_port` support multiple addresses separated by comma.
For example `./accelerator --iri_host  host1,host2, ...`

Correct the misused TA binding port and address.
Correct error casting and range checking of CLI options.

Close #583 #584