### PR TITLE
fix(router): Sync url path to MAM implementation

### DIFF
--- a/connectivity/http/http.c
+++ b/connectivity/http/http.c
@@ -142,14 +142,9 @@ static inline int process_send_transfer_request(ta_http_t *const http, iota_clie
 }
 
 static inline int process_recv_mam_msg_request(ta_http_t *const http, iota_client_service_t *const iota_service,
-                                               char const *const url, char **const out) {
+                                               char const *const payload, char **const out) {
   status_t ret;
-  char *bundle = NULL;
-  ret = ta_get_url_parameter(url, 1, &bundle);
-  if (ret == SC_OK) {
-    ret = api_recv_mam_message(&http->core->iota_conf, iota_service, bundle, out);
-  }
-  free(bundle);
+  ret = api_recv_mam_message(&http->core->iota_conf, iota_service, payload, out);
   return set_response_content(ret, out);
 }
 
@@ -256,14 +251,16 @@ static int ta_http_process_request(ta_http_t *const http, iota_client_service_t 
     return process_options_request(out);
   }
 
-  if (api_path_matcher(url, "/mam/[A-Z9]{81}[/]?") == SC_OK) {
-    return process_recv_mam_msg_request(http, iota_service, url, out);
-  } else if (api_path_matcher(url, "/mam[/]?") == SC_OK) {
-    if (payload != NULL) {
+  if (api_path_matcher(url, "/mam/(recv|send)[/]?") == SC_OK) {
+    if (payload == NULL) {
+      return process_method_not_allowed_request(out);
+    }
+
+    if (api_path_matcher(url, ".*/recv.*") == SC_OK) {
+      return process_recv_mam_msg_request(http, iota_service, payload, out);
+    } else {
       return process_send_mam_msg_request(http, iota_service, payload, out);
     }
-    return process_method_not_allowed_request(out);
-
   } else if (api_path_matcher(url, "/transaction/[A-Z9]{81}[/]?") == SC_OK) {
     return process_find_txn_obj_single_request(iota_service, url, out);
   } else if (api_path_matcher(url, "/transaction/object[/]?") == SC_OK) {


### PR DESCRIPTION
With URL path `mam/send`, a user can send MAM message
With URL path `mam/recv`, a user can receive MAM message.

API `recv_mam_message()` has been changed to POST method from this
PR, so the old GET method matcher has been removed here.