### PR TITLE
feat(endpoint): Legato AF integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -95,3 +95,9 @@ __pycache__/
 
 # Certificate for build system
 pem/*.inc
+
+# Legato app related files
+resolv.conf
+output_base/
+_build_endpoint/
+endpoint.wp77xx.update

--- a/endpoint/BUILD
+++ b/endpoint/BUILD
@@ -1,7 +1,7 @@
 cc_library(
-    name = "endpoint",
-    srcs = ["endpoint.c"],
-    hdrs = ["endpoint.h"],
+    name = "endpoint_core",
+    srcs = ["endpoint_core.c"],
+    hdrs = ["endpoint_core.h"],
     defines = [
         "ENDPOINT_HOST=\"localhost\"",
         "ENDPOINT_PORT=\"443\"",
@@ -18,13 +18,44 @@ cc_library(
 )
 
 cc_test(
-    name = "test_endpoint",
+    name = "test_endpoint_core",
     srcs = [
-        "test_endpoint.c",
+        "test_endpoint_core.c",
     ],
     deps = [
-        ":endpoint",
+        ":endpoint_core",
         "//common",
         "//tests:test_define",
+    ],
+)
+
+cc_binary(
+    name = "libendpoint.so",
+    srcs = [
+        "endpoint_core.c",
+        "endpoint_core.h",
+    ],
+    defines = [
+        "TA_HOST=\"localhost\"",
+        "TA_PORT=\"443\"",
+        "TA_SSL_SEED=\"nonce\"",
+    ],
+    linkshared = True,
+    deps = [
+        "//common",
+        "//utils:cipher",
+        "//utils:https",
+        "//utils:text_serializer",
+        "//utils:tryte_byte_conv",
+    ],
+)
+
+platform(
+    name = "linux_arm",
+    constraint_values = [
+        "@platforms//os:linux",
+        # FIXME: The generic CPU name will be replaced in the future
+        # ref: https://github.com/bazelbuild/platforms/blob/master/cpu/BUILD
+        "@platforms//cpu:arm",
     ],
 )

--- a/endpoint/endpoint.adef
+++ b/endpoint/endpoint.adef
@@ -1,0 +1,14 @@
+executables:
+{
+    endpoint = ( endpointComp )
+}
+
+processes:
+{
+    run:
+    {
+        (endpoint)
+    }
+}
+
+start: manual

--- a/endpoint/endpointComp/Component.cdef
+++ b/endpoint/endpointComp/Component.cdef
@@ -1,0 +1,119 @@
+sources:
+{
+    ${CURDIR}/../endpoint_core.c
+
+    ${CURDIR}/../../output_base/external/http_parser/http_parser.c
+
+    ${CURDIR}/../../output_base/external/mbedtls_2_16_6/library/aes.c
+    ${CURDIR}/../../output_base/external/mbedtls_2_16_6/library/arc4.c
+    ${CURDIR}/../../output_base/external/mbedtls_2_16_6/library/asn1parse.c
+    ${CURDIR}/../../output_base/external/mbedtls_2_16_6/library/asn1write.c
+    ${CURDIR}/../../output_base/external/mbedtls_2_16_6/library/base64.c
+    ${CURDIR}/../../output_base/external/mbedtls_2_16_6/library/bignum.c
+    ${CURDIR}/../../output_base/external/mbedtls_2_16_6/library/blowfish.c
+    ${CURDIR}/../../output_base/external/mbedtls_2_16_6/library/camellia.c
+    ${CURDIR}/../../output_base/external/mbedtls_2_16_6/library/ccm.c
+    ${CURDIR}/../../output_base/external/mbedtls_2_16_6/library/certs.c
+    ${CURDIR}/../../output_base/external/mbedtls_2_16_6/library/chacha20.c
+    ${CURDIR}/../../output_base/external/mbedtls_2_16_6/library/chachapoly.c
+    ${CURDIR}/../../output_base/external/mbedtls_2_16_6/library/cipher.c
+    ${CURDIR}/../../output_base/external/mbedtls_2_16_6/library/cipher_wrap.c
+    ${CURDIR}/../../output_base/external/mbedtls_2_16_6/library/ctr_drbg.c
+    ${CURDIR}/../../output_base/external/mbedtls_2_16_6/library/debug.c
+    ${CURDIR}/../../output_base/external/mbedtls_2_16_6/library/des.c
+    ${CURDIR}/../../output_base/external/mbedtls_2_16_6/library/dhm.c
+    ${CURDIR}/../../output_base/external/mbedtls_2_16_6/library/ecdh.c
+    ${CURDIR}/../../output_base/external/mbedtls_2_16_6/library/ecdsa.c
+    ${CURDIR}/../../output_base/external/mbedtls_2_16_6/library/ecp.c
+    ${CURDIR}/../../output_base/external/mbedtls_2_16_6/library/ecp_curves.c
+    ${CURDIR}/../../output_base/external/mbedtls_2_16_6/library/entropy.c
+    ${CURDIR}/../../output_base/external/mbedtls_2_16_6/library/entropy_poll.c
+    ${CURDIR}/../../output_base/external/mbedtls_2_16_6/library/gcm.c
+    ${CURDIR}/../../output_base/external/mbedtls_2_16_6/library/hmac_drbg.c
+    ${CURDIR}/../../output_base/external/mbedtls_2_16_6/library/md5.c
+    ${CURDIR}/../../output_base/external/mbedtls_2_16_6/library/md.c
+    ${CURDIR}/../../output_base/external/mbedtls_2_16_6/library/md_wrap.c
+    ${CURDIR}/../../output_base/external/mbedtls_2_16_6/library/net_sockets.c
+    ${CURDIR}/../../output_base/external/mbedtls_2_16_6/library/oid.c
+    ${CURDIR}/../../output_base/external/mbedtls_2_16_6/library/pem.c
+    ${CURDIR}/../../output_base/external/mbedtls_2_16_6/library/pk.c
+    ${CURDIR}/../../output_base/external/mbedtls_2_16_6/library/pkcs12.c
+    ${CURDIR}/../../output_base/external/mbedtls_2_16_6/library/pkcs5.c
+    ${CURDIR}/../../output_base/external/mbedtls_2_16_6/library/pkparse.c
+    ${CURDIR}/../../output_base/external/mbedtls_2_16_6/library/pk_wrap.c
+    ${CURDIR}/../../output_base/external/mbedtls_2_16_6/library/platform_util.c
+    ${CURDIR}/../../output_base/external/mbedtls_2_16_6/library/poly1305.c
+    ${CURDIR}/../../output_base/external/mbedtls_2_16_6/library/ripemd160.c
+    ${CURDIR}/../../output_base/external/mbedtls_2_16_6/library/rsa.c
+    ${CURDIR}/../../output_base/external/mbedtls_2_16_6/library/rsa_internal.c
+    ${CURDIR}/../../output_base/external/mbedtls_2_16_6/library/sha1.c
+    ${CURDIR}/../../output_base/external/mbedtls_2_16_6/library/sha256.c
+    ${CURDIR}/../../output_base/external/mbedtls_2_16_6/library/sha512.c
+    ${CURDIR}/../../output_base/external/mbedtls_2_16_6/library/ssl_ciphersuites.c
+    ${CURDIR}/../../output_base/external/mbedtls_2_16_6/library/ssl_cli.c
+    ${CURDIR}/../../output_base/external/mbedtls_2_16_6/library/ssl_srv.c
+    ${CURDIR}/../../output_base/external/mbedtls_2_16_6/library/ssl_tls.c
+    ${CURDIR}/../../output_base/external/mbedtls_2_16_6/library/timing.c
+    ${CURDIR}/../../output_base/external/mbedtls_2_16_6/library/x509.c
+    ${CURDIR}/../../output_base/external/mbedtls_2_16_6/library/x509_crt.c
+
+    ${CURDIR}/../../utils/cipher.c
+    ${CURDIR}/../../utils/connectivity/conn_http.c
+    ${CURDIR}/../../utils/https.c
+    ${CURDIR}/../../utils/text_serializer.c
+    ${CURDIR}/../../utils/tryte_byte_conv.c
+
+    endpoint.c
+}
+
+cflags:
+{
+    -g -O0
+
+    -I${CURDIR}/../..
+
+    // The header files under this directory are downloaded only when the corresponding 'bazel build' command is used
+    -I${CURDIR}/../../output_base/execroot/__main__/bazel-out/k8-fastbuild/bin/external/entangled
+
+    -I${CURDIR}/../../output_base/external/com_github_uthash/src
+    -I${CURDIR}/../../output_base/external/entangled
+    -I${CURDIR}/../../output_base/external/http_parser
+    -I${CURDIR}/../../output_base/external/keccak
+    -I${CURDIR}/../../output_base/external/keccak/lib/high/Keccak
+    -I${CURDIR}/../../output_base/external/keccak/lib/common
+    -I${CURDIR}/../../output_base/external/keccak/lib/low/KeccakP-1600/OptimizedAVX512a
+    -I${CURDIR}/../../output_base/external/keccak/lib/low/KeccakP-1600/OptimizedAsmX86-64
+    -I${CURDIR}/../../output_base/external/keccak/lib/low/KeccakP-1600/Inplace32BI
+    -I${CURDIR}/../../output_base/external/keccak/lib/low/KeccakP-1600/OptimizedXOP
+    -I${CURDIR}/../../output_base/external/keccak/lib/low/KeccakP-1600/OptimizedAVX512c
+    -I${CURDIR}/../../output_base/external/keccak/lib/low/KeccakP-1600/Optimized32biAsmARM
+    -I${CURDIR}/../../output_base/external/keccak/lib/low/KeccakP-1600/OptimizedAsmAVR8
+    -I${CURDIR}/../../output_base/external/keccak/lib/low/KeccakP-1600/OptimizedAVX2
+    -I${CURDIR}/../../output_base/external/keccak/lib/low/KeccakP-1600/OptimizedAsmARM
+    -I${CURDIR}/../../output_base/external/keccak/lib/low/KeccakP-1600/Compact64
+    -I${CURDIR}/../../output_base/external/keccak/lib/low/KeccakP-1600/Reference
+    -I${CURDIR}/../../output_base/external/keccak/lib/low/KeccakP-1600/Optimized64/CompiledByGCC474forNehalem
+    -I${CURDIR}/../../output_base/external/keccak/lib/low/KeccakP-1600/Optimized64/CompiledByGCC474forHaswell
+    -I${CURDIR}/../../output_base/external/keccak/lib/low/KeccakP-1600/Optimized64
+    -I${CURDIR}/../../output_base/external/keccak/lib/low/KeccakP-1600/Optimized64/CompiledByGCC474forSandyBridge
+    -I${CURDIR}/../../output_base/external/keccak/lib/low/KeccakP-1600/Reference32BI
+    -I${CURDIR}/../../output_base/external/keccak/lib/low/KeccakP-1600/Optimized64AsmARM
+    -I${CURDIR}/../../output_base/external/mbedtls_2_16_6/include
+}
+
+bundles:
+{
+    // List of files copied from the build host into the App for runtime usage
+    file:
+    {
+        resolv.conf /etc/
+    }
+}
+
+requires:
+{
+    device:
+    {
+        [rw] /dev/ttyHS0 /dev/ttyHS0
+    }
+}

--- a/endpoint/endpointComp/endpoint.c
+++ b/endpoint/endpointComp/endpoint.c
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2019-2020 BiiLabs Co., Ltd. and Contributors
+ * All Rights Reserved.
+ * This is free software; you can redistribute it and/or modify it under the
+ * terms of the MIT license. A copy of the license can be found in the file
+ * "LICENSE" at the root of this distribution.
+ */
+
+#include "endpoint.h"
+
+#include "legato.h"
+
+#include "endpoint/endpoint_core.h"
+#include "utils/cipher.h"
+
+#define TEST_VALUE 0
+#define TEST_MESSAGE "THISISMSG9THISISMSG9THISISMSG"
+#define TEST_MESSAGE_FMT "ascii"
+#define TEST_TAG "POWEREDBYTANGLEACCELERATOR9"
+#define TEST_ADDRESS                                                           \
+  "POWEREDBYTANGLEACCELERATOR999999999999999999999999999999999999999999999999" \
+  "999999A"
+#define TEST_NEXT_ADDRESS                                                      \
+  "POWEREDBYTANGLEACCELERATOR999999999999999999999999999999999999999999999999" \
+  "999999B"
+#define TEST_DEVICE_ID "470010171566423"
+
+const uint8_t test_key[32] = {82,  142, 184, 64,  74, 105, 126, 65,  154, 116, 14,  193, 208, 41,  8,  115,
+                              158, 252, 228, 160, 79, 5,   167, 185, 13,  159, 135, 113, 49,  209, 58, 68};
+const uint8_t test_iv[AES_IV_SIZE] = {164, 3, 98, 193, 52, 162, 107, 252, 184, 42, 74, 225, 157, 26, 88, 72};
+
+static void print_help(void) {
+  puts(
+      "NAME\n"
+      "endpoint - The endpoint for sending transactions to Tangle-accelerator.\n"
+      "\n"
+      "SYNOPSIS\n"
+      "  endpoint [-h]\n"
+      "  endpoint [--help]\n"
+      "\n"
+      "OPTIONS\n"
+      "  -h\n"
+      "  --help\n"
+      "    Print the information for helping the users. Ignore other arguments.\n"
+      "\n");
+
+  exit(EXIT_SUCCESS);
+}
+
+COMPONENT_INIT {
+  // FIXME:
+  // The current code is a prototype for passing the CI.
+  // The initialization of hardware and the input from hardware are not implemented yet.
+  le_arg_SetFlagCallback(print_help, "h", "help");
+  le_arg_Scan();
+
+  uint8_t iv[AES_IV_SIZE] = {0};
+
+  memcpy(iv, test_iv, AES_IV_SIZE);
+  srand(time(NULL));
+
+  while (true) {
+    send_transaction_information(TEST_VALUE, TEST_MESSAGE, TEST_MESSAGE_FMT, TEST_TAG, TEST_ADDRESS, TEST_NEXT_ADDRESS,
+                                 test_key, TEST_DEVICE_ID, iv);
+    sleep(10);
+  }
+}

