### PR TITLE
refactor(mam): refactor MAM APIs

### DIFF
--- a/accelerator/core/apis.h
+++ b/accelerator/core/apis.h
@@ -10,9 +10,7 @@
 #define CORE_APIS_H_
 
 #include "accelerator/core/core.h"
-#include "common/trinary/trit_tryte.h"
-#include "mam/api/api.h"
-#include "mam/mam/mam_channel_t_set.h"
+#include "accelerator/core/mam_core.h"
 #include "serializer/serializer.h"
 
 #ifdef __cplusplus
@@ -126,41 +124,41 @@ status_t api_get_tips_pair(const iota_config_t* const iconf, const iota_client_s
 status_t api_get_tips(const iota_client_service_t* const service, char** json_result);
 
 /**
- * @brief Receive a MAM message.
+ * @brief Receive MAM messages.
  *
- * Receive a MAM message from given bundle hash.
+ * Receive a MAM message from given channel id or bundle hash.
  *
- * @param[in] service IOTA node service
- * @param[in] chid channel ID string
- * @param[out] json_result Fetched MAM message in JSON format
+ * @param iconf[in] IOTA API parameter configurations
+ * @param service[in] IOTA node service
+ * @param obj[in] Input data in JSON
+ * @param json_result[out] Fetched MAM message in JSON format
  *
  * @return
  * - SC_OK on success
  * - non-zero on error
  */
 status_t api_recv_mam_message(const iota_config_t* const iconf, const iota_client_service_t* const service,
-                              const char* const chid, char** json_result);
+                              const char* const obj, char** json_result);
 
 /**
  * @brief Send a MAM message with given Payload.
  *
- * Send a MAM message from given Payload(ascii message).
+ * Send a MAM message from given request format.
  * There is no need to decode the ascii payload to tryte, since the
  * api_send_mam_message() will take this job.
  *
- * @param[in] info Tangle-accelerator configuration variables
- * @param[in] iconf IOTA API parameter configurations
- * @param[in] service IOTA node service
- * @param[in] payload message to send undecoded ascii string.
- * @param[out] json_result Result containing channel id and bundle hash
+ * @param info[in] Tangle-accelerator configuration variables
+ * @param iconf[in] IOTA API parameter configurations
+ * @param service[in] IOTA node service
+ * @param obj[in] Input data in JSON
+ * @param json_result[out] Result containing channel id, message id and bundle hash
  *
  * @return
  * - SC_OK on success
  * - non-zero on error
  */
 status_t api_send_mam_message(const ta_config_t* const info, const iota_config_t* const iconf,
-                              const iota_client_service_t* const service, char const* const payload,
-                              char** json_result);
+                              const iota_client_service_t* const service, char const* const obj, char** json_result);
 
 /**
  * @brief Send transfer to tangle.

--- a/accelerator/core/mam_core.c
+++ b/accelerator/core/mam_core.c
@@ -156,16 +156,53 @@ static mam_endpoint_t *mam_api_endpoint_get(mam_api_t const *const api, tryte_t 
   return NULL;
 }
 
-/***********************************************************************************************************
- * External functions
- ***********************************************************************************************************/
+/**
+ * @brief Add all the keys in the list of Pre-Shared Key and NTRU public key into corresponding key set.
+ *
+ * @param psks[in] Pre-Shared Key set
+ * @param ntru_pks[in] NTRU public key set
+ * @param psk[in] List of Pre-Shared Key
+ * @param ntru_pk[in] List of NTRU public key
+ *
+ * @return status code
+ */
+static status_t ta_set_mam_key(mam_psk_t_set_t *const psks, mam_ntru_pk_t_set_t *const ntru_pks,
+                               UT_array const *const psk, UT_array const *const ntru_pk) {
+  char **p = NULL;
+  if (psk) {
+    mam_psk_t psk_obj;
+    while ((p = (char **)utarray_next(psk, p))) {
+      trytes_to_trits((tryte_t *)*p, psk_obj.key, NUM_TRYTES_MAM_PSK_KEY_SIZE);
+      if (mam_psk_t_set_add(psks, &psk_obj) != RC_OK) {
+        ta_log_error("%s\n", "SC_MAM_FAILED_INIT");
+        return SC_MAM_FAILED_INIT;
+      }
+    }
+  }
 
-void bundle_transactions_renew(bundle_transactions_t **bundle) {
-  bundle_transactions_free(bundle);
-  bundle_transactions_new(bundle);
+  if (ntru_pk) {
+    mam_ntru_pk_t ntru_pk_obj;
+    while ((p = (char **)utarray_next(ntru_pk, p))) {
+      trytes_to_trits((tryte_t *)*p, ntru_pk_obj.key, NUM_TRYTES_MAM_NTRU_PK_SIZE);
+      if (mam_ntru_pk_t_set_add(ntru_pks, &ntru_pk_obj) != RC_OK) {
+        ta_log_error("%s\n", "SC_MAM_FAILED_INIT");
+        return SC_MAM_FAILED_INIT;
+      }
+    }
+  }
+  return SC_OK;
 }
 
-status_t ta_mam_init(mam_api_t *const api, const iota_config_t *const iconf, tryte_t const *const seed) {
+/**
+ * @brief Initialize a mam_api_t object
+ *
+ * @param api[in,out] The MAM API object
+ * @param iconf[in] IOTA API parameter configurations
+ * @param seed[in] Seed of MAM channels. It is an optional choice
+ *
+ * @return return code
+ */
+static status_t ta_mam_init(mam_api_t *const api, const iota_config_t *const iconf, tryte_t const *const seed) {
   if (!api || (!iconf && !seed)) {
     return SC_MAM_NULL;
   }
@@ -192,36 +229,9 @@ status_t ta_mam_init(mam_api_t *const api, const iota_config_t *const iconf, try
   return SC_OK;
 }
 
-status_t ta_set_mam_key(mam_psk_t_set_t *const psks, mam_ntru_pk_t_set_t *const ntru_pks, UT_array const *const psk,
-                        UT_array const *const ntru_pk) {
-  char **p = NULL;
-  if (psk) {
-    mam_psk_t psk_obj;
-    while ((p = (char **)utarray_next(psk, p))) {
-      trytes_to_trits((tryte_t *)*p, psk_obj.key, NUM_TRYTES_MAM_PSK_KEY_SIZE);
-      if (mam_psk_t_set_add(psks, &psk_obj) != RC_OK) {
-        ta_log_error("%s\n", "SC_MAM_FAILED_INIT");
-        return SC_MAM_FAILED_INIT;
-      }
-    }
-  }
-
-  if (ntru_pk) {
-    mam_ntru_pk_t ntru_pk_obj;
-    while ((p = (char **)utarray_next(ntru_pk, p))) {
-      trytes_to_trits((tryte_t *)*p, ntru_pk_obj.key, NUM_TRYTES_MAM_NTRU_PK_SIZE);
-      if (mam_ntru_pk_t_set_add(ntru_pks, &ntru_pk_obj) != RC_OK) {
-        ta_log_error("%s\n", "SC_MAM_FAILED_INIT");
-        return SC_MAM_FAILED_INIT;
-      }
-    }
-  }
-  return SC_OK;
-}
-
-status_t create_channel_fetch_all_transactions(const iota_client_service_t *const service, mam_api_t *const api,
-                                               const size_t channel_depth, tryte_t *const chid,
-                                               hash81_array_p tag_array) {
+static status_t create_channel_fetch_all_transactions(const iota_client_service_t *const service, mam_api_t *const api,
+                                                      const size_t channel_depth, tryte_t *const chid,
+                                                      hash81_array_p tag_array) {
   status_t ret = SC_OK;
   find_transactions_req_t *txn_req = find_transactions_req_new();
   transaction_array_t *obj_res = transaction_array_new();
@@ -256,13 +266,31 @@ done:
   return ret;
 }
 
-status_t ta_mam_written_msg_to_bundle(const iota_client_service_t *const service, mam_api_t *const api,
-                                      const size_t channel_depth, tryte_t *const chid, mam_psk_t_set_t psks,
-                                      mam_ntru_pk_t_set_t ntru_pks, char const *const payload,
-                                      bundle_transactions_t **bundle, tryte_t *msg_id,
-                                      mam_mss_key_status_t *key_status) {
+/**
+ * @brief Write payload to bundle on the smallest secret key.
+ *
+ * With given channel_depth and endpoint_depth, generate the corresponding Channel ID and Endpoint ID, and write the
+ * payload to a bundle. The payload is signed with secret key which has the smallest ordinal number.
+ *
+ * @param service[in] IOTA node service
+ * @param api[in,out] The MAM API object
+ * @param channel_depth[in] Depth of channel merkle tree
+ * @param mam_key[in] Key object to encrypt MAM mesage
+ * @param payload[in] The message that is going to send with MAM
+ * @param bundle[out] The bundle contains the Header and Packets of the current Message
+ * @param chid[out] Channel ID
+ * @param msg_id[out] Unique Message identifier under each channel
+ * @param mam_operation[out]
+ *
+ * @return return code
+ */
+static status_t ta_mam_written_msg_to_bundle(const iota_client_service_t *const service, mam_api_t *const api,
+                                             const size_t channel_depth, mam_encrypt_key_t mam_key,
+                                             char const *const payload, bundle_transactions_t **bundle,
+                                             tryte_t *const chid, tryte_t *const msg_id,
+                                             mam_send_operation_t *mam_operation) {
   status_t ret = SC_OK;
-  if (!service || !api || !chid || channel_depth < 1) {
+  if (!service || !api || !chid || !msg_id || channel_depth < 1) {
     ret = SC_MAM_NULL;
     ta_log_error("%s\n", ta_error_to_string(ret));
     return ret;
@@ -295,7 +323,7 @@ status_t ta_mam_written_msg_to_bundle(const iota_client_service_t *const service
       used_key_num--;
       ch_remain_key_num--;
 
-      if (ta_mam_write_header(api, chid, psks, ntru_pks, *bundle, msg_id_trits)) {
+      if (ta_mam_write_header(api, chid, mam_key.psks, mam_key.ntru_pks, *bundle, msg_id_trits)) {
         ret = SC_MAM_FAILED_WRITE;
         ta_log_error("%s\n", "SC_MAM_FAILED_WRITE");
         goto done;
@@ -312,13 +340,13 @@ status_t ta_mam_written_msg_to_bundle(const iota_client_service_t *const service
     if (ch_remain_key_num == 1) {
       // Publish announcement, when there is only one mss key available.
       ta_log_debug("%s\n", "Publish announcement for the next channel.");
-      *key_status = ANNOUNCE_CHID;
+      *mam_operation = ANNOUNCE_CHID;
       break;
     } else if (ch_remain_key_num == 0 && used_key_num == 0) {
       // Check the next channel, since all the mss key are used in current channel
       continue;
     } else {
-      *key_status = KEY_AVAILABLE;
+      *mam_operation = SEND_MESSAGE;
       break;
     }
   }
@@ -337,34 +365,51 @@ done:
   return ret;
 }
 
-status_t ta_mam_write_announce_to_bundle(mam_api_t *const api, const size_t channel_depth,
-                                         mam_mss_key_status_t key_status, tryte_t *const chid, mam_psk_t_set_t psks,
-                                         mam_ntru_pk_t_set_t ntru_pks, tryte_t *const chid1,
-                                         bundle_transactions_t **bundle) {
+/**
+ * @brief Write an announcement to bundle.
+ *
+ * Write the announcement of the next Channel ID.
+ *
+ * @param api[in,out] The MAM API object
+ * @param channel_depth[in] Depth of channel merkle tree
+ * @param chid[in] Channel ID
+ * @param mam_key[in] Key object to encrypt MAM mesage
+ * @param chid1[in] The next Channel ID
+ * @param bundle[out] The bundle which contains the Header and Packets of the current Message
+ *
+ * @return return code
+ */
+static status_t ta_mam_write_announce_to_bundle(mam_api_t *const api, const size_t channel_depth, tryte_t *const chid,
+                                                mam_encrypt_key_t mam_key, tryte_t *const chid1,
+                                                bundle_transactions_t **bundle) {
   status_t ret = SC_OK;
   trit_t msg_id[MAM_MSG_ID_SIZE];
+  if (mam_api_channel_create(api, channel_depth, chid1) != RC_OK) {
+    ret = SC_MAM_FAILED_CREATE_OR_GET_ID;
+    ta_log_error("%s\n", "SC_MAM_FAILED_CREATE_OR_GET_ID");
+    goto done;
+  }
 
-  if (key_status == ANNOUNCE_CHID) {
-    if (mam_api_channel_create(api, channel_depth, chid1) != RC_OK) {
-      ret = SC_MAM_FAILED_CREATE_OR_GET_ID;
-      ta_log_error("%s\n", "SC_MAM_FAILED_CREATE_OR_GET_ID");
-      goto done;
-    }
-
-    if (mam_api_bundle_announce_channel(api, chid, chid1, psks, ntru_pks, *bundle, msg_id) != RC_OK) {
-      ret = SC_MAM_FAILED_WRITE_HEADER;
-      ta_log_error("%s\n", "SC_MAM_FAILED_WRITE_HEADER");
-      goto done;
-    }
-    tryte_t msg_id_tryte[NUM_TRYTES_MAM_MSG_ID + 1] = {};
-    trits_to_trytes(msg_id, msg_id_tryte, NUM_TRYTES_MAM_MSG_ID);
+  if (mam_api_bundle_announce_channel(api, chid, chid1, mam_key.psks, mam_key.ntru_pks, *bundle, msg_id) != RC_OK) {
+    ret = SC_MAM_FAILED_WRITE_HEADER;
+    ta_log_error("%s\n", "SC_MAM_FAILED_WRITE_HEADER");
+    goto done;
   }
 
 done:
   return ret;
 }
 
-status_t ta_mam_api_bundle_read(mam_api_t *const api, bundle_transactions_t *bundle, char **payload_out) {
+/**
+ * @brief Read the MAM message from a bundle
+ *
+ * @param api[in] The MAM API object
+ * @param bundle[in] The bundle that contains the message
+ * @param payload_out[out] The output playload in ascii
+ *
+ * @return status code
+ */
+static status_t ta_mam_api_bundle_read(mam_api_t *const api, bundle_transactions_t *bundle, char **payload_out) {
   status_t ret = SC_OK;
   tryte_t *payload_trytes = NULL;
   size_t payload_size = 0;
@@ -385,10 +430,196 @@ status_t ta_mam_api_bundle_read(mam_api_t *const api, bundle_transactions_t *bun
     }
   } else {
     ret = SC_MAM_MESSAGE_NOT_FOUND;
-    ta_log_error("entangled retcode_t:%d, %s\n", rc, error_2_string(rc));
+    ta_log_error("retcode_t:%d, %s\n", rc, error_2_string(rc));
   }
 
 done:
   free(payload_trytes);
+  return ret;
+}
+
+/***********************************************************************************************************
+ * External functions
+ ***********************************************************************************************************/
+
+void bundle_transactions_renew(bundle_transactions_t **bundle) {
+  bundle_transactions_free(bundle);
+  bundle_transactions_new(bundle);
+}
+
+status_t ta_send_mam_message(const ta_config_t *const info, const iota_config_t *const iconf,
+                             const iota_client_service_t *const service, ta_send_mam_req_t const *const req,
+                             ta_send_mam_res_t *const res) {
+  status_t ret = SC_OK;
+  mam_api_t mam;
+  tryte_t chid[MAM_CHANNEL_ID_TRYTE_SIZE] = {}, msg_id[NUM_TRYTES_MAM_MSG_ID] = {};
+  bundle_transactions_t *bundle = NULL;
+  send_mam_data_mam_v1_t *data = (send_mam_data_mam_v1_t *)req->data;
+  mam_encrypt_key_t mam_key = {.psks = NULL, .ntru_pks = NULL};
+  bool msg_sent = false;
+
+  // Creating MAM API
+  ret = ta_mam_init(&mam, iconf, data->seed);
+  if (ret) {
+    ta_log_error("%s\n", ta_error_to_string(ret));
+    goto done;
+  }
+
+  mam_send_operation_t mam_operation;
+  while (!msg_sent) {
+    bundle_transactions_renew(&bundle);
+
+    // Create channel merkle tree and find the smallest unused secret key.
+    // Write both Header and Packet into one single bundle.
+    ret = ta_mam_written_msg_to_bundle(service, &mam, data->ch_mss_depth, mam_key, data->message, &bundle, chid, msg_id,
+                                       &mam_operation);
+    if (ret == SC_OK) {
+      msg_sent = true;
+    } else if (ret == SC_MAM_ALL_MSS_KEYS_USED) {
+      ta_log_debug("%s\n", ta_error_to_string(ret));
+      goto mam_announce;
+    } else {
+      ta_log_error("%s\n", ta_error_to_string(ret));
+      goto done;
+    }
+
+    // Sending bundle
+    ret = ta_send_bundle(info, iconf, service, bundle);
+    if (ret != SC_OK) {
+      ta_log_error("%s\n", ta_error_to_string(ret));
+      goto done;
+    }
+
+    ret = send_mam_res_set_msg_result(res, chid, msg_id, bundle);
+    if (ret) {
+      ta_log_error("%s\n", ta_error_to_string(ret));
+      goto done;
+    }
+
+  mam_announce:
+    if (mam_operation == ANNOUNCE_CHID) {
+      bundle_transactions_renew(&bundle);
+      // Send announcement for the next endpoint (epid1) or next channel (chid1)
+      tryte_t chid1[MAM_CHANNEL_ID_TRYTE_SIZE] = {};
+      ret = ta_mam_write_announce_to_bundle(&mam, data->ch_mss_depth, chid, mam_key, chid1, &bundle);
+      if (ret) {
+        ta_log_error("%s\n", ta_error_to_string(ret));
+        goto done;
+      }
+
+      ret = ta_send_bundle(info, iconf, service, bundle);
+      if (ret) {
+        ta_log_error("%s\n", ta_error_to_string(ret));
+        goto done;
+      }
+
+      ret = send_mam_res_set_announce(res, chid1, bundle);
+      if (ret) {
+        ta_log_error("%s\n", ta_error_to_string(ret));
+        goto done;
+      }
+    }
+  }
+
+done:
+  // Destroy MAM API
+  if (ret != SC_MAM_FAILED_INIT) {
+    // If `seed` is not assigned, then the local MAM file will be used. Therefore, we need to close the MAM file.
+    if (!data->seed && mam_api_save(&mam, iconf->mam_file_path, NULL, 0) != RC_OK) {
+      ret = SC_MAM_FILE_SAVE;
+      ta_log_error("%s\n", ta_error_to_string(ret));
+    }
+    if (mam_api_destroy(&mam)) {
+      ret = SC_MAM_FAILED_DESTROYED;
+      ta_log_error("%s\n", ta_error_to_string(ret));
+    }
+  }
+  bundle_transactions_free(&bundle);
+
+  return ret;
+}
+
+status_t ta_recv_mam_message(const iota_config_t *const iconf, const iota_client_service_t *const service,
+                             ta_recv_mam_req_t *const req, ta_recv_mam_res_t *const res) {
+  status_t ret = SC_OK;
+  mam_api_t mam;
+  bundle_array_t *bundle_array = NULL;
+  bundle_array_new(&bundle_array);
+  recv_mam_data_id_mam_v1_t *data_id = (recv_mam_data_id_mam_v1_t *)req->data_id;
+  if (mam_api_init(&mam, (tryte_t *)iconf->seed) != RC_OK) {
+    ret = SC_MAM_FAILED_INIT;
+    ta_log_error("%s\n", ta_error_to_string(ret));
+    goto done;
+  }
+
+  if (data_id->chid) {
+    if (mam_api_add_trusted_channel_pk(&mam, (tryte_t *)data_id->chid) != RC_OK) {
+      ret = SC_MAM_INVAID_CHID_OR_EPID;
+      ta_log_error("%s\n", ta_error_to_string(ret));
+      goto done;
+    }
+  }
+
+  if (data_id->bundle_hash) {
+    bundle_transactions_t *bundle = NULL;
+    bundle_transactions_new(&bundle);
+    ret = ta_get_bundle(service, (tryte_t *)data_id->bundle_hash, bundle);
+    if (ret != SC_OK) {
+      bundle_transactions_free(&bundle);
+      ta_log_error("%s\n", "Failed to get bundle by bundle hash");
+      goto done;
+    }
+    bundle_array_add(bundle_array, bundle);
+    bundle_transactions_free(&bundle);
+  } else if (data_id->chid) {
+    ret = ta_get_bundles_by_addr(service, (tryte_t *)data_id->chid, bundle_array);
+    if (ret != SC_OK) {
+      ta_log_error("%s\n", "Failed to get bundle by chid");
+      goto done;
+    }
+  }
+
+  // Copy the trusted_channel_pks, before fetching the information from MAM.
+  mam_pk_t_set_t init_trusted_ch = NULL;
+  mam_pk_t_set_entry_t *curr_entry = NULL;
+  mam_pk_t_set_entry_t *tmp_entry = NULL;
+  HASH_ITER(hh, mam.trusted_channel_pks, curr_entry, tmp_entry) {
+    mam_pk_t_set_add(&init_trusted_ch, &(curr_entry->value));
+  }
+
+  bundle_transactions_t *bundle = NULL;
+  BUNDLE_ARRAY_FOREACH(bundle_array, bundle) {
+    char *payload = NULL;
+    status_t read_ret = ta_mam_api_bundle_read(&mam, bundle, &payload);
+    if (read_ret != SC_OK && read_ret != SC_MAM_NO_PAYLOAD) {
+      // If we read a bundle which contains MAM announcement, then it will return "SC_MAM_NO_PAYLOAD"
+      ta_log_error("%s\n", ta_error_to_string(read_ret));
+      goto done;
+    }
+
+    utarray_push_back(res->payload_array, &payload);
+    free(payload);
+  }
+
+  // Find the channel ID which was just added
+  HASH_ITER(hh, mam.trusted_channel_pks, curr_entry, tmp_entry) {
+    if (!mam_pk_t_set_contains(init_trusted_ch, &(curr_entry->value))) {
+      trits_to_trytes(curr_entry->value.key, (tryte_t *)res->chid1, NUM_TRITS_ADDRESS);
+    }
+  }
+
+done:
+  // Destroy MAM API
+  if (ret != SC_MAM_FAILED_INIT) {
+    if (mam_api_save(&mam, iconf->mam_file_path, NULL, 0) != RC_OK) {
+      ta_log_error("%s\n", ta_error_to_string(ret));
+    }
+    if (mam_api_destroy(&mam) != RC_OK) {
+      ret = SC_MAM_FAILED_DESTROYED;
+      ta_log_error("%s\n", ta_error_to_string(ret));
+    }
+  }
+  bundle_array_free(&bundle_array);
+  mam_pk_t_set_free(&init_trusted_ch);
   return ret;
 }

--- a/accelerator/core/request/ta_send_mam.c
+++ b/accelerator/core/request/ta_send_mam.c
@@ -38,7 +38,6 @@ status_t send_mam_req_v1_init(ta_send_mam_req_t* req) {
   data->seed = NULL;
   data->message = NULL;
   data->ch_mss_depth = 6;
-  data->ep_mss_depth = 6;
 
   send_mam_key_mam_v1_t* key = req->key;
   utarray_new(key->psk_array, &ut_str_icd);

--- a/accelerator/core/request/ta_send_mam.h
+++ b/accelerator/core/request/ta_send_mam.h
@@ -45,8 +45,6 @@ typedef struct send_mam_data_mam_v1_s {
   tryte_t* seed;
   /** Optional. The depth of channel merkle tree. */
   int32_t ch_mss_depth;
-  /** Optional. The depth of endpoint merkle tree. */
-  int32_t ep_mss_depth;
   /** Required. The message will be append to the channel. */
   char* message;
 } send_mam_data_mam_v1_t;

--- a/accelerator/core/response/ta_send_mam.c
+++ b/accelerator/core/response/ta_send_mam.c
@@ -48,7 +48,26 @@ status_t send_mam_res_set_msg_id(ta_send_mam_res_t* res, const tryte_t* msg_id) 
   return SC_OK;
 }
 
-status_t send_mam_res_set_announcement_bundle_hash(ta_send_mam_res_t* res, const tryte_t* announcement_bundle_hash) {
+status_t send_mam_res_set_msg_result(ta_send_mam_res_t* res, const tryte_t* chid, const tryte_t* msg_id,
+                                     bundle_transactions_t* bundle) {
+  status_t ret = SC_OK;
+  ret = send_mam_res_set_channel_id(res, chid);
+  if (ret) {
+    goto done;
+  }
+
+  ret = send_mam_res_set_msg_id(res, msg_id);
+  if (ret) {
+    goto done;
+  }
+
+  ret = send_mam_res_set_bundle_hash(res, transaction_bundle((iota_transaction_t*)utarray_front(bundle)));
+
+done:
+  return SC_OK;
+}
+
+status_t send_mam_res_set_announce_bundle_hash(ta_send_mam_res_t* res, const tryte_t* announcement_bundle_hash) {
   if (!announcement_bundle_hash || !res) {
     return SC_RES_NULL;
   }
@@ -65,6 +84,19 @@ status_t send_mam_res_set_chid1(ta_send_mam_res_t* res, const tryte_t* chid1) {
 
   memcpy(res->chid1, chid1, NUM_TRYTES_HASH);
   res->chid1[NUM_TRYTES_HASH] = '\0';
+  return SC_OK;
+}
+
+status_t send_mam_res_set_announce(ta_send_mam_res_t* res, const tryte_t* chid1, bundle_transactions_t* bundle) {
+  status_t ret = SC_OK;
+  ret = send_mam_res_set_announce_bundle_hash(res, transaction_bundle((iota_transaction_t*)utarray_front(bundle)));
+  if (ret) {
+    goto done;
+  }
+
+  ret = send_mam_res_set_chid1(res, chid1);
+
+done:
   return SC_OK;
 }
 

--- a/accelerator/core/response/ta_send_mam.h
+++ b/accelerator/core/response/ta_send_mam.h
@@ -104,7 +104,7 @@ status_t send_mam_res_set_msg_id(ta_send_mam_res_t* res, const tryte_t* msg_id);
  * - SC_OK on success
  * - non-zero on error
  */
-status_t send_mam_res_set_announcement_bundle_hash(ta_send_mam_res_t* res, const tryte_t* announcement_bundle_hash);
+status_t send_mam_res_set_announce_bundle_hash(ta_send_mam_res_t* res, const tryte_t* announcement_bundle_hash);
 
 /**
  * @brief Set the next channel_id field of send_mam_res object.
@@ -121,6 +121,33 @@ status_t send_mam_res_set_announcement_bundle_hash(ta_send_mam_res_t* res, const
  * - non-zero on error
  */
 status_t send_mam_res_set_chid1(ta_send_mam_res_t* res, const tryte_t* chid1);
+
+/**
+ * @brief Set the content of the response of a MAM message request
+ *
+ * @param res[in/out] ta_send_mam_res_t struct object
+ * @param chid[in] Current Channel ID decoded in trytes string
+ * @param msg_id[in] Message ID decoded in trytes string
+ * @param bundle[in] Bundle object with MAM message
+ *
+ * @return
+ * - SC_OK on success
+ * - non-zero on error
+ */
+status_t send_mam_res_set_msg_result(ta_send_mam_res_t* res, const tryte_t* chid, const tryte_t* msg_id,
+                                     bundle_transactions_t* bundle);
+/**
+ * @brief Set the content of the response of a MAM announcement
+ *
+ * @param res[in/out] ta_send_mam_res_t struct object
+ * @param chid1[in] Next Channel ID (chid1) decoded in trytes string
+ * @param bundle[in] Bundle object with MAM announcement
+ *
+ * @return
+ * - SC_OK on success
+ * - non-zero on error
+ */
+status_t send_mam_res_set_announce(ta_send_mam_res_t* res, const tryte_t* chid1, bundle_transactions_t* bundle);
 
 /**
  * Free memory of ta_send_mam_res_t

--- a/accelerator/core/serializer/serializer.c
+++ b/accelerator/core/serializer/serializer.c
@@ -814,11 +814,6 @@ static status_t send_mam_message_mam_v1_req_deserialize(cJSON const* const json_
     data->ch_mss_depth = json_value->valueint;
   }
 
-  json_value = cJSON_GetObjectItemCaseSensitive(json_key, "ep_mss_depth");
-  if ((json_value != NULL) && cJSON_IsNumber(json_value)) {
-    data->ep_mss_depth = json_value->valueint;
-  }
-
 done:
   return ret;
 }
@@ -1208,7 +1203,7 @@ status_t send_mam_res_deserialize(const char* const obj, ta_send_mam_res_t* cons
       ta_log_error("%s\n", ta_error_to_string(ret));
       goto done;
     }
-    send_mam_res_set_announcement_bundle_hash(res, addr);
+    send_mam_res_set_announce_bundle_hash(res, addr);
   }
 
 done:

--- a/common/macros.h
+++ b/common/macros.h
@@ -9,8 +9,9 @@
 #ifndef COMMON_MACROS_H_
 #define COMMON_MACROS_H_
 
+#include "common/model/bundle.h"
 #include "common/model/transaction.h"
-#include "common/trinary/tryte.h"
+#include "common/trinary/trit_tryte.h"
 #include "mam/mam/message.h"
 
 #include <stdbool.h>

--- a/tests/api/mam_test.c
+++ b/tests/api/mam_test.c
@@ -76,6 +76,8 @@ void test_write_until_next_channel(void) {
   const char payload[] = "This is test payload number";
   const int len = strlen(json_template_send) + NUM_TRYTES_ADDRESS + strlen(payload) + 2;
   gen_rand_trytes(NUM_TRYTES_ADDRESS, (tryte_t*)seed);
+  double sum = 0;
+  test_time_start(&start_time);
   for (int i = 0; i < msg_num; i++) {
     char* json_result;
     mam_res_array[i] = send_mam_res_new();
@@ -108,6 +110,7 @@ void test_write_until_next_channel(void) {
       snprintf(substr, strlen(payload) + 3, "%s:%d", payload, j);
       TEST_ASSERT_TRUE(strstr(json_result, substr));
     }
+    test_time_end(&start_time, &end_time, &sum);
 
     recv_mam_res_deserialize(json_result, res);
     if (res->chid1[0]) {
@@ -127,6 +130,7 @@ void test_write_until_next_channel(void) {
     recv_mam_res_free(&res);
   }
 
+  printf("Average time of write_until_next_channel: %lf\n", sum / TEST_COUNT);
   for (int i = 0; i < msg_num; i++) {
     send_mam_res_free(&(mam_res_array[i]));
   }

--- a/tests/unit-test/test_serializer.c
+++ b/tests/unit-test/test_serializer.c
@@ -359,7 +359,6 @@ void test_send_mam_message_request_deserialize(void) {
   TEST_ASSERT_EQUAL_STRING(TEST_TOKEN, req->service_token);
   TEST_ASSERT_EQUAL_MEMORY(TRYTES_81_1, data->seed, NUM_TRYTES_HASH);
   TEST_ASSERT_EQUAL_INT(TEST_CH_DEPTH, data->ch_mss_depth);
-  TEST_ASSERT_EQUAL_INT(TEST_EP_DEPTH, data->ep_mss_depth);
   TEST_ASSERT_EQUAL_STRING(TEST_PAYLOAD, data->message);
   TEST_ASSERT_EQUAL_STRING(TEST_NTRU_PK, mamv1_ntru_key_at(req, 0));
   TEST_ASSERT_EQUAL_STRING(TRYTES_81_2, mamv1_psk_key_at(req, 0));
@@ -384,7 +383,7 @@ void test_send_mam_message_response_serialize(void) {
   send_mam_res_set_bundle_hash(res, (tryte_t*)TRYTES_81_1);
   send_mam_res_set_channel_id(res, (tryte_t*)TRYTES_81_2);
   send_mam_res_set_msg_id(res, (tryte_t*)TEST_MSG_ID);
-  send_mam_res_set_announcement_bundle_hash(res, (tryte_t*)ADDRESS_1);
+  send_mam_res_set_announce_bundle_hash(res, (tryte_t*)ADDRESS_1);
   send_mam_res_set_chid1(res, (tryte_t*)ADDRESS_2);
 
   send_mam_res_serialize(res, &json_result);


### PR DESCRIPTION
To follow the pattern of other APIs, the MAM-related operations
are moved to `mam_core`, and some of datatypes are renamed.