### PR TITLE
cleanup(endpoint): Eliminate compilation warnings

### DIFF
--- a/endpoint/BUILD
+++ b/endpoint/BUILD
@@ -3,13 +3,13 @@ cc_library(
     srcs = ["endpoint.c"],
     hdrs = ["endpoint.h"],
     defines = [
-        "TA_HOST=\"tangle-accel.biilabs.io\"",
-        "TA_PORT=\"443\"",
-        "TA_SSL_SEED=\"nonce\"",
+        "ENDPOINT_HOST=\"tangle-accel.biilabs.io\"",
+        "ENDPOINT_PORT=\"443\"",
+        "ENDPOINT_SSL_SEED=\"nonce\"",
     ],
     visibility = ["//visibility:public"],
     deps = [
-        "//common:defined_error",
+        "//common",
         "//utils:cipher",
         "//utils:https",
         "//utils:text_serializer",

--- a/endpoint/hal/BUILD
+++ b/endpoint/hal/BUILD
@@ -4,4 +4,7 @@ cc_library(
     name = "hal",
     srcs = ["device.c"],
     hdrs = ["device.h"],
+    deps = [
+        "//common",
+    ],
 )

--- a/endpoint/hal/device.c
+++ b/endpoint/hal/device.c
@@ -36,11 +36,11 @@ status_t register_device(struct device_type *dv) {
   status_t res = SC_OK;
   struct device_type **p;
   if (dv->next) {
-    return SC_DEVICE_INIT;
+    return SC_ENDPOINT_DEVICE_INIT;
   }
   p = find_device(dv->name, strlen(dv->name));
   if (*p) {
-    res = SC_DEVICE_INIT;
+    res = SC_ENDPOINT_DEVICE_INIT;
   } else {
     *p = dv;
   }
@@ -55,5 +55,5 @@ status_t unregister_device(struct device_type *dv) {
       return SC_OK;
     }
   }
-  return SC_DEVICE_FINI;
+  return SC_ENDPOINT_DEVICE_FINI;
 }

--- a/endpoint/hal/device.h
+++ b/endpoint/hal/device.h
@@ -17,7 +17,7 @@ extern "C" {
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include "ta_errors.h"
+#include "common/ta_errors.h"
 
 /*! device initialization entry point */
 #define DECLARE_DEVICE(name)                                  \
@@ -113,7 +113,7 @@ device_t *ta_device(const char *device);
  *
  * @return
  * - #SC_OK on success
- * - #SC_DEVICE_INIT on failed
+ * - #SC_ENDPOINT_DEVICE_INIT on failed
  */
 status_t register_device(struct device_type *dv);
 
@@ -124,7 +124,7 @@ status_t register_device(struct device_type *dv);
  *
  * @return
  * - #SC_OK on success
- * - #SC_DEVICE_FINI on failed
+ * - #SC_ENDPOINT_DEVICE_FINI on failed
  */
 status_t unregister_device(struct device_type *dv);
 

--- a/endpoint/test_endpoint.c
+++ b/endpoint/test_endpoint.c
@@ -19,10 +19,6 @@
 #define TEST_VALUE 0
 #define TEST_MESSAGE "THISISMSG9THISISMSG9THISISMSG"
 #define TEST_MESSAGE_FMT "ascii"
-#define TEST_TAG "POWEREDBYTANGLEACCELERATOR9"
-#define TEST_ADDRESS                                                           \
-  "POWEREDBYTANGLEACCELERATOR999999999999999999999999999999999999999999999999" \
-  "999999A"
 #define TEST_DEVICE_ID "470010171566423"
 
 #define TEST_REQ_BODY                               \
@@ -37,16 +33,14 @@ const uint8_t test_iv[AES_IV_SIZE] = {164, 3, 98, 193, 52, 162, 107, 252, 184, 4
 void gen_rand_trytes(uint8_t *out, size_t len) {
   const char tryte_alphabet[] = "9ABCDEFGHIJKLMNOPQRSTUVWXYZ";
   const int alphabet_array_length = ARRAY_SIZE(tryte_alphabet);
-  for (int i = 0; i < len; i++) {
+  for (size_t i = 0; i < len; i++) {
     uint8_t rand_index = rand() % alphabet_array_length;
     out[i] = tryte_alphabet[rand_index];
   }
 }
 
 void test_endpoint(void) {
-  uint8_t *address = TEST_ADDRESS;
   uint8_t next_addr[ADDR_LEN] = {0};
-  char raw_msg[MAX_MSG_LEN] = {0};
   uint8_t iv[AES_IV_SIZE] = {0};
 
   memcpy(iv, test_iv, AES_IV_SIZE);
@@ -62,11 +56,11 @@ void test_endpoint(void) {
   gen_rand_trytes(next_addr, ADDR_LEN);
 
   status_t ret = send_transaction_information(TEST_VALUE, TEST_MESSAGE, TEST_MESSAGE_FMT, TEST_TAG, TEST_ADDRESS,
-                                              next_addr, test_key, TEST_DEVICE_ID, iv);
+                                              (char *)next_addr, test_key, TEST_DEVICE_ID, iv);
   TEST_ASSERT(ret == SC_OK);
 }
 
-int main(int argc, char *argv[]) {
+int main(void) {
   UNITY_BEGIN();
   RUN_TEST(test_endpoint);
   return UNITY_END();

--- a/tests/unit-test/test_cipher.c
+++ b/tests/unit-test/test_cipher.c
@@ -15,10 +15,10 @@
 
 #define MAXLINE 1024
 
-const char test_payload1[] = "0123456789abcdef";
+char test_payload1[] = "0123456789abcdef";
 const size_t test_paylen1 = 16;
 
-const uint8_t test_payload2[] = {
+uint8_t test_payload2[] = {
     99,  44,  121, 217, 149, 161, 127, 33,  133, 77,  125, 156, 53,  53,  248, 95,  57,  196, 141, 90,  121, 158,
     133, 218, 153, 153, 24,  84,  32,  245, 68,  131, 33,  189, 93,  182, 94,  220, 215, 227, 42,  85,  127, 95,
     138, 119, 190, 196, 60,  75,  30,  181, 233, 164, 143, 130, 61,  167, 214, 93,  156, 26,  225, 189, 216, 62,
@@ -46,7 +46,7 @@ void test_cipher1(void) {
   uint8_t ciphertext[MAXLINE] = {0};
   uint8_t plaintext[MAXLINE] = {0};
 
-  ta_cipher_ctx encrypt_ctx = {.plaintext = test_payload1,
+  ta_cipher_ctx encrypt_ctx = {.plaintext = (uint8_t*)test_payload1,
                                .plaintext_len = test_paylen1,
                                .ciphertext = ciphertext,
                                .ciphertext_len = MAXLINE,

--- a/tests/unit-test/test_text_serializer.c
+++ b/tests/unit-test/test_text_serializer.c
@@ -35,11 +35,12 @@ void tearDown(void) {}
 
 void test_serialize_deserialize(void) {
   uint8_t out[1024], iv_out[AES_BLOCK_SIZE], payload_out[1024];
-  uint32_t payload_len_out, out_msg_len;
-  int rc1 = serialize_msg(iv, payload_len, payload, out, &out_msg_len);
-  TEST_ASSERT_EQUAL_INT32(SC_OK, rc1);
-  int rc2 = deserialize_msg(out, iv_out, &payload_len_out, payload_out);
-  TEST_ASSERT_EQUAL_INT32(SC_OK, rc2);
+
+  size_t payload_len_out, out_msg_len;
+  int rc1 = serialize_msg(iv, payload_len, (char*)payload, (char*)out, &out_msg_len);
+  TEST_ASSERT(rc1 == SC_OK);
+  int rc2 = deserialize_msg((char*)out, iv_out, &payload_len_out, (char*)payload_out);
+  TEST_ASSERT(rc2 == SC_OK);
 
   out[1023] = 0;
   payload_out[payload_len] = 0;

--- a/tests/unit-test/test_tryte_byte_conv.c
+++ b/tests/unit-test/test_tryte_byte_conv.c
@@ -6,6 +6,7 @@
  * "LICENSE" at the root of this distribution.
  */
 
+#include <stdint.h>
 #include <stdio.h>
 #include <string.h>
 #include "tests/test_define.h"
@@ -16,13 +17,13 @@ void setUp(void) {}
 void tearDown(void) {}
 
 void test_bytes_trytes_bytes_conv(void) {
-  const char test_str[1024] = {48, 48, 48, 48, 48, 0,  48, 48, 48, 48, 48, 48, 48, 48,
-                               48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48};
+  const uint8_t test_str[1024] = {48, 48, 48, 48, 48, 0,  48, 48, 48, 48, 48, 48, 48, 48,
+                                  48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48};
   const int str_len = 28;
   char enc_msg[1024] = {0}, dec_msg[1024] = {0};
 
   bytes_to_trytes(test_str, str_len, enc_msg);
-  trytes_to_bytes(enc_msg, strlen(enc_msg), dec_msg);
+  trytes_to_bytes((uint8_t*)enc_msg, strlen(enc_msg), dec_msg);
 
   TEST_ASSERT_EQUAL_INT8_ARRAY(test_str, dec_msg, str_len);
 }

--- a/utils/cipher.h
+++ b/utils/cipher.h
@@ -31,7 +31,7 @@ typedef struct ta_cipher_ctx {
   size_t ciphertext_len;   /**< Ciphertext length */
   uint8_t iv[AES_IV_SIZE]; /**< Initialization vector, mbedtls_aes needs r/w iv[] */
   const uint8_t* key;      /**< Encryption key */
-  const uint8_t keybits;   /**< Bits of key, valid options are 128,192,256 bits */
+  const size_t keybits;    /**< Bits of key, valid options are 128,192,256 bits */
   const char* device_id;   /**< Device id */
 } ta_cipher_ctx;
 

--- a/utils/connectivity/BUILD
+++ b/utils/connectivity/BUILD
@@ -7,7 +7,7 @@ cc_library(
         "conn_http.h",
     ],
     deps = [
-        "//common:defined_error",
+        "//common",
         "//pem:cert",
         "//third_party:http-parser",
         "//third_party:mbedtls",

--- a/utils/connectivity/conn_http.c
+++ b/utils/connectivity/conn_http.c
@@ -120,7 +120,8 @@ status_t http_open(connect_info_t *const info, char const *const seed_nonce, cha
 }
 
 status_t http_send_request(connect_info_t *const info, const char *req) {
-  size_t req_len = strlen(req), write_len = 0, ret_len;
+  size_t req_len = strlen(req), write_len = 0;
+  int ret_len;
 
   while (write_len < req_len) {
     if (info->https) {

--- a/utils/https.c
+++ b/utils/https.c
@@ -15,8 +15,7 @@
 
 static http_parser parser;
 
-status_t send_https_msg(char const *host, char const *port, char const *api, const char *msg, const int msg_len,
-                        const char *ssl_seed) {
+status_t send_https_msg(char const *host, char const *port, char const *api, const char *msg, const char *ssl_seed) {
   char res[4096] = {0};
   char *req = NULL;
   status_t ret = SC_OK;

--- a/utils/https.h
+++ b/utils/https.h
@@ -18,11 +18,9 @@
  * @param[in] port HTTP(S) port
  * @param[in] api API path for POST request to HTTP(S) server, i.e "transaction/". It must be in string.
  * @param[in] msg Message to send
- * @param[in] msg_len Length of message
  * @param[in] ssl_seed Seed for ssl connection
  *
  * @return #status_t
  */
-status_t send_https_msg(char const *host, char const *port, char const *api, const char *msg, const int msg_len,
-                        const char *ssl_seed);
+status_t send_https_msg(char const *host, char const *port, char const *api, const char *msg, const char *ssl_seed);
 #endif  // UTILS_HTTPS_H

--- a/utils/text_serializer.c
+++ b/utils/text_serializer.c
@@ -15,7 +15,7 @@
 #define UINT32_LEN 10
 
 status_t serialize_msg(const uint8_t *iv, uint32_t ciphertext_len, const char *ciphertext, char *out_msg,
-                       uint32_t *out_msg_len) {
+                       size_t *out_msg_len) {
   /* FIXME: Provide some checks here */
   char str_ciphertext_len[UINT32_LEN + 1] = {0};
   char *ptr = out_msg;
@@ -38,7 +38,7 @@ status_t serialize_msg(const uint8_t *iv, uint32_t ciphertext_len, const char *c
   return SC_OK;
 }
 
-status_t deserialize_msg(char *msg, const uint8_t *iv, uint32_t *ciphertext_len, char *ciphertext) {
+status_t deserialize_msg(char *msg, const uint8_t *iv, size_t *ciphertext_len, char *ciphertext) {
   /* FIXME: Provide some checks here */
   char str_ciphertext_len[UINT32_LEN + 1] = {};
   char *ptr = msg;

--- a/utils/text_serializer.h
+++ b/utils/text_serializer.h
@@ -9,6 +9,7 @@
 #ifndef TEXT_SERIALIZER_H
 #define TEXT_SERIALIZER_H
 
+#include <stddef.h>
 #include <stdint.h>
 #include "common/ta_errors.h"
 
@@ -34,7 +35,7 @@ extern "C" {
  * - SC_UTILS_TEXT_SERIALIZE on error
  */
 status_t serialize_msg(const uint8_t *iv, uint32_t ciphertext_len, const char *ciphertext, char *out_msg,
-                       uint32_t *out_msg_len);
+                       size_t *out_msg_len);
 
 /**
  * @brief Deserialize message from serialize_msg
@@ -49,7 +50,7 @@ status_t serialize_msg(const uint8_t *iv, uint32_t ciphertext_len, const char *c
  * - SC_UTILS_TEXT_DESERIALIZE on error
  * @see #serialize_msg
  */
-status_t deserialize_msg(char *msg, const uint8_t *iv, uint32_t *ciphertext_len, char *ciphertext);
+status_t deserialize_msg(char *msg, const uint8_t *iv, size_t *ciphertext_len, char *ciphertext);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Eliminate compilation warnings when building utils, test and endpoint.
The warning was generated from -Wextra's sign-compare flag.
Close #603