--- a/endpoint/endpointComp/endpoint.h
+++ b/endpoint/endpointComp/endpoint.h
@@ -1,0 +1,17 @@
+/*
+ * Copyright (C) 2019-2020 BiiLabs Co., Ltd. and Contributors
+ * All Rights Reserved.
+ * This is free software; you can redistribute it and/or modify it under the
+ * terms of the MIT license. A copy of the license can be found in the file
+ * "LICENSE" at the root of this distribution.
+ */
+
+#ifndef ENDPOINT_H
+#define ENDPOINT_H
+
+/**
+ * @brief Print the help message of endpoint application
+ */
+static void print_help(void);
+
+#endif  // ENDPOINT_H

--- a/endpoint/endpoint_core.c
+++ b/endpoint/endpoint_core.c
@@ -6,7 +6,7 @@
  * "LICENSE" at the root of this distribution.
  */
 
-#include "endpoint.h"
+#include "endpoint_core.h"
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/endpoint/endpoint_core.h
+++ b/endpoint/endpoint_core.h
@@ -6,8 +6,8 @@
  * "LICENSE" at the root of this distribution.
  */
 
-#ifndef ENDPOINT_H
-#define ENDPOINT_H
+#ifndef ENDPOINT_CORE_H
+#define ENDPOINT_CORE_H
 
 #define ADDR_LEN 81
 #define MAX_MSG_LEN 1024
