### PR TITLE
refactor(logger): Include undefined logger level object

### DIFF
--- a/accelerator/config.h
+++ b/accelerator/config.h
@@ -19,7 +19,7 @@
 #ifdef DB_ENABLE
 #include "storage/ta_storage.h"
 #endif
-#include "common/logger.h"
+#include "common/ta_logger.h"
 #include "utils/cache/cache.h"
 
 #define FILE_PATH_SIZE 128

--- a/accelerator/core/pow.c
+++ b/accelerator/core/pow.c
@@ -8,7 +8,7 @@
 
 #include "pow.h"
 #include "common/helpers/digest.h"
-#include "common/logger.h"
+#include "common/ta_logger.h"
 #include "third_party/dcurl/src/dcurl.h"
 #include "utils/time.h"
 

--- a/accelerator/core/serializer/serializer.c
+++ b/accelerator/core/serializer/serializer.c
@@ -10,7 +10,7 @@
 #ifdef MQTT_ENABLE
 #include "connectivity/mqtt/mqtt_common.h"
 #endif
-#include "common/logger.h"
+#include "common/ta_logger.h"
 #include "time.h"
 #define SERI_LOGGER "serializer"
 

--- a/accelerator/main.c
+++ b/accelerator/main.c
@@ -1,7 +1,7 @@
 #include <errno.h>
 
-#include "common/logger.h"
 #include "common/ta_errors.h"
+#include "common/ta_logger.h"
 #include "connectivity/common.h"
 #include "connectivity/http/http.h"
 #include "pthread.h"

--- a/common/BUILD
+++ b/common/BUILD
@@ -17,10 +17,11 @@ cc_library(
 
 cc_library(
     name = "ta_logger",
-    srcs = ["logger.h"],
+    srcs = ["ta_logger.h"],
     defines = ["LOGGER_ENABLE"],
     deps = [
         ":ta_errors",
+        "@com_github_embear_logger//:logger",
         "@entangled//utils:logger_helper",
     ],
 )

--- a/common/debug.h
+++ b/common/debug.h
@@ -24,7 +24,7 @@
 #include "common/model/transaction.h"
 #include "common/trinary/trit_long.h"
 
-#include "logger.h"
+#include "ta_logger.h"
 
 /**
  * Initialize logger

--- a/common/ta_logger.h
+++ b/common/ta_logger.h
@@ -13,6 +13,7 @@ extern "C" {
 #endif
 
 #include "common/ta_errors.h"
+#include "logger.h"
 #include "utils/logger_helper.h"
 
 #ifdef NDEBUG
@@ -22,7 +23,7 @@ extern "C" {
 #endif
 
 /**
- * @file common/logger.h
+ * @file common/ta_logger.h
  */
 
 /**

--- a/connectivity/common.c
+++ b/connectivity/common.c
@@ -4,8 +4,8 @@
 
 #include "cJSON.h"
 #include "common.h"
-#include "common/logger.h"
 #include "common/ta_errors.h"
+#include "common/ta_logger.h"
 
 #define CONN_LOGGER "connectivity"
 static logger_id_t logger_id;

--- a/connectivity/mqtt/duplex_utils.c
+++ b/connectivity/mqtt/duplex_utils.c
@@ -10,8 +10,8 @@
 #include <errno.h>
 #include <stdlib.h>
 #include <string.h>
-#include "common/logger.h"
 #include "common/macros.h"
+#include "common/ta_logger.h"
 
 #define MQTT_UTILS_LOGGER "duplex_utils"
 

--- a/connectivity/mqtt/mqtt_common.c
+++ b/connectivity/mqtt/mqtt_common.c
@@ -11,7 +11,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <time.h>
-#include "common/logger.h"
+#include "common/ta_logger.h"
 
 #define MQTT_COMMON_LOGGER "mqtt_common"
 static logger_id_t logger_id;

--- a/connectivity/mqtt/pub_utils.c
+++ b/connectivity/mqtt/pub_utils.c
@@ -10,7 +10,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <time.h>
-#include "common/logger.h"
+#include "common/ta_logger.h"
 
 #define MQTT_PUB_LOGGER "pub_utils"
 static logger_id_t logger_id;

--- a/connectivity/mqtt/sub_utils.c
+++ b/connectivity/mqtt/sub_utils.c
@@ -10,7 +10,7 @@
 #include <signal.h>
 #include <stdlib.h>
 #include <string.h>
-#include "common/logger.h"
+#include "common/ta_logger.h"
 
 #define MQTT_SUB_LOGGER "sub_utils"
 static logger_id_t logger_id;

--- a/storage/scylladb_utils.h
+++ b/storage/scylladb_utils.h
@@ -12,7 +12,7 @@ extern "C" {
 #endif
 #include <stdlib.h>
 #include "cassandra.h"
-#include "common/logger.h"
+#include "common/ta_logger.h"
 
 /**
  * @file storage/scylladb_utils.h

--- a/utils/cache/backend_redis.c
+++ b/utils/cache/backend_redis.c
@@ -8,7 +8,7 @@
 
 #include <hiredis/hiredis.h>
 #include "cache.h"
-#include "common/logger.h"
+#include "common/ta_logger.h"
 
 #define BR_LOGGER "backend_redis"
 

--- a/utils/timer.c
+++ b/utils/timer.c
@@ -7,7 +7,7 @@
  */
 
 #include "timer.h"
-#include "common/logger.h"
+#include "common/ta_logger.h"
 
 #define TIMER_LOGGER "timer"
 


### PR DESCRIPTION
Include `logger.h` from thirt-party project `embear/logger` to
include undefined `DEBUG_LEVEL` objects.