### PR TITLE
feat(test): Add sanitizer for router

### DIFF
--- a/accelerator/main.c
+++ b/accelerator/main.c
@@ -134,6 +134,10 @@ int main(int argc, char* argv[]) {
     br_logger_init();
   }
 
+  // Once tangle-accelerator finished initializing, return 'SIGUSR1' to parent process
+  pid_t pid = getppid();
+  kill(pid, SIGUSR1);
+
   /* pause() cause TA to sleep until it catch a signal,
    * also the return value and errno should be -1 and EINTR on success.
    */

--- a/endpoint/platform/simulator/impl.c
+++ b/endpoint/platform/simulator/impl.c
@@ -86,7 +86,7 @@ static status_t sec_init(void) {
 
 static status_t sec_write(const char *name, const uint8_t *buf, size_t buf_size) {
   uint8_t *data = malloc(buf_size);
-  if(data == NULL){
+  if (data == NULL) {
     LE_ERROR("Cannot fetch enough memory");
     return SC_OOM;
   }

--- a/endpoint/unit-test/driver.sh
+++ b/endpoint/unit-test/driver.sh
@@ -34,10 +34,22 @@ function run_test_suite(){
 
 function start_ta(){
     # Create tangle-accelerator for unit-test
+    trap 'TA_INIT=1' USR1
     bazel run accelerator &
     TA=$!
+    TA_INIT=0
+
     # Wait for tangle-acclerator build finish
-    sleep 20 
+    while [ "$TA_INIT" -ne 1 ]; do
+        if ps -p $TA > /dev/null; then
+            echo "waiting for tangle-accelerator initialization"
+            sleep 1
+            continue
+        else
+            # pid does not exist
+            break
+        fi
+    done
 }
 
 echo "Start unit-test for endpoint"

--- a/tests/regression/common.sh
+++ b/tests/regression/common.sh
@@ -18,6 +18,17 @@ setup_build_opts() {
     fail=()
 }
 
+# Set sanitizer options
+setup_sanitizer_opts() {
+    SAN_OPTIONS=(
+        "--config=asan"
+        "--config=tsan"
+        "--config=ubsan"
+    )
+    success=()
+    fail=()
+}
+
 # Check environment variables
 check_env() {
     ENV_NAME=(

--- a/tests/regression/router-sanitizer.sh
+++ b/tests/regression/router-sanitizer.sh
@@ -3,43 +3,47 @@
 source tests/regression/common.sh
 
 check_env
-setup_build_opts
+setup_sanitizer_opts
 
 # Get command line arguments
 # Current arguments parsed are <sleep_time> <remaining_args>
 get_cli_args $@
 
 # Install prerequisites
-make MQTT
+make
 pip3 install --user -r tests/regression/requirements.txt
 
 # FIXME: Check Redis status
 redis-server &
 
 # Iterate over all available build options
-for (( i = 0; i < ${#OPTIONS[@]}; i++ )); do
-    option=${OPTIONS[${i}]}
-    cli_arg=${option} | cut -d '|' -f 1
-    build_arg=${option} | cut -d '|' -f 2
+for (( i = 0; i < ${#SAN_OPTIONS[@]}; i++ )); do
+    option=${SAN_OPTIONS[${i}]}
 
     trap 'TA_INIT=1' USR1
-    bazel run accelerator --define mqtt=enable ${build_arg} -- --quiet --ta_port=${TA_PORT} ${cli_arg} &
+    bazel run accelerator ${option} -c dbg -- --ta_port=${TA_PORT} &
     TA=$!
     
     TA_INIT=0
     while [ "$TA_INIT" -ne 1 ]; do
-        echo "waiting for tangle-accelerator initialization"
-        sleep 1
+        if ps -p $TA > /dev/null; then
+            echo "waiting for tangle-accelerator initialization"
+            sleep 1
+            continue
+        else
+            # pid does not exist
+            break
+        fi
     done
     
     trap "kill -9 ${TA};" INT # Trap SIGINT from Ctrl-C to stop TA
 
-    python3 tests/regression/runner.py ${remaining_args} --url "localhost" --mqtt
+    python3 tests/regression/runner.py ${remaining_args} --url localhost:${TA_PORT}
     rc=$?
 
     if [ $rc -ne 0 ]
     then
-        echo "Build option '${option}' failed"
+        echo "Build sanitizer '${option}' failed"
         fail+=("${option}")
     else
         success+=("${option}")

--- a/tests/regression/run-api.sh
+++ b/tests/regression/run-api.sh
@@ -11,7 +11,9 @@ get_cli_args $@
 
 # Install prerequisites
 make
-pip install --user -r tests/regression/requirements.txt
+pip3 install --user -r tests/regression/requirements.txt
+
+# FIXME: Check Redis status
 redis-server &
 
 # Iterate over all available build options
@@ -20,9 +22,22 @@ for (( i = 0; i < ${#OPTIONS[@]}; i++ )); do
     cli_arg=$(echo ${option} | cut -d '|' -f 2)
     build_arg=$(echo ${option} | cut -d '|' -f 1)
 
+    trap 'TA_INIT=1' USR1
     bazel run accelerator ${build_arg} -- --ta_port=${TA_PORT} ${cli_arg} &
     TA=$!
-    sleep ${sleep_time} # TA takes time to be built
+    
+    TA_INIT=0
+    while [ "$TA_INIT" -ne 1 ]; do
+        if ps -p $TA > /dev/null; then
+            echo "waiting for tangle-accelerator initialization"
+            sleep 1
+            continue
+        else
+            # pid does not exist
+            break
+        fi
+    done
+    
     trap "kill -9 ${TA};" INT # Trap SIGINT from Ctrl-C to stop TA
 
     python3 tests/regression/runner.py ${remaining_args} --url localhost:${TA_PORT}
@@ -44,3 +59,7 @@ echo "--------- Successful build options ---------"
 for (( i = 0; i < ${#success[@]}; i++ )); do echo ${success[${i}]}; done
 echo "----------- Failed build options -----------"
 for (( i = 0; i < ${#fail[@]}; i++ )); do echo ${fail[${i}]}; done
+
+if [ ${#fail[@]} -gt 0 ]; then
+    exit 1
+fi


### PR DESCRIPTION
Building tangle-accelerator with sanitizer, and run regression test
with the just built tangle-accelerator. With this procedure, we can
test router with sanitizers.

Now once tangle-accelerator has been initialized, tangle-accelerator
will send SIGUSR1 to the parent bash script. The bash script will wait
for the signal, then run the Python script.