@@ -36,4 +36,4 @@ status_t send_transaction_information(const int value, const char* message, cons
                                       const char* address, const char* next_address, const uint8_t* private_key,
                                       const char* device_id, uint8_t* iv);
 
-#endif  // ENDPOINT_H
+#endif  // ENDPOINT_CORE_H

--- a/endpoint/test_endpoint_core.c
+++ b/endpoint/test_endpoint_core.c
@@ -12,7 +12,7 @@
 #include <time.h>
 #include "common/macros.h"
 #include "common/ta_errors.h"
-#include "endpoint.h"
+#include "endpoint_core.h"
 #include "tests/test_define.h"
 #include "utils/cipher.h"
 

--- a/utils/cipher.c
+++ b/utils/cipher.c
@@ -7,6 +7,7 @@
  */
 
 #include "cipher.h"
+#include <inttypes.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -46,7 +47,7 @@ status_t aes_decrypt(ta_cipher_ctx* cipher_ctx) {
   }
 
   // concatenate (Device_ID, timestamp)
-  snprintf((char*)nonce, IMSI_LEN + MAX_TIMESTAMP_LEN + 1, "%s-%ld", cipher_ctx->device_id, cipher_ctx->timestamp);
+  snprintf((char*)nonce, IMSI_LEN + MAX_TIMESTAMP_LEN + 1, "%s-%" PRIu64, cipher_ctx->device_id, cipher_ctx->timestamp);
   // hash base data
   mbedtls_md_starts(&sha_ctx);
   mbedtls_md_update(&sha_ctx, digest, AES_BLOCK_SIZE * 2);
@@ -126,7 +127,7 @@ status_t aes_encrypt(ta_cipher_ctx* cipher_ctx) {
   mbedtls_platform_zeroize(ciphertext, sizeof(ciphertext));
 
   // concatenate (Device_ID, timestamp)
-  snprintf((char*)nonce, IMSI_LEN + MAX_TIMESTAMP_LEN + 1, "%s-%ld", cipher_ctx->device_id, cipher_ctx->timestamp);
+  snprintf((char*)nonce, IMSI_LEN + MAX_TIMESTAMP_LEN + 1, "%s-%" PRIu64, cipher_ctx->device_id, cipher_ctx->timestamp);
   // hash base data
   mbedtls_md_starts(&sha_ctx);
   mbedtls_md_update(&sha_ctx, digest, AES_BLOCK_SIZE * 2);


### PR DESCRIPTION
The files and directory structure are changed.
The directory endpoint/endpointComp is for building the Legato app.
The endpoint/endpoint.c is renamed as endpoint/endpoint_core.c to
separate the core functions. Same as the endpoint/endpoint.h.

New:
To build the endpoint Legato app, use the command 'make legato'.
It is implemented with the mkapp command.

Besides, the shared library libendpoint.so can be generated with Bazel
as well.

Close #576.