### PR TITLE
refactor: Cleanup improper/redundant operations

### DIFF
--- a/accelerator/core/response/ta_fetch_txn_with_uuid.c
+++ b/accelerator/core/response/ta_fetch_txn_with_uuid.c
@@ -10,8 +10,10 @@
 
 ta_fetch_txn_with_uuid_res_t* ta_fetch_txn_with_uuid_res_new() {
   ta_fetch_txn_with_uuid_res_t* res = (ta_fetch_txn_with_uuid_res_t*)malloc(sizeof(ta_fetch_txn_with_uuid_res_t));
-  res->txn = NULL;
-  res->status = NOT_EXIST;
+  if (res) {
+    res->txn = NULL;
+    res->status = NOT_EXIST;
+  }
   return res;
 }
 

--- a/accelerator/core/response/ta_find_transactions.c
+++ b/accelerator/core/response/ta_find_transactions.c
@@ -22,9 +22,7 @@ void ta_find_transactions_res_free(ta_find_transactions_by_tag_res_t** res) {
     return;
   }
 
-  if ((*res)->hashes) {
-    hash243_queue_free(&(*res)->hashes);
-  }
+  hash243_queue_free(&(*res)->hashes);
   free(*res);
   *res = NULL;
 }

--- a/accelerator/core/response/ta_find_transactions_obj.c
+++ b/accelerator/core/response/ta_find_transactions_obj.c
@@ -24,7 +24,6 @@ void ta_find_transactions_obj_res_free(ta_find_transactions_obj_res_t** res) {
   }
 
   if ((*res)->txn_obj) {
-    utarray_clear((*res)->txn_obj);
     utarray_free((*res)->txn_obj);
   }
   free(*res);

--- a/accelerator/core/response/ta_send_transfer.c
+++ b/accelerator/core/response/ta_send_transfer.c
@@ -10,8 +10,10 @@
 
 ta_send_transfer_res_t* ta_send_transfer_res_new() {
   ta_send_transfer_res_t* res = (ta_send_transfer_res_t*)malloc(sizeof(ta_send_transfer_res_t));
-  res->hash = NULL;
-  res->uuid = NULL;
+  if (res) {
+    res->hash = NULL;
+    res->uuid = NULL;
+  }
   return res;
 }
 


### PR DESCRIPTION
Some initializers of the datatype of tangle-accelerator don't have
the protection if-condition for Out Of Memory situation.

if-condition of `(*res)->hashes` and `utarray_clear()` for
`(*res)->txn_obj` are both redundant, so we could remove them.

Fix #596