### PR TITLE
feat(api): Return address with UUID in failed requests

### DIFF
--- a/accelerator/core/core.c
+++ b/accelerator/core/core.c
@@ -229,6 +229,11 @@ status_t ta_send_transfer(const ta_config_t* const info, const iota_config_t* co
     ta_log_error("Error in ta_send_trytes. Push transaction trytes to buffer.\n");
     res->uuid = (char*)malloc(sizeof(char) * UUID_STR_LEN);
     push_txn_to_buffer(cache, raw_tx, res->uuid);
+
+    txn = (iota_transaction_t*)utarray_front(out_bundle);
+    res->address = (tryte_t*)malloc(sizeof(char) * NUM_TRYTES_ADDRESS);
+    flex_trits_to_trytes(res->address, NUM_TRYTES_ADDRESS, transaction_address(txn), NUM_TRITS_ADDRESS,
+                         NUM_TRITS_ADDRESS);
     goto done;
   }
 

--- a/accelerator/core/response/ta_send_transfer.c
+++ b/accelerator/core/response/ta_send_transfer.c
@@ -13,6 +13,7 @@ ta_send_transfer_res_t* ta_send_transfer_res_new() {
   if (res) {
     res->hash = NULL;
     res->uuid = NULL;
+    res->address = NULL;
   }
   return res;
 }
@@ -20,6 +21,7 @@ ta_send_transfer_res_t* ta_send_transfer_res_new() {
 void ta_send_transfer_res_free(ta_send_transfer_res_t** res) {
   if ((*res)) {
     free((*res)->uuid);
+    free((*res)->address);
     hash243_queue_free(&(*res)->hash);
     free((*res));
     *res = NULL;

--- a/accelerator/core/response/ta_send_transfer.h
+++ b/accelerator/core/response/ta_send_transfer.h
@@ -31,6 +31,7 @@ typedef struct {
   hash243_queue_t hash;
   transaction_array_t* txn_array;
   char* uuid;
+  tryte_t* address;
 #ifdef DB_ENABLE
   char uuid_string[DB_UUID_STRING_LENGTH];
 #endif

--- a/accelerator/core/serializer/serializer.c
+++ b/accelerator/core/serializer/serializer.c
@@ -857,6 +857,7 @@ status_t ta_send_transfer_res_serialize(ta_send_transfer_res_t* res, char** obj)
 
   if (res->uuid) {
     cJSON_AddStringToObject(json_root, "uuid", res->uuid);
+    cJSON_AddStringToObject(json_root, "address", (char*)res->address);
   } else {
     ret = iota_transaction_to_json_object(transaction_array_at(res->txn_array, 0), &json_root);
     if (ret != SC_OK) {

--- a/tests/unit-test/test_serializer.c
+++ b/tests/unit-test/test_serializer.c
@@ -29,7 +29,7 @@ void test_serialize_ta_generate_address(void) {
   free(json_result);
 }
 
-void test_deserialize_ta_send_transfer(void) {
+void test_ta_send_transfer_req_deserialize(void) {
   const char* json_template =
       "{\"value\":100,"
       "\"message_format\":\"trytes\","
@@ -59,7 +59,7 @@ void test_deserialize_ta_send_transfer(void) {
   free(json);
 }
 
-void test_deserialize_ta_send_transfer_raw_message(void) {
+void test_ta_send_transfer_raw_message_req_deserialize(void) {
   const char* json_template =
       "{\"value\":100,"
       "\"message\":\"%s\",\"tag\":\"" TEST_TAG
@@ -88,7 +88,7 @@ void test_deserialize_ta_send_transfer_raw_message(void) {
   free(json);
 }
 
-void test_deserialize_ta_send_transfer_overrun(void) {
+void test_ta_send_transfer_overrun_req_deserialize(void) {
   const char* json_template =
       "{\"value\":100,"
       "\"message\":\"%s\",\"tag\":\"" TEST_TAG
@@ -105,6 +105,20 @@ void test_deserialize_ta_send_transfer_overrun(void) {
 
   ta_send_transfer_req_free(&req);
   free(json);
+}
+
+void test_ta_send_transfer_buffered_res_serialize(void) {
+  const char* json = "{\"uuid\":\"" TEST_UUID "\",\"address\":\"" TEST_ADDRESS "\"}";
+  char* json_result;
+  ta_send_transfer_res_t* res = ta_send_transfer_res_new();
+  res->uuid = strdup(TEST_UUID);
+  res->address = strdup(TEST_ADDRESS);
+
+  ta_send_transfer_res_serialize(res, &json_result);
+
+  TEST_ASSERT_EQUAL_STRING(json, json_result);
+  ta_send_transfer_res_free(&res);
+  free(json_result);
 }
 
 void test_serialize_ta_find_transaction_objects(void) {
@@ -625,9 +639,10 @@ int main(void) {
 
   serializer_logger_init();
   RUN_TEST(test_serialize_ta_generate_address);
-  RUN_TEST(test_deserialize_ta_send_transfer);
-  RUN_TEST(test_deserialize_ta_send_transfer_raw_message);
-  RUN_TEST(test_deserialize_ta_send_transfer_overrun);
+  RUN_TEST(test_ta_send_transfer_req_deserialize);
+  RUN_TEST(test_ta_send_transfer_raw_message_req_deserialize);
+  RUN_TEST(test_ta_send_transfer_overrun_req_deserialize);
+  RUN_TEST(test_ta_send_transfer_buffered_res_serialize);
   RUN_TEST(test_serialize_ta_find_transaction_objects);
   RUN_TEST(test_serialize_ta_find_transactions_by_tag);
   RUN_TEST(test_serialize_ta_find_transactions_obj_by_tag);


### PR DESCRIPTION
Tangle-accelerator would return the uuid and the address of
failed transaction request.

The example response is as following:
```
{"uuid":"b76ad723-660a-44d7-bea5-26cc87ccbd05",
"address":"POWEREDBYTANGLEACCELERATOR99999999999999999999999999999999 \
99999999999999999999999"}
```

close #619