### PR TITLE
feat(mam): Send mam message from given chid 

### DIFF
--- a/accelerator/core/mam_core.h
+++ b/accelerator/core/mam_core.h
@@ -47,14 +47,6 @@ typedef struct mam_encrypt_key_s {
 } mam_encrypt_key_t;
 
 /**
- * @brief Renew the given bundle
- *
- * @param bundle[in,out] The bundle that will be renewed
- *
- */
-void bundle_transactions_renew(bundle_transactions_t** bundle);
-
-/**
  * @brief Send a MAM message.
  *
  * @param iconf[in] IOTA API parameter configurations

--- a/accelerator/core/request/ta_send_mam.c
+++ b/accelerator/core/request/ta_send_mam.c
@@ -36,6 +36,7 @@ status_t send_mam_req_v1_init(ta_send_mam_req_t* req) {
 
   send_mam_data_mam_v1_t* data = req->data;
   data->seed = NULL;
+  data->chid = NULL;
   data->message = NULL;
   data->ch_mss_depth = 6;
 
@@ -50,6 +51,7 @@ static void send_mam_req_v1_free(ta_send_mam_req_t** req) {
   if ((*req)->data) {
     send_mam_data_mam_v1_t* data = (*req)->data;
     free(data->seed);
+    free(data->chid);
     free(data->message);
     free((*req)->data);
     (*req)->data = NULL;

--- a/accelerator/core/request/ta_send_mam.h
+++ b/accelerator/core/request/ta_send_mam.h
@@ -45,6 +45,8 @@ typedef struct send_mam_data_mam_v1_s {
   tryte_t* seed;
   /** Optional. The depth of channel merkle tree. */
   int32_t ch_mss_depth;
+  /** Optional. The Channel ID which tangle-accelerator starts to search available message slot. */
+  tryte_t* chid;
   /** Required. The message will be append to the channel. */
   char* message;
 } send_mam_data_mam_v1_t;

