### PR TITLE
fix(endpoint): Use ta_cipher_ctx pointer

### DIFF
--- a/common/macros.h
+++ b/common/macros.h
@@ -43,6 +43,9 @@ typedef enum mam_protocol_e { MAM_V1 } mam_protocol_t;
 // release cached data.
 #define CACHE_FAILED_TXN_TIMEOUT (7 * 24 * 60 * 60)
 
+#define STR_HELPER(num) #num
+#define STR(num) STR_HELPER(num)
+
 #ifdef __cplusplus
 }
 #endif

--- a/endpoint/endpoint.c
+++ b/endpoint/endpoint.c
@@ -70,8 +70,7 @@ status_t send_transaction_information(int value, const char* message, const char
     fprintf(stderr, "%s\n", "encrypt msg error");
     return ret;
   }
-  serialize_msg(iv, encrypt_ctx.ciphertext_len, (char*)encrypt_ctx.ciphertext, encrypt_ctx.timestamp, encrypt_ctx.hmac,
-                msg, &msg_len);
+  serialize_msg(&encrypt_ctx, msg, &msg_len);
   bytes_to_trytes((const unsigned char*)msg, msg_len, tryte_msg);
 
   memset(req_body, 0, sizeof(char) * MAX_MSG_LEN);

--- a/utils/BUILD
+++ b/utils/BUILD
@@ -70,7 +70,7 @@ cc_library(
     hdrs = ["text_serializer.h"],
     deps = [
         ":cipher",
-        "//common:ta_errors",
+        "//common",
     ],
 )
 

--- a/utils/text_serializer.h
+++ b/utils/text_serializer.h
@@ -12,6 +12,7 @@
 #include <stddef.h>
 #include <stdint.h>
 #include "common/ta_errors.h"
+#include "utils/cipher.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -26,11 +27,7 @@ extern "C" {
  * - ciphertext length(10 bytes)
  * - ciphertext(other bytes)
  *
- * @param[in] iv Pointer to initialize vector
- * @param[in] ciphertext_len Length of ciphertext
- * @param[in] ciphertext Ciphertext to be serialized
- * @param[in] timestamp Timestamp to be serialized
- * @param[in] hmac Hash mac array to be serialized
+ * @param[in] ctx The cipher context to be serialized
  * @param[out] out_msg Pointer to output message
  * @param[out] out_msg_len Pointer to length of serialized message
  *
@@ -38,26 +35,20 @@ extern "C" {
  * - SC_OK on success
  * - SC_UTILS_TEXT_SERIALIZE on error
  */
-status_t serialize_msg(const uint8_t *iv, uint32_t ciphertext_len, const char *ciphertext, const uint64_t timestamp,
-                       const uint8_t *hmac, char *out_msg, size_t *out_msg_len);
+status_t serialize_msg(const ta_cipher_ctx* ctx, char *out_msg, size_t *out_msg_len);
 
 /**
  * @brief Deserialize message from serialize_msg
  *
  * @param[in] msg Pointer to serialize message
- * @param[in] iv Pointer to initialize vector
- * @param[out] ciphertext_len Pointer to plaintext length
- * @param[out] ciphertext Pointer to plaintext output array
- * @param[out] timestamp Pointer to timestamp
- * @param[out] hmac Pointer to hash mac output array
+ * @param[in/out] ctx The cipher context to be deserialized
  *
  * @return
  * - SC_OK on success
  * - SC_UTILS_TEXT_DESERIALIZE on error
  * @see #serialize_msg
  */
-status_t deserialize_msg(char *msg, const uint8_t *iv, size_t *ciphertext_len, char *ciphertext, uint64_t *timestamp,
-                         uint8_t *hmac);
+status_t deserialize_msg(const char *msg, ta_cipher_ctx* ctx);
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
There are individual parameters of serialize_msg and
deserialize_msg. The individual parameters are the same as
ta_cipher_ctx's member. We can pass a ta_cipher_ctx pointer
instead of individual parameters.
    
Close #627