### PR TITLE
doc: Add documentation for different build types

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,18 @@ Tangle-accelerator supports several different build time options.
 * Docker images
 * MQTT connectivity
 * External database
+* Debug Mode
+
+    Debug mode enables tangle-accelerator to display extra `debug` logs.
+```
+bazel run --define build_type=debug //accelerator
+```
+* Profiling Mode
+
+    Profiling mode adds `-pg` flag when compiling tangle-accelerator. This allows tangle-accelerator to write profile information for the analysis program gprof.
+```
+bazel run --define build_type=profile //accelerator
+```
 
 See [docs/build.md](docs/build.md) for more information.
 

--- a/docs/build.md
+++ b/docs/build.md
@@ -61,7 +61,7 @@ make && bazel run --define db=enable //accelerator
 
 When enabling reattachment, every transaction issues from the `tangle-accelerator` API called `Send Transfer Message` will be stored in the specific ScyllaDB host and response a UUID string for each transfer message as the identifier. With a promoting process that monitors the status of storing transactions, persistent pending transactions will be reattached to the Tangle.
 
-Transaction reattachment relies on ScyllDB, you need to install the dependency by following commands.
+Transaction reattachment relies on ScyllaDB, you need to install the dependency by following commands.
 
 For Ubuntu Linux 16.04/x86_64:
 


### PR DESCRIPTION
Closes #611.
Add `build_type=debug` and `build_type=profile` documentation in section
`Building Options`.