--- a/accelerator/core/serializer/serializer.c
+++ b/accelerator/core/serializer/serializer.c
@@ -808,13 +808,28 @@ static status_t send_mam_message_mam_v1_req_deserialize(cJSON const* const json_
   if (json_value != NULL) {
     size_t seed_size = strnlen(json_value->valuestring, NUM_TRYTES_ADDRESS);
 
-    if (seed_size != NUM_TRYTES_HASH) {
+    if (seed_size != NUM_TRYTES_ADDRESS) {
       ret = SC_SERIALIZER_INVALID_REQ;
       ta_log_error("%s\n", ta_error_to_string(ret));
       goto done;
     }
     data->seed = (tryte_t*)malloc(sizeof(tryte_t) * (NUM_TRYTES_ADDRESS + 1));
     snprintf((char*)data->seed, seed_size + 1, "%s", json_value->valuestring);
+  }
+
+  if (cJSON_HasObjectItem(json_key, "chid")) {
+    json_value = cJSON_GetObjectItemCaseSensitive(json_key, "chid");
+    if (json_value != NULL) {
+      size_t chid_size = strnlen(json_value->valuestring, NUM_TRYTES_ADDRESS);
+
+      if (chid_size != NUM_TRYTES_ADDRESS) {
+        ret = SC_SERIALIZER_INVALID_REQ;
+        ta_log_error("%s\n", ta_error_to_string(ret));
+        goto done;
+      }
+      data->chid = (tryte_t*)malloc(sizeof(tryte_t) * (NUM_TRYTES_ADDRESS + 1));
+      snprintf((char*)data->chid, chid_size + 1, "%s", json_value->valuestring);
+    }
   }
 
   json_value = cJSON_GetObjectItemCaseSensitive(json_key, "message");

--- a/common/ta_errors.h
+++ b/common/ta_errors.h
@@ -156,6 +156,8 @@ typedef enum {
   /**< Can't find message in the assign bundle */
   SC_MAM_INVAID_CHID_OR_EPID = 0x0E | SC_MODULE_MAM | SC_SEVERITY_FATAL,
   /**< Failed to add trusted channel ID or endpoint ID */
+  SC_MAM_EXCEEDED_CHID_ITER = 0x0F | SC_MODULE_MAM | SC_SEVERITY_FATAL,
+  /**< Too much iteration for finding a starting chid */
 
   // response module
   SC_RES_NULL = 0x01 | SC_MODULE_RES | SC_SEVERITY_FATAL,

--- a/tests/api/mam_test.c
+++ b/tests/api/mam_test.c
@@ -136,6 +136,50 @@ void test_write_until_next_channel(void) {
   }
 }
 
+void test_write_with_chid(void) {
+  const int beginning_msg_num = 1;
+  char seed[NUM_TRYTES_ADDRESS + 1] = {};
+  const char* json_template_send =
+      "{\"x-api-key\":\"" TEST_TOKEN
+      "\",\"data\":{\"seed\":\"%s\",\"ch_mss_depth\":1,\"message\":\"%s:%d\"}, \"protocol\":\"MAM_V1\"}";
+  const char payload[] = "This is test payload number";
+  const int len = strlen(json_template_send) + NUM_TRYTES_ADDRESS + strlen(payload) + 2;
+  gen_rand_trytes(NUM_TRYTES_ADDRESS, (tryte_t*)seed);
+  double sum = 0;
+  ta_send_mam_res_t* res;
+  test_time_start(&start_time);
+  char* json_result = NULL;
+  for (int i = 0; i < beginning_msg_num; ++i) {
+    res = send_mam_res_new();
+    char* json = (char*)malloc(sizeof(char) * len);
+    snprintf(json, len, json_template_send, seed, payload, i);
+    TEST_ASSERT_EQUAL_INT32(
+        SC_OK, api_send_mam_message(&ta_core.ta_conf, &ta_core.iota_conf, &ta_core.iota_service, json, &json_result));
+    free(json);
+    if (i != beginning_msg_num - 1) {
+      free(json_result);
+      send_mam_res_free(&res);
+    }
+  }
+  send_mam_res_deserialize(json_result, res);
+  free(json_result);
+
+  // Send message from next channel ID
+  const char* json_template_send_chid =
+      "{\"x-api-key\":\"" TEST_TOKEN
+      "\",\"data\":{\"seed\":\"%s\",\"chid\":\"%s\",\"ch_mss_depth\":2,\"message\":\"%s\"}, \"protocol\":\"MAM_V1\"}";
+  const int len_send_chid = strlen(json_template_send_chid) + NUM_TRYTES_ADDRESS * 2 + strlen(payload);
+  char* json_send_chid = (char*)malloc(sizeof(char) * (len_send_chid + 1));
+  snprintf(json_send_chid, len_send_chid, json_template_send_chid, seed, res->chid1, payload);
+  TEST_ASSERT_EQUAL_INT32(SC_OK, api_send_mam_message(&ta_core.ta_conf, &ta_core.iota_conf, &ta_core.iota_service,
+                                                      json_send_chid, &json_result));
+  test_time_end(&start_time, &end_time, &sum);
+  send_mam_res_free(&res);
+  free(json_send_chid);
+  free(json_result);
+  printf("Elapsed time of write_with_chid: %lf\n", sum);
+}
+
 int main(int argc, char* argv[]) {
   UNITY_BEGIN();
   rand_trytes_init();
@@ -158,6 +202,7 @@ int main(int argc, char* argv[]) {
   RUN_TEST(test_send_mam_message);
   RUN_TEST(test_receive_mam_message);
   RUN_TEST(test_write_until_next_channel);
+  RUN_TEST(test_write_with_chid);
   ta_core_destroy(&ta_core);
   return UNITY_END();
 }

--- a/tests/unit-test/test_serializer.c
+++ b/tests/unit-test/test_serializer.c
@@ -361,8 +361,8 @@ void test_recv_mam_message_response_deserialize(void) {
 
 void test_send_mam_message_request_deserialize(void) {
   const char* json =
-      "{\"x-api-key\":\"" TEST_TOKEN "\",\"data\":{\"seed\":\"" TRYTES_81_1 "\",\"message\":\"" TEST_PAYLOAD
-      "\",\"ch_mss_depth\":" STR(TEST_CH_DEPTH) ",\"ep_mss_depth\":" STR(
+      "{\"x-api-key\":\"" TEST_TOKEN "\",\"data\":{\"seed\":\"" TRYTES_81_1 "\",\"chid\":\"" TEST_ADDRESS
+      "\",\"message\":\"" TEST_PAYLOAD "\",\"ch_mss_depth\":" STR(TEST_CH_DEPTH) ",\"ep_mss_depth\":" STR(
           TEST_EP_DEPTH) "},\"key\":{\"ntru\":[\"" TEST_NTRU_PK "\"],\"psk\":[\"" TRYTES_81_2 "\",\"" TRYTES_81_3
                          "\"]}, \"protocol\":\"MAM_V1\"}";
 
@@ -371,7 +371,8 @@ void test_send_mam_message_request_deserialize(void) {
   send_mam_data_mam_v1_t* data = (send_mam_data_mam_v1_t*)req->data;
 
   TEST_ASSERT_EQUAL_STRING(TEST_TOKEN, req->service_token);
-  TEST_ASSERT_EQUAL_MEMORY(TRYTES_81_1, data->seed, NUM_TRYTES_HASH);
+  TEST_ASSERT_EQUAL_STRING(TRYTES_81_1, data->seed);
+  TEST_ASSERT_EQUAL_STRING(TEST_ADDRESS, data->chid);
   TEST_ASSERT_EQUAL_INT(TEST_CH_DEPTH, data->ch_mss_depth);
   TEST_ASSERT_EQUAL_STRING(TEST_PAYLOAD, data->message);
   TEST_ASSERT_EQUAL_STRING(TEST_NTRU_PK, mamv1_ntru_key_at(req, 0));

--- a/utils/bundle_array.h
+++ b/utils/bundle_array.h
@@ -23,6 +23,17 @@ extern "C" {
  * `bundle_transactions_t` objects. It provides an easier way to save and traverse all the bundles.
  */
 
+/**
+ * @brief Renew the given bundle
+ *
+ * @param bundle[in,out] The bundle that will be renewed
+ *
+ */
+static inline void bundle_transactions_renew(bundle_transactions_t **bundle) {
+  bundle_transactions_free(bundle);
+  bundle_transactions_new(bundle);
+}
+
 typedef UT_array bundle_array_t;
 // We should synchronize this implementation as to the implementation in the IOTA library
 static UT_icd bundle_transactions_icd = {sizeof(iota_transaction_t), 0, 0, 0};


### PR DESCRIPTION
The current implemetaion of MAM service is a data structure which is
similar to linked-list. This structure causes searching time increase
linearly, so if the user is searching some information with a large
N, then then elapsing time would be really long, too.
Therefore, in this PR, tangle-accelerator starts to support searching
MAM message from a given channel ID which can dramatically reduce
searching time with a proper given channel ID.

Close #610