### PR TITLE
refactor(mam): Return chid1 with recv_mam_message 

### DIFF
--- a/accelerator/core/mam_core.c
+++ b/accelerator/core/mam_core.c
@@ -373,7 +373,7 @@ status_t ta_mam_api_bundle_read(mam_api_t *const api, bundle_transactions_t *bun
   if (rc == RC_OK) {
     if (payload_trytes == NULL || payload_size == 0) {
       ret = SC_MAM_NO_PAYLOAD;
-      ta_log_error("%s\n", ta_error_to_string(ret));
+      ta_log_debug("%s\n", ta_error_to_string(ret));
     } else {
       *payload_out = calloc(payload_size * 2 + 1, sizeof(char));
       if (*payload_out == NULL) {

--- a/accelerator/core/response/response.h
+++ b/accelerator/core/response/response.h
@@ -14,6 +14,7 @@
 #include "ta_find_transactions_obj.h"
 #include "ta_generate_address.h"
 #include "ta_get_tips.h"
+#include "ta_recv_mam.h"
 #include "ta_send_mam.h"
 #include "ta_send_transfer.h"
 

--- a/accelerator/core/response/ta_recv_mam.c
+++ b/accelerator/core/response/ta_recv_mam.c
@@ -1,0 +1,27 @@
+/*
+ * Copyright (C) 2020 BiiLabs Co., Ltd. and Contributors
+ * All Rights Reserved.
+ * This is free software; you can redistribute it and/or modify it under the
+ * terms of the MIT license. A copy of the license can be found in the file
+ * "LICENSE" at the root of this distribution.
+ */
+
+#include "ta_recv_mam.h"
+ta_recv_mam_res_t* recv_mam_res_new() {
+  ta_recv_mam_res_t* res = (ta_recv_mam_res_t*)malloc(sizeof(ta_recv_mam_res_t));
+  if (res) {
+    memset(res->chid1, 0, NUM_TRYTES_ADDRESS + 1);
+    utarray_new(res->payload_array, &ut_str_icd);
+  }
+  return res;
+}
+
+void recv_mam_res_free(ta_recv_mam_res_t** res) {
+  if (!res || !(*res)) {
+    return;
+  }
+
+  utarray_free((*res)->payload_array);
+  free(*res);
+  *res = NULL;
+}

--- a/accelerator/core/response/ta_recv_mam.h
+++ b/accelerator/core/response/ta_recv_mam.h
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2020 BiiLabs Co., Ltd. and Contributors
+ * All Rights Reserved.
+ * This is free software; you can redistribute it and/or modify it under the
+ * terms of the MIT license. A copy of the license can be found in the file
+ * "LICENSE" at the root of this distribution.
+ */
+
+#ifndef RESPONSE_TA_RECV_MAM_H_
+#define RESPONSE_TA_RECV_MAM_H_
+
+#include "common/macros.h"
+#include "common/ta_errors.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @file accelerator/core/response/ta_recv_mam.h
+ */
+
+/** struct of ta_recv_mam_res_t */
+typedef struct recv_mam_res_s {
+  UT_array* payload_array;
+  char chid1[NUM_TRYTES_HASH + 1];
+} ta_recv_mam_res_t;
+
+/**
+ * @brief Allocate memory of ta_recv_mam_res_t
+ *
+ * @return
+ * - The pointer of the ta_recv_mam_res_t struct
+ * - NULL on error
+ */
+ta_recv_mam_res_t* recv_mam_res_new();
+
+/**
+ * @brief Free memory of ta_recv_mam_res_t
+ *
+ * @param res[in/out] Data type of ta_recv_mam_res_t
+ */
+void recv_mam_res_free(ta_recv_mam_res_t** res);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // RESPONSE_TA_RECV_MAM_H_

--- a/accelerator/core/serializer/serializer.h
+++ b/accelerator/core/serializer/serializer.h
@@ -124,7 +124,7 @@ status_t ta_get_tips_res_serialize(const get_tips_res_t* const res, char** obj);
 status_t ta_insert_identity_res_serialize(const char* hash, const char* uuid_string, char** obj);
 
 /**
- * @brief Deserialze JSON string to type of ta_send_transfer_req_t
+ * @brief Deserialize JSON string to type of ta_send_transfer_req_t
  *
  * @param[in] obj Input values in JSON
  * @param[out] req Request data in type of ta_send_transfer_req_t
@@ -148,7 +148,7 @@ status_t ta_send_transfer_req_deserialize(const char* const obj, ta_send_transfe
 status_t ta_send_transfer_res_serialize(ta_send_transfer_res_t* res, char** obj);
 
 /**
- * @brief Deserialze JSON string to hash8019_array_p
+ * @brief Deserialize JSON string to hash8019_array_p
  *
  * @param[in] obj Input values in JSON
  * @param[out] out_trytes trytes arrary in the request data in type of
@@ -185,7 +185,7 @@ status_t ta_send_trytes_res_serialize(const hash8019_array_p trytes, char** obj)
 status_t ta_find_transaction_object_single_res_serialize(transaction_array_t* res, char** obj);
 
 /**
- * @brief Deserialze type of ta_find_transaction_objects_req_t from JSON string
+ * @brief Deserialize type of ta_find_transaction_objects_req_t from JSON string
  *
  * @param[in] obj List of transaction hashes
  * @param[out] res Response data in type of ta_find_transaction_objects_req_t
@@ -236,17 +236,29 @@ status_t recv_mam_message_req_deserialize(const char* const obj, ta_recv_mam_req
 /**
  * @brief Serialize response of mam message
  *
- * @param[in] payload_array Response of payload message in utarray
- * @param[out] obj message array formed in JSON
+ * @param payload_array[in]  Response of payload message in 'ta_recv_mam_res_t' datatype
+ * @param obj[out] Message array formed in JSON
  *
  * @return
  * - SC_OK on success
  * - non-zero on error
  */
-status_t recv_mam_message_res_serialize(UT_array* const payload_array, char** obj);
+status_t recv_mam_message_res_serialize(ta_recv_mam_res_t* const res, char** obj);
 
 /**
- * @brief Deserialze JSON string to type of ta_send_mam_req_t
+ * @brief Deserialize JSON string to type of ta_recv_mam_res_t
+ *
+ * @param[in] obj Input values in JSON
+ * @param[out] req Request data in type of ta_recv_mam_res_t
+ *
+ * @return
+ * - SC_OK on success
+ * - non-zero on error
+ */
+status_t recv_mam_res_deserialize(const char* const obj, ta_recv_mam_res_t* const res);
+
+/**
+ * @brief Deserialize JSON string to type of ta_send_mam_req_t
  *
  * @param[in] obj Input values in JSON
  * @param[out] req Request data in type of ta_send_mam_req_t
@@ -258,7 +270,7 @@ status_t recv_mam_message_res_serialize(UT_array* const payload_array, char** ob
 status_t send_mam_req_deserialize(const char* const obj, ta_send_mam_req_t* req);
 
 /**
- * @brief Deserialze JSON string to type of ta_send_mam_res_t
+ * @brief Deserialize JSON string to type of ta_send_mam_res_t
  *
  * @param[in] obj Input values in JSON
  * @param[out] res Response data in type of ta_send_mam_res_t
@@ -295,7 +307,7 @@ status_t send_mam_res_serialize(const ta_send_mam_res_t* const res, char** obj);
 status_t mqtt_device_id_deserialize(const char* const obj, char* device_id);
 
 /**
- * @brief Deserialze tag in string from MQTT JSON request.
+ * @brief Deserialize tag in string from MQTT JSON request.
  *
  * @param[in] obj Input request in JSON with tag field
  * @param[out] tag Tag in string
@@ -307,7 +319,7 @@ status_t mqtt_device_id_deserialize(const char* const obj, char* device_id);
 status_t mqtt_tag_req_deserialize(const char* const obj, char* tag);
 
 /**
- * @brief Deserialze transaction hash in string from MQTT JSON request.
+ * @brief Deserialize transaction hash in string from MQTT JSON request.
  *
  * @param[in] obj Input request in JSON with hash field
  * @param[out] hash Transaction hash in string
@@ -320,7 +332,7 @@ status_t mqtt_transaction_hash_req_deserialize(const char* const obj, char* hash
 #endif
 
 /**
- * @brief Deserialze proxy api command.
+ * @brief Deserialize proxy api command.
  *
  * @param[in] obj Input request in JSON with hash field
  * @param[out] command Proxy API command name in string
@@ -332,7 +344,7 @@ status_t mqtt_transaction_hash_req_deserialize(const char* const obj, char* hash
 status_t proxy_apis_command_req_deserialize(const char* const obj, char* command);
 
 /**
- * @brief Deserialze latestMilestone and latestSolidSubtangleMilestone from IRI core API getNodeInfo
+ * @brief Deserialize latestMilestone and latestSolidSubtangleMilestone from IRI core API getNodeInfo
  *
  * @param[in] obj getNodeInfo response in JSON.
  * @param[out] latestMilestoneIndex Index of latestMilestone

--- a/tests/unit-test/test_serializer.c
+++ b/tests/unit-test/test_serializer.c
@@ -309,6 +309,42 @@ void test_recv_mam_message_request_ntru_deserialize(void) {
   recv_mam_req_free(&req);
 }
 
+void test_recv_mam_message_response_serialize(void) {
+  const char* json = "{\"payload\":[\"" TRYTES_81_1 "\",\"" TRYTES_81_2 "\"],\"chid1\":\"" TEST_ADDRESS "\"}";
+  ta_recv_mam_res_t* res = recv_mam_res_new();
+  char* json_result = NULL;
+  char* str;
+  str = TRYTES_81_1;
+  utarray_push_back(res->payload_array, &str);
+  str = TRYTES_81_2;
+  utarray_push_back(res->payload_array, &str);
+  strncpy(res->chid1, TEST_ADDRESS, NUM_TRYTES_ADDRESS);
+
+  TEST_ASSERT_EQUAL_INT32(SC_OK, recv_mam_message_res_serialize(res, &json_result));
+  TEST_ASSERT_EQUAL_STRING(json, json_result);
+
+  recv_mam_res_free(&res);
+  free(json_result);
+}
+
+void test_recv_mam_message_response_deserialize(void) {
+  const char* json = "{\"payload\":[\"" TRYTES_81_1 "\",\"" TRYTES_81_2 "\"],\"chid1\":\"" TEST_ADDRESS "\"}";
+  ta_recv_mam_res_t* res = recv_mam_res_new();
+  char* json_result = NULL;
+  char* str;
+  str = TRYTES_81_1;
+  utarray_push_back(res->payload_array, &str);
+  str = TRYTES_81_2;
+  utarray_push_back(res->payload_array, &str);
+  strncpy(res->chid1, TEST_ADDRESS, NUM_TRYTES_ADDRESS);
+
+  TEST_ASSERT_EQUAL_INT32(SC_OK, recv_mam_message_res_serialize(res, &json_result));
+  TEST_ASSERT_EQUAL_STRING(json, json_result);
+
+  recv_mam_res_free(&res);
+  free(json_result);
+}
+
 void test_send_mam_message_request_deserialize(void) {
   const char* json =
       "{\"x-api-key\":\"" TEST_TOKEN "\",\"data\":{\"seed\":\"" TRYTES_81_1 "\",\"message\":\"" TEST_PAYLOAD
@@ -560,6 +596,7 @@ int main(void) {
   RUN_TEST(test_serialize_ta_find_transactions_obj_by_tag);
   RUN_TEST(test_recv_mam_message_request_psk_deserialize);
   RUN_TEST(test_recv_mam_message_request_ntru_deserialize);
+  RUN_TEST(test_recv_mam_message_response_serialize);
   RUN_TEST(test_send_mam_message_request_deserialize);
   RUN_TEST(test_send_mam_message_response_serialize);
   RUN_TEST(test_send_mam_message_response_deserialize);


### PR DESCRIPTION
If the chid1 (the next channel ID) existed, then return it in the
API response.

The tests of `test_send_read_mam_bundle()` has been covered by
other tests.

Close #593 