### PR TITLE
cleanup: Eliminate compilation warnings

### DIFF
--- a/accelerator/config.h
+++ b/accelerator/config.h
@@ -20,6 +20,7 @@
 #ifdef DB_ENABLE
 #include "storage/ta_storage.h"
 #endif
+#include "cclient/serialization/json/json_serializer.h"
 #include "common/logger.h"
 #include "utils/cache/cache.h"
 

--- a/accelerator/main.c
+++ b/accelerator/main.c
@@ -20,7 +20,7 @@ static void ta_stop(int signal) {
   }
 }
 
-void health_track(void* arg) {
+static void* health_track(void* arg) {
   ta_core_t* core = (ta_core_t*)arg;
   while (true) {
     status_t ret = ta_get_iri_status(&core->iota_service);
@@ -42,6 +42,7 @@ void health_track(void* arg) {
 
     sleep(core->ta_conf.health_track_period);
   }
+  return ((void*)NULL);
 }
 
 int main(int argc, char* argv[]) {

--- a/tests/unit-test/BUILD
+++ b/tests/unit-test/BUILD
@@ -37,13 +37,10 @@ cc_test(
 cc_test(
     name = "test_scylladb",
     srcs = ["test_scylladb.c"],
-    deps = select({
-        "//accelerator:db_enable": [
-            "//storage",
-            "//tests:test_define",
-        ],
-        "//conditions:default": [],
-    }),
+    deps = [
+        "//storage",
+        "//tests:test_define",
+    ],
 )
 
 cc_test(

--- a/tests/unit-test/test_scylladb.c
+++ b/tests/unit-test/test_scylladb.c
@@ -6,8 +6,6 @@
  * "LICENSE" at the root of this distribution.
  */
 
-#ifdef DB_ENABLE
-
 #include "storage/ta_storage.h"
 #include "tests/test_define.h"
 
@@ -197,10 +195,12 @@ void test_db_identity_table(void) {
 
   db_client_service_free(&db_client_service);
 }
-#endif  // DB_ENABLE
 
 int main(int argc, char** argv) {
-#ifdef DB_ENABLE
+#if !defined(DB_ENABLE)
+  return 0;
+#endif
+
   int cmdOpt;
   int optIdx;
   const struct option longOpt[] = {
@@ -234,7 +234,4 @@ int main(int argc, char** argv) {
   RUN_TEST(test_permanode);
   scylladb_logger_release();
   return UNITY_END();
-#else
-  return 0;
-#endif  // DB_ENABLE
 }


### PR DESCRIPTION
Include necessary headers.
Correct the function signature for the pthread start routine.
Remove unused parameters.