### PR TITLE
endpoint(fix): Reset default host

### DIFF
--- a/endpoint/BUILD
+++ b/endpoint/BUILD
@@ -3,7 +3,7 @@ cc_library(
     srcs = ["endpoint.c"],
     hdrs = ["endpoint.h"],
     defines = [
-        "ENDPOINT_HOST=\"tangle-accel.biilabs.io\"",
+        "ENDPOINT_HOST=\"localhost\"",
         "ENDPOINT_PORT=\"443\"",
         "ENDPOINT_SSL_SEED=\"nonce\"",
     ],


### PR DESCRIPTION
The previous host is for deployment. This commit reset the
endpoint default host to localhost for consistency. The localhost
is the default setting inside tangle-accelerator.

Close #606