### PR TITLE
fix(core): Fix invalid memory operation when sending transfer with invalid tag

### DIFF
--- a/accelerator/core/pow.c
+++ b/accelerator/core/pow.c
@@ -41,6 +41,9 @@ flex_trit_t* ta_pow_flex(const flex_trit_t* const trits_in, const uint8_t mwm) {
   flex_trits_to_trytes(trytes_in, NUM_TRYTES_SERIALIZED_TRANSACTION, trits_in, NUM_TRITS_SERIALIZED_TRANSACTION,
                        NUM_TRITS_SERIALIZED_TRANSACTION);
   int8_t* ret_trytes = ta_pow_dcurl(trytes_in, mwm, 0);
+  if (ret_trytes == NULL) {
+    return NULL;
+  }
   memcpy(nonce_trytes, ret_trytes + NUM_TRYTES_SERIALIZED_TRANSACTION - NUM_TRYTES_NONCE, NUM_TRYTES_NONCE);
 
   flex_trit_t* nonce_trits = (flex_trit_t*)calloc(NUM_TRITS_NONCE, sizeof(flex_trit_t));

--- a/tests/api/driver.c
+++ b/tests/api/driver.c
@@ -105,7 +105,7 @@ void test_send_transfer(void) {
       "\"address\":\"" TRYTES_81_1 "\"}";
   tryte_t test_transfer_message[TEST_TRANSFER_MESSAGE_LEN + 1] = {};
   gen_rand_trytes(TEST_TRANSFER_MESSAGE_LEN, test_transfer_message);
-  const int len = strlen(json_template) + TEST_TRANSFER_MESSAGE_LEN;
+  const int len = strlen(json_template) + TEST_TRANSFER_MESSAGE_LEN + 1;
   char* json = (char*)malloc(sizeof(char) * len);
   snprintf(json, len, json_template, test_transfer_message);
   char* json_result;

--- a/tests/regression/test_suite/send_transfer.py
+++ b/tests/regression/test_suite/send_transfer.py
@@ -82,6 +82,27 @@ class SendTransfer(unittest.TestCase):
         res = API("/transaction/",
                   post_data=map_field(self.post_field, self.query_string[10]))
         self._verify_pass(res)
+    
+    # Zero value, tryte maessage, invalid tag, tryte address (fail)
+    @test_logger
+    def test_invalid_tag(self):
+        res = API("/transaction/",
+                  post_data=map_field(self.post_field, self.query_string[11]))
+        self._verify_pass(res)
+    
+    # Zero value, tryte maessage, tryte tag, invalid address (fail)
+    @test_logger
+    def test_invalid_address(self):
+        res = API("/transaction/",
+                  post_data=map_field(self.post_field, self.query_string[12]))
+        self._verify_pass(res)
+
+    # Zero value, tryte maessage, invalid tag, invalid address (fail)
+    @test_logger
+    def test_invalid_tag_and_address(self):
+        res = API("/transaction/",
+                  post_data=map_field(self.post_field, self.query_string[13]))
+        self._verify_pass(res)
 
     # Time statistics
     @test_logger
@@ -109,6 +130,8 @@ class SendTransfer(unittest.TestCase):
         rand_msg = gen_rand_trytes(30)
         rand_tag = gen_rand_trytes(27)
         rand_addr = gen_rand_trytes(81)
+        rand_invalid_tag = gen_rand_trytes(999)
+        rand_invalid_addr = gen_rand_trytes(999)
         cls.post_field = ["value", "message", "tag", "address"]
         cls.query_string = [[420, rand_msg, rand_tag, rand_addr],
                             [0, rand_msg, rand_tag, rand_addr],
@@ -120,7 +143,11 @@ class SendTransfer(unittest.TestCase):
                             [0, None, rand_tag, rand_addr],
                             [0, rand_msg, None, rand_addr],
                             [0, rand_msg, rand_tag, None],
-                            [0, rand_msg, rand_tag, "我思故我在"]]
+                            [0, rand_msg, rand_tag, "我思故我在"],
+                            [0, rand_msg, "ololaola", rand_addr],
+                            [0, rand_msg, rand_tag, "dio"],
+                            [0, rand_msg, "olaolaola", "dio"],
+                           ]
 
     def _verify_pass(self, res):
         self.assertEqual(STATUS_CODE_200, res["status_code"])


### PR DESCRIPTION
Sending invalid tag with `iri-host` flag enabled will cause
SEGV. The ta_pow_flex didn't handle the NULL pointer when
ta_pow_dcurl returned NULL.

Close #625