### PR TITLE
cleanup(common): Clean redundant status code

### DIFF
--- a/accelerator/config.c
+++ b/accelerator/config.c
@@ -39,8 +39,8 @@ static int get_conf_key(char const* const key) {
 
 status_t cli_core_set(ta_core_t* const core, int key, char* const value) {
   if (value == NULL && (key != CACHE && key != PROXY_API && key != QUIET && key != NO_GTTA)) {
-    ta_log_error("%s\n", "SC_CONF_NULL");
-    return SC_CONF_NULL;
+    ta_log_error("%s\n", "SC_NULL");
+    return SC_NULL;
   }
   ta_config_t* const ta_conf = &core->ta_conf;
   iota_config_t* const iota_conf = &core->iota_conf;
@@ -441,7 +441,7 @@ status_t ta_core_set(ta_core_t* core) {
 #endif
   if (iota_client_service_init(iota_service)) {
     ta_log_error("Initializing IRI connection failed!\n");
-    ret = SC_TA_OOM;
+    ret = SC_OOM;
     goto exit;
   }
 

--- a/accelerator/core/apis.c
+++ b/accelerator/core/apis.c
@@ -39,7 +39,7 @@ status_t api_find_transaction_object_single(const iota_client_service_t* const s
   ta_find_transaction_objects_req_t* req = ta_find_transaction_objects_req_new();
   transaction_array_t* res = transaction_array_new();
   if (req == NULL || res == NULL) {
-    ret = SC_TA_OOM;
+    ret = SC_OOM;
     ta_log_error("%s\n", ta_error_to_string(ret));
     goto done;
   }
@@ -67,7 +67,7 @@ status_t api_find_transaction_objects(const iota_client_service_t* const service
   ta_find_transaction_objects_req_t* req = ta_find_transaction_objects_req_new();
   transaction_array_t* res = transaction_array_new();
   if (req == NULL || res == NULL) {
-    ret = SC_TA_OOM;
+    ret = SC_OOM;
     ta_log_error("%s\n", ta_error_to_string(ret));
     goto done;
   }
@@ -99,7 +99,7 @@ status_t api_find_transactions_by_tag(const iota_client_service_t* const service
   find_transactions_req_t* req = find_transactions_req_new();
   find_transactions_res_t* res = find_transactions_res_new();
   if (req == NULL || res == NULL) {
-    ret = SC_TA_OOM;
+    ret = SC_OOM;
     ta_log_error("%s\n", ta_error_to_string(ret));
     goto done;
   }
@@ -143,7 +143,7 @@ status_t api_find_transactions_obj_by_tag(const iota_client_service_t* const ser
   find_transactions_req_t* req = find_transactions_req_new();
   transaction_array_t* res = transaction_array_new();
   if (req == NULL || res == NULL) {
-    ret = SC_TA_OOM;
+    ret = SC_OOM;
     ta_log_error("%s\n", ta_error_to_string(ret));
     goto done;
   }
@@ -186,7 +186,7 @@ status_t api_recv_mam_message(const iota_config_t* const iconf, const iota_clien
   ta_recv_mam_req_t* req = recv_mam_req_new();
   ta_recv_mam_res_t* res = recv_mam_res_new();
   if (!req || !res) {
-    ret = SC_TA_OOM;
+    ret = SC_OOM;
     ta_log_error("%s\n", ta_error_to_string(ret));
     return ret;
   }
@@ -252,7 +252,7 @@ status_t api_send_transfer(const ta_core_t* const core, const iota_client_servic
   transaction_array_t* res_txn_array = transaction_array_new();
 
   if (req == NULL || res == NULL || txn_obj_req == NULL || res_txn_array == NULL) {
-    ret = SC_TA_OOM;
+    ret = SC_OOM;
     ta_log_error("%s\n", ta_error_to_string(ret));
     goto done;
   }
@@ -315,7 +315,7 @@ status_t api_send_trytes(const ta_config_t* const info, const iota_config_t* con
   hash8019_array_p trytes = hash8019_array_new();
 
   if (!trytes) {
-    ret = SC_TA_OOM;
+    ret = SC_OOM;
     ta_log_error("%s\n", ta_error_to_string(ret));
     goto done;
   }
@@ -372,7 +372,7 @@ status_t api_fetch_txn_with_uuid(const ta_cache_t* const cache, const char* cons
 
   ta_fetch_txn_with_uuid_res_t* res = ta_fetch_txn_with_uuid_res_new();
   if (res == NULL) {
-    ret = SC_CORE_OOM;
+    ret = SC_OOM;
     ta_log_error("%s\n", ta_error_to_string(ret));
     return ret;
   }
@@ -399,7 +399,7 @@ status_t api_find_transactions_by_id(const iota_client_service_t* const iota_ser
                                      char** json_result) {
   if (obj == NULL) {
     ta_log_error("Invalid NULL pointer to uuid string\n");
-    return SC_TA_NULL;
+    return SC_NULL;
   }
   status_t ret = SC_OK;
   ta_log_info("find transaction by uuid string: %s\n", obj);
@@ -427,7 +427,7 @@ status_t api_get_identity_info_by_hash(const db_client_service_t* const db_servi
                                        char** json_result) {
   if (obj == NULL) {
     ta_log_error("Invalid NULL pointer to uuid string\n");
-    return SC_TA_NULL;
+    return SC_NULL;
   }
   status_t ret = SC_OK;
   ta_log_info("get identity info by hash : %s\n", obj);
@@ -454,7 +454,7 @@ status_t api_get_identity_info_by_id(const db_client_service_t* const db_service
                                      char** json_result) {
   if (obj == NULL) {
     ta_log_error("Invalid NULL pointer to uuid string\n");
-    return SC_TA_NULL;
+    return SC_NULL;
   }
 
   status_t ret = SC_OK;

--- a/accelerator/core/core.c
+++ b/accelerator/core/core.c
@@ -72,7 +72,7 @@ status_t ta_send_trytes(const ta_config_t* const info, const iota_config_t* cons
   attach_to_tangle_req_t* attach_req = attach_to_tangle_req_new();
   attach_to_tangle_res_t* attach_res = attach_to_tangle_res_new();
   if (!tx_approve_req || !tx_approve_res || !attach_req || !attach_res) {
-    ret = SC_CCLIENT_OOM;
+    ret = SC_OOM;
     ta_log_error("%s\n", ta_error_to_string(ret));
     goto done;
   }
@@ -123,8 +123,8 @@ status_t ta_send_transfer(const ta_config_t* const info, const iota_config_t* co
                           const iota_client_service_t* const service, const ta_cache_t* const cache,
                           const ta_send_transfer_req_t* const req, ta_send_transfer_res_t* res) {
   if (req == NULL || res == NULL) {
-    ta_log_error("%s\n", ta_error_to_string(SC_TA_NULL));
-    return SC_TA_NULL;
+    ta_log_error("%s\n", ta_error_to_string(SC_NULL));
+    return SC_NULL;
   }
 
   status_t ret = SC_OK;
@@ -137,7 +137,7 @@ status_t ta_send_transfer(const ta_config_t* const info, const iota_config_t* co
   bundle_transactions_new(&out_bundle);
   transfer_array_t* transfers = transfer_array_new();
   if (find_tx_req == NULL || find_tx_res == NULL || transfers == NULL) {
-    ret = SC_CCLIENT_OOM;
+    ret = SC_OOM;
     ta_log_error("%s\n", ta_error_to_string(ret));
     goto done;
   }
@@ -145,7 +145,7 @@ status_t ta_send_transfer(const ta_config_t* const info, const iota_config_t* co
   transfer_t transfer = {.value = 0, .timestamp = current_timestamp_ms(), .msg_len = req->msg_len};
 
   if (transfer_message_set_trytes(&transfer, req->message, transfer.msg_len) != RC_OK) {
-    ret = SC_CCLIENT_OOM;
+    ret = SC_OOM;
     ta_log_error("%s\n", ta_error_to_string(ret));
     goto done;
   }
@@ -219,15 +219,15 @@ done:
 status_t ta_find_transactions_obj_by_tag(const iota_client_service_t* const service,
                                          const find_transactions_req_t* const req, transaction_array_t* res) {
   if (req == NULL || res == NULL) {
-    ta_log_error("%s\n", ta_error_to_string(SC_TA_NULL));
-    return SC_TA_NULL;
+    ta_log_error("%s\n", ta_error_to_string(SC_NULL));
+    return SC_NULL;
   }
 
   status_t ret = SC_OK;
   find_transactions_res_t* txn_res = find_transactions_res_new();
   ta_find_transaction_objects_req_t* obj_req = ta_find_transaction_objects_req_new();
   if (txn_res == NULL || obj_req == NULL) {
-    ret = SC_TA_OOM;
+    ret = SC_OOM;
     ta_log_error("%s\n", ta_error_to_string(ret));
     goto done;
   }
@@ -262,7 +262,7 @@ status_t ta_find_transaction_objects(const iota_client_service_t* const service,
   transaction_array_t* uncached_txn_array = transaction_array_new();
   flex_trit_t* temp_txn_trits = NULL;
   if (req == NULL || res == NULL || req_get_trytes == NULL || uncached_txn_array == NULL) {
-    ret = SC_TA_NULL;
+    ret = SC_NULL;
     ta_log_error("%s\n", ta_error_to_string(ret));
     goto done;
   }
@@ -285,7 +285,7 @@ status_t ta_find_transaction_objects(const iota_client_service_t* const service,
       // deserialize raw data to transaction object
       temp = transaction_deserialize(tx_trits, true);
       if (temp == NULL) {
-        ret = SC_CCLIENT_OOM;
+        ret = SC_OOM;
         ta_log_error("%s\n", ta_error_to_string(ret));
         goto done;
       }
@@ -374,7 +374,7 @@ status_t ta_get_bundle(const iota_client_service_t* const service, tryte_t const
   transaction_array_t* tx_objs = transaction_array_new();
   find_transactions_req_t* find_tx_req = find_transactions_req_new();
   if (find_tx_req == NULL) {
-    ret = SC_CCLIENT_OOM;
+    ret = SC_OOM;
     ta_log_error("%s\n", ta_error_to_string(ret));
     goto done;
   }
@@ -435,7 +435,7 @@ status_t ta_get_bundles_by_addr(const iota_client_service_t* const service, tryt
   transaction_array_t* obj_res = transaction_array_new();
 
   if (txn_req == NULL || txn_res == NULL || obj_req == NULL || obj_res == NULL) {
-    ret = SC_TA_OOM;
+    ret = SC_OOM;
     ta_log_error("%s\n", ta_error_to_string(ret));
     goto done;
   }
@@ -559,7 +559,7 @@ done:
 status_t push_txn_to_buffer(const ta_cache_t* const cache, hash8019_array_p raw_txn_flex_trit_array, char* uuid) {
   status_t ret = SC_OK;
   if (!uuid) {
-    ret = SC_CORE_NULL;
+    ret = SC_NULL;
     ta_log_error("%s\n", ta_error_to_string(ret));
     goto done;
   }
@@ -800,7 +800,7 @@ status_t ta_fetch_txn_with_uuid(const ta_cache_t* const cache, const char* const
       iota_transaction_t* txn = transaction_deserialize(txn_flex_trits, false);
 
       if (bundle_transactions_add(res->bundle, txn) != RC_OK) {
-        ret = SC_CORE_NULL;
+        ret = SC_NULL;
         ta_log_error("%s\n", "Failed to add transaction to bundle.");
         free(txn);
         goto done;

--- a/accelerator/core/pow.c
+++ b/accelerator/core/pow.c
@@ -67,7 +67,7 @@ status_t ta_pow(const bundle_transactions_t* bundle, const flex_trit_t* const tr
 
   tx = (iota_transaction_t*)utarray_back(bundle);
   if (tx == NULL) {
-    ret = SC_TA_NULL;
+    ret = SC_NULL;
     ta_log_error("%s\n", ta_error_to_string(ret));
     goto done;
   }
@@ -93,7 +93,7 @@ status_t ta_pow(const bundle_transactions_t* bundle, const flex_trit_t* const tr
     // get nonce
     flex_trit_t* nonce = ta_pow_flex(tx_trits, mwm);
     if (nonce == NULL) {
-      ret = SC_TA_OOM;
+      ret = SC_OOM;
       ta_log_error("%s\n", ta_error_to_string(ret));
       goto done;
     }

--- a/accelerator/core/proxy_apis.c
+++ b/accelerator/core/proxy_apis.c
@@ -33,7 +33,7 @@ static status_t api_check_consistency(const iota_client_service_t* const service
   check_consistency_res_t* res = check_consistency_res_new();
   char_buffer_t* res_buff = char_buffer_new();
   if (req == NULL || res == NULL || res_buff == NULL) {
-    ret = SC_TA_OOM;
+    ret = SC_OOM;
     ta_log_error("%s\n", ta_error_to_string(ret));
     goto done;
   }
@@ -72,7 +72,7 @@ static status_t api_find_transactions(const iota_client_service_t* const service
   find_transactions_res_t* res = find_transactions_res_new();
   char_buffer_t* res_buff = char_buffer_new();
   if (req == NULL || res == NULL || res_buff == NULL) {
-    ret = SC_TA_OOM;
+    ret = SC_OOM;
     ta_log_error("%s\n", ta_error_to_string(ret));
     goto done;
   }
@@ -111,7 +111,7 @@ static status_t api_get_balances(const iota_client_service_t* const service, con
   get_balances_res_t* res = get_balances_res_new();
   char_buffer_t* res_buff = char_buffer_new();
   if (req == NULL || res == NULL || res_buff == NULL) {
-    ret = SC_TA_OOM;
+    ret = SC_OOM;
     ta_log_error("%s\n", ta_error_to_string(ret));
     goto done;
   }
@@ -150,7 +150,7 @@ static status_t api_get_inclusion_states(const iota_client_service_t* const serv
   get_inclusion_states_res_t* res = get_inclusion_states_res_new();
   char_buffer_t* res_buff = char_buffer_new();
   if (req == NULL || res == NULL || res_buff == NULL) {
-    ret = SC_TA_OOM;
+    ret = SC_OOM;
     ta_log_error("%s\n", ta_error_to_string(ret));
     goto done;
   }
@@ -187,7 +187,7 @@ static status_t api_get_node_info(const iota_client_service_t* const service, ch
   get_node_info_res_t* res = get_node_info_res_new();
   char_buffer_t* res_buff = char_buffer_new();
   if (res == NULL || res_buff == NULL) {
-    ret = SC_TA_OOM;
+    ret = SC_OOM;
     ta_log_error("%s\n", ta_error_to_string(ret));
     goto done;
   }
@@ -218,7 +218,7 @@ static status_t api_get_trytes(const iota_client_service_t* const service, const
   get_trytes_res_t* res = get_trytes_res_new();
   char_buffer_t* res_buff = char_buffer_new();
   if (req == NULL || res == NULL || res_buff == NULL) {
-    ret = SC_TA_OOM;
+    ret = SC_OOM;
     ta_log_error("%s\n", ta_error_to_string(ret));
     goto done;
   }

--- a/accelerator/core/request/ta_recv_mam.c
+++ b/accelerator/core/request/ta_recv_mam.c
@@ -61,16 +61,16 @@ void recv_mam_req_free(ta_recv_mam_req_t** req) {
 
 status_t recv_mam_req_v1_init(ta_recv_mam_req_t* req) {
   if (req == NULL) {
-    return SC_TA_NULL;
+    return SC_NULL;
   }
 
   req->data_id = (recv_mam_data_id_mam_v1_t*)malloc(sizeof(recv_mam_data_id_mam_v1_t));
   if (req->data_id == NULL) {
-    return SC_TA_OOM;
+    return SC_OOM;
   }
   req->key = (recv_mam_key_mam_v1_t*)malloc(sizeof(recv_mam_key_mam_v1_t));
   if (req->key == NULL) {
-    return SC_TA_OOM;
+    return SC_OOM;
   }
 
   recv_mam_data_id_mam_v1_t* data_id = (recv_mam_data_id_mam_v1_t*)req->data_id;
@@ -87,7 +87,7 @@ status_t recv_mam_req_v1_init(ta_recv_mam_req_t* req) {
 
 status_t recv_mam_set_mam_v1_data_id(ta_recv_mam_req_t* req, char* bundle_hash, char* chid, char* msg_id) {
   if (req == NULL || (!bundle_hash && !chid && !msg_id)) {
-    return SC_TA_NULL;
+    return SC_NULL;
   }
   status_t ret = SC_OK;
 
@@ -95,21 +95,21 @@ status_t recv_mam_set_mam_v1_data_id(ta_recv_mam_req_t* req, char* bundle_hash, 
   if (bundle_hash) {
     data_id->bundle_hash = (tryte_t*)strdup(bundle_hash);
     if (!data_id->bundle_hash) {
-      ret = SC_TA_OOM;
+      ret = SC_OOM;
       goto error;
     }
   }
   if (chid) {
     data_id->chid = (tryte_t*)strdup(chid);
     if (!data_id->chid) {
-      ret = SC_TA_OOM;
+      ret = SC_OOM;
       goto error;
     }
   }
   if (msg_id) {
     data_id->msg_id = (tryte_t*)strdup(msg_id);
     if (!data_id->msg_id) {
-      ret = SC_TA_OOM;
+      ret = SC_OOM;
       goto error;
     }
   }

--- a/accelerator/core/request/ta_send_mam.c
+++ b/accelerator/core/request/ta_send_mam.c
@@ -20,18 +20,18 @@ ta_send_mam_req_t* send_mam_req_new() {
 
 status_t send_mam_req_v1_init(ta_send_mam_req_t* req) {
   if (req == NULL) {
-    return SC_TA_NULL;
+    return SC_NULL;
   }
 
   memset(req->service_token, 0, SERVICE_TOKEN_LEN + 1);
 
   req->data = (send_mam_data_mam_v1_t*)malloc(sizeof(send_mam_data_mam_v1_t));
   if (req->data == NULL) {
-    return SC_TA_OOM;
+    return SC_OOM;
   }
   req->key = (send_mam_key_mam_v1_t*)malloc(sizeof(send_mam_key_mam_v1_t));
   if (req->key == NULL) {
-    return SC_TA_OOM;
+    return SC_OOM;
   }
 
   send_mam_data_mam_v1_t* data = req->data;

--- a/accelerator/core/response/ta_recv_mam.h
+++ b/accelerator/core/response/ta_recv_mam.h
@@ -38,7 +38,7 @@ ta_recv_mam_res_t* recv_mam_res_new();
 /**
  * @brief Free memory of ta_recv_mam_res_t
  *
- * @param res[in/out] Data type of ta_recv_mam_res_t
+ * @param res[in,out] Data type of ta_recv_mam_res_t
  */
 void recv_mam_res_free(ta_recv_mam_res_t** res);
 

--- a/accelerator/core/response/ta_send_mam.c
+++ b/accelerator/core/response/ta_send_mam.c
@@ -20,7 +20,7 @@ ta_send_mam_res_t* send_mam_res_new() {
 
 status_t send_mam_res_set_bundle_hash(ta_send_mam_res_t* res, const tryte_t* bundle_hash) {
   if (!bundle_hash || !res) {
-    return SC_RES_NULL;
+    return SC_NULL;
   }
 
   memcpy(res->bundle_hash, bundle_hash, NUM_TRYTES_HASH);
@@ -30,7 +30,7 @@ status_t send_mam_res_set_bundle_hash(ta_send_mam_res_t* res, const tryte_t* bun
 
 status_t send_mam_res_set_channel_id(ta_send_mam_res_t* res, const tryte_t* channel_id) {
   if (!channel_id || !res) {
-    return SC_RES_NULL;
+    return SC_NULL;
   }
 
   memcpy(res->chid, channel_id, NUM_TRYTES_HASH);
@@ -40,7 +40,7 @@ status_t send_mam_res_set_channel_id(ta_send_mam_res_t* res, const tryte_t* chan
 
 status_t send_mam_res_set_msg_id(ta_send_mam_res_t* res, const tryte_t* msg_id) {
   if (!msg_id || !res) {
-    return SC_RES_NULL;
+    return SC_NULL;
   }
 
   memcpy(res->msg_id, msg_id, NUM_TRYTES_MAM_MSG_ID);
@@ -69,7 +69,7 @@ done:
 
 status_t send_mam_res_set_announce_bundle_hash(ta_send_mam_res_t* res, const tryte_t* announcement_bundle_hash) {
   if (!announcement_bundle_hash || !res) {
-    return SC_RES_NULL;
+    return SC_NULL;
   }
 
   memcpy(res->announcement_bundle_hash, announcement_bundle_hash, NUM_TRYTES_HASH);
@@ -79,7 +79,7 @@ status_t send_mam_res_set_announce_bundle_hash(ta_send_mam_res_t* res, const try
 
 status_t send_mam_res_set_chid1(ta_send_mam_res_t* res, const tryte_t* chid1) {
   if (!chid1 || !res) {
-    return SC_RES_NULL;
+    return SC_NULL;
   }
 
   memcpy(res->chid1, chid1, NUM_TRYTES_HASH);

--- a/accelerator/core/response/ta_send_mam.h
+++ b/accelerator/core/response/ta_send_mam.h
@@ -125,7 +125,7 @@ status_t send_mam_res_set_chid1(ta_send_mam_res_t* res, const tryte_t* chid1);
 /**
  * @brief Set the content of the response of a MAM message request
  *
- * @param res[in/out] ta_send_mam_res_t struct object
+ * @param res[in,out] ta_send_mam_res_t struct object
  * @param chid[in] Current Channel ID decoded in trytes string
  * @param msg_id[in] Message ID decoded in trytes string
  * @param bundle[in] Bundle object with MAM message
@@ -139,7 +139,7 @@ status_t send_mam_res_set_msg_result(ta_send_mam_res_t* res, const tryte_t* chid
 /**
  * @brief Set the content of the response of a MAM announcement
  *
- * @param res[in/out] ta_send_mam_res_t struct object
+ * @param res[in,out] ta_send_mam_res_t struct object
  * @param chid1[in] Next Channel ID (chid1) decoded in trytes string
  * @param bundle[in] Bundle object with MAM announcement
  *

--- a/accelerator/core/serializer/ser_helper.h
+++ b/accelerator/core/serializer/ser_helper.h
@@ -157,7 +157,7 @@ status_t ta_bundle_transaction_to_json_array(const bundle_transactions_t* const 
  *
  * @param json_obj[in] Input cJSON object
  * @param obj_name[in] The name of this element in JSON
- * @param text[in/out] Output string value
+ * @param text[in,out] Output string value
  * @param size[in] The length of string
  *
  * @return

--- a/accelerator/core/serializer/serializer.c
+++ b/accelerator/core/serializer/serializer.c
@@ -592,7 +592,7 @@ done:
 status_t fetch_txn_with_uuid_res_serialize(const ta_fetch_txn_with_uuid_res_t* const res, char** obj) {
   status_t ret = SC_OK;
   if (res == NULL) {
-    ret = SC_TA_NULL;
+    ret = SC_NULL;
     ta_log_error("%s\n", ta_error_to_string(ret));
     goto done;
   }

--- a/common/ta_errors.c
+++ b/common/ta_errors.c
@@ -4,6 +4,8 @@ const char* ta_error_to_string(status_t err) {
   switch (err) {
     case SC_OK:
       return "No error.";
+
+    // HTTP
     case SC_HTTP_OK:
       return "HTTP response OK.";
     case SC_HTTP_BAD_REQUEST:
@@ -12,16 +14,18 @@ const char* ta_error_to_string(status_t err) {
       return "HTTP request not found.";
     case SC_HTTP_INTERNAL_SERVICE_ERROR:
       return "HTTP response, other errors in TA.";
-    case SC_TA_OOM:
+
+    // Tangle-Accelerator
+    case SC_OOM:
       return "Failed to create TA object.";
-    case SC_TA_NULL:
+    case SC_NULL:
       return "NULL TA objects.";
     case SC_TA_WRONG_REQUEST_OBJ:
       return "Wrong TA request object.";
     case SC_TA_LOGGER_INIT_FAIL:
       return "Failed to init TA logger.";
-    case SC_CCLIENT_OOM:
-      return "Failed to create cclient object.";
+
+    // CClient module
     case SC_CCLIENT_NOT_FOUND:
       return "Empty result from cclient.";
     case SC_CCLIENT_FAILED_RESPONSE:
@@ -38,6 +42,8 @@ const char* ta_error_to_string(status_t err) {
       return "flex_trits converting error.";
     case SC_CCLIENT_JSON_CREATE:
       return "JSON create object error.";
+
+    // Serializer
     case SC_SERIALIZER_JSON_CREATE:
       return "Failed to create JSON object in serializer.";
     case SC_SERIALIZER_NULL:
@@ -50,14 +56,18 @@ const char* ta_error_to_string(status_t err) {
       return "Invalid request value in JSON.";
     case SC_SERIALIZER_MESSAGE_OVERRUN:
       return "Message length is out of valid size.";
-    case SC_CACHE_NULL:
-      return "NULL object in cache.";
+
+    // Cache
     case SC_CACHE_FAILED_RESPONSE:
       return "Failed in cache operations.";
     case SC_CACHE_OFF:
       return "Cache server is not turned on.";
-    case SC_MAM_NULL:
-      return "NULL object in MAM.";
+    case SC_CACHE_INIT_FINI:
+      return "Failed to initialize or destroy lock in cache";
+    case SC_CACHE_LOCK_FAILURE:
+      return "Failed to lock or unlock cache operation";
+
+    // MAM
     case SC_MAM_NOT_FOUND:
       return "Empty result from MAM.";
     case SC_MAM_FAILED_INIT:
@@ -69,7 +79,7 @@ const char* ta_error_to_string(status_t err) {
     case SC_MAM_NO_PAYLOAD:
       return "No payload or no chid in MAM.";
     case SC_MAM_FAILED_WRITE:
-      return "Failed to write in MAM.";
+      return "Failed to write MAM packet.";
     case SC_MAM_FILE_SAVE:
       return "Failed to save MAM file.";
     case SC_MAM_ALL_MSS_KEYS_USED:
@@ -77,11 +87,15 @@ const char* ta_error_to_string(status_t err) {
     case SC_MAM_FAILED_CREATE_OR_GET_ID:
       return "Failed to created/get chid or epid or msg_id.";
     case SC_MAM_FAILED_WRITE_HEADER:
-      return "Failed to write header in MAM.";
-    case SC_RES_NULL:
-      return "NULL object in response.";
-    case SC_CONF_NULL:
-      return "NULL object in configuration.";
+      return "Failed to write header or packet in MAM.";
+    case SC_MAM_READ_MESSAGE_ERROR:
+      return "Met error when reading MAM message from bundle";
+    case SC_MAM_INVAID_CHID_OR_EPID:
+      return "Failed to add trusted channel ID or endpoint ID";
+    case SC_MAM_EXCEEDED_CHID_ITER:
+      return "Too much iteration for finding a starting chid";
+
+    // Configuration
     case SC_CONF_MISSING_ARGUMENT:
       return "No argument in CLI.";
     case SC_CONF_UNKNOWN_OPTION:
@@ -94,16 +108,36 @@ const char* ta_error_to_string(status_t err) {
       return "Failed to initialize yaml parser.";
     case SC_CONF_FOPEN_ERROR:
       return "Failed to open file.";
-    case SC_UTILS_WRONG_REQUEST_OBJ:
-      return "Wrong TA request object.";
+
+    // Utilities
+    case SC_UTILS_WRONG_INPUT_ARG:
+      return "Wrong utilities input object";
     case SC_UTILS_TIMER_ERROR:
-      return "Errors occurred in timer function.";
+      return "Errors occurred in timer function";
     case SC_UTILS_TIMER_EXPIRED:
-      return "Timer expired.";
-    case SC_HTTP_OOM:
-      return "Failed to create http object.";
-    case SC_HTTP_NULL:
-      return "NULL object in http.";
+      return "Timer expired";
+    case SC_UTILS_HTTPS_SEND_ERROR:
+      return "Failed to send message";
+    case SC_UTILS_HTTPS_INIT_ERROR:
+      return "HTTPS module initialize error";
+    case SC_UTILS_HTTPS_X509_ERROR:
+      return "HTTPS X509 certificate parse error";
+    case SC_UTILS_HTTPS_CONN_ERROR:
+      return "HTTPS initial connection error";
+    case SC_UTILS_HTTPS_SSL_ERROR:
+      return "HTTPS setting SSL config error";
+    case SC_UTILS_HTTPS_RESPONSE_ERROR:
+      return "HTTPS response error";
+    case SC_UTILS_TEXT_SERIALIZE:
+      return "Error occurred when serializing message";
+    case SC_UTILS_TEXT_DESERIALIZE:
+      return "Error occurred when deserializing message";
+    case SC_UTILS_OVERFLOW_ERROR:
+      return "Overflow error";
+    case SC_UTILS_CIPHER_ERROR:
+      return "Error occurred when encrypting or descrypting message";
+
+    // Connection HTTP
     case SC_HTTP_INVALID_REGEX:
       return "Invalid URL regular expression rule in http.";
     case SC_HTTP_URL_NOT_MATCH:
@@ -112,36 +146,49 @@ const char* ta_error_to_string(status_t err) {
       return "URL parameter parsing error.";
     case SC_HTTP_COMMAND_NOT_MATCH:
       return "Proxy API command hash does not match.";
-    case SC_MQTT_OOM:
-      return "Failed to create MQTT object.";
-    case SC_MQTT_NULL:
-      return "NULL object in MQTT.";
+
+    // Connection MQTT
     case SC_MQTT_INIT:
       return "Error during initialization in MQTT.";
-    case SC_MOSQ_OBJ_INIT_ERROR:
+    case SC_MQTT_MOSQ_OBJ_INIT_ERROR:
       return "Error initializing mosquitto object.";
     case SC_MQTT_TOPIC_SET:
       return "Error setting topic in MQTT.";
     case SC_MQTT_OPT_SET:
       return "Error setting options of mosquitto object.";
-    case SC_MQTT_INVALID_TAG:
-      return "Received invalid tag length in MQTT.";
-    case SC_CLIENT_CONNECT:
+    case SC_MQTT_CONNECT:
       return "Error in connecting to broker.";
-    case SC_STORAGE_OOM:
-      return "Failed to create storage object.";
+    case SC_MQTT_INVALID_TAG:
+      return "Received invalid tag length in MQTT";
+
+    // Storage
     case SC_STORAGE_CONNECT_FAIL:
       return "Failed to connect ScyllaDB node.";
     case SC_STORAGE_INVALID_INPUT:
       return "Invalid input parameter in ScyllaDB.";
     case SC_STORAGE_CASSANDRA_QUERY_FAIL:
       return "Failed to execute Cassandra query.";
-    case SC_CORE_OOM:
-      return "Failed to create core object.";
-    case SC_CORE_NULL:
-      return "NULL object in core.";
+
+    // Core
     case SC_CORE_IRI_UNSYNC:
       return "IRI host is not synchronized.";
+
+      // Endpoint
+    case SC_ENDPOINT_DEVICE_INIT:
+      return "Failed to initialize the device.";
+    case SC_ENDPOINT_DEVICE_FINI:
+      return "Failed to finalize the device";
+    case SC_ENDPOINT_UART:
+      return "UART error occurred in device component";
+    case SC_ENDPOINT_SEC_FAULT:
+      return "Error occurred inside secure storage";
+    case SC_ENDPOINT_SEC_ITEM_NOT_FOUND:
+      return "Item not found inside secure storage";
+    case SC_ENDPOINT_SEC_UNAVAILABLE:
+      return "Secure storage service is unavailable";
+    case SC_ENDPOINT_SEND_TRANSFER:
+      return "Error occurred when the sending transfer message";
+
     default:
       return "Unknown error.";
   }

--- a/common/ta_errors.h
+++ b/common/ta_errors.h
@@ -49,14 +49,13 @@ extern "C" {
 #define SC_MODULE_SERIALIZER (0x03 << SC_MODULE_SHIFT)
 #define SC_MODULE_CACHE (0x04 << SC_MODULE_SHIFT)
 #define SC_MODULE_MAM (0x05 << SC_MODULE_SHIFT)
-#define SC_MODULE_RES (0x06 << SC_MODULE_SHIFT)
-#define SC_MODULE_CONF (0x07 << SC_MODULE_SHIFT)
-#define SC_MODULE_UTILS (0x08 << SC_MODULE_SHIFT)
-#define SC_MODULE_HTTP (0x09 << SC_MODULE_SHIFT)
-#define SC_MODULE_MQTT (0x0A << SC_MODULE_SHIFT)
-#define SC_MODULE_STORAGE (0x0B << SC_MODULE_SHIFT)
-#define SC_MODULE_CORE (0x0C << SC_MODULE_SHIFT)
-#define SC_MODULE_ENDPOINT (0x0D << SC_MODULE_SHIFT)
+#define SC_MODULE_CONF (0x06 << SC_MODULE_SHIFT)
+#define SC_MODULE_UTILS (0x07 << SC_MODULE_SHIFT)
+#define SC_MODULE_HTTP (0x08 << SC_MODULE_SHIFT)
+#define SC_MODULE_MQTT (0x09 << SC_MODULE_SHIFT)
+#define SC_MODULE_STORAGE (0x0A << SC_MODULE_SHIFT)
+#define SC_MODULE_CORE (0x0B << SC_MODULE_SHIFT)
+#define SC_MODULE_ENDPOINT (0x0C << SC_MODULE_SHIFT)
 /** @} */
 
 /** @name serverity code */
@@ -74,9 +73,9 @@ typedef enum {
   SC_HTTP_INTERNAL_SERVICE_ERROR = 500,
   /**< HTTP response, other errors in TA */
 
-  SC_TA_OOM = 0x01 | SC_MODULE_TA | SC_SEVERITY_FATAL,
+  SC_OOM = 0x01 | SC_MODULE_TA | SC_SEVERITY_FATAL,
   /**< Failed to create TA object */
-  SC_TA_NULL = 0x02 | SC_MODULE_TA | SC_SEVERITY_FATAL,
+  SC_NULL = 0x02 | SC_MODULE_TA | SC_SEVERITY_FATAL,
   /**< NULL TA objects */
   SC_TA_WRONG_REQUEST_OBJ = 0x03 | SC_MODULE_TA | SC_SEVERITY_FATAL,
   /**< wrong TA request object */
@@ -84,23 +83,21 @@ typedef enum {
   /**< Failed to init TA logger */
 
   // CClient module
-  SC_CCLIENT_OOM = 0x01 | SC_MODULE_CCLIENT | SC_SEVERITY_FATAL,
-  /**< Failed to create cclient object */
-  SC_CCLIENT_NOT_FOUND = 0x02 | SC_MODULE_CCLIENT | SC_SEVERITY_FATAL,
+  SC_CCLIENT_NOT_FOUND = 0x01 | SC_MODULE_CCLIENT | SC_SEVERITY_FATAL,
   /**< Empty result from cclient */
-  SC_CCLIENT_FAILED_RESPONSE = 0x03 | SC_MODULE_CCLIENT | SC_SEVERITY_FATAL,
+  SC_CCLIENT_FAILED_RESPONSE = 0x02 | SC_MODULE_CCLIENT | SC_SEVERITY_FATAL,
   /**< Error in cclient response */
-  SC_CCLIENT_INVALID_FLEX_TRITS = 0x04 | SC_MODULE_CCLIENT | SC_SEVERITY_MAJOR,
+  SC_CCLIENT_INVALID_FLEX_TRITS = 0x03 | SC_MODULE_CCLIENT | SC_SEVERITY_MAJOR,
   /**< Invalid flex trits */
-  SC_CCLIENT_HASH = 0x05 | SC_MODULE_CCLIENT | SC_SEVERITY_MAJOR,
+  SC_CCLIENT_HASH = 0x04 | SC_MODULE_CCLIENT | SC_SEVERITY_MAJOR,
   /**< hash container operation error */
-  SC_CCLIENT_JSON_KEY = 0x06 | SC_MODULE_CCLIENT | SC_SEVERITY_MAJOR,
+  SC_CCLIENT_JSON_KEY = 0x05 | SC_MODULE_CCLIENT | SC_SEVERITY_MAJOR,
   /**< JSON key not found */
-  SC_CCLIENT_JSON_PARSE = 0x07 | SC_MODULE_CCLIENT | SC_SEVERITY_MAJOR,
+  SC_CCLIENT_JSON_PARSE = 0x06 | SC_MODULE_CCLIENT | SC_SEVERITY_MAJOR,
   /**< json parsing error, might the wrong format */
-  SC_CCLIENT_FLEX_TRITS = 0x09 | SC_MODULE_CCLIENT | SC_SEVERITY_MAJOR,
+  SC_CCLIENT_FLEX_TRITS = 0x07 | SC_MODULE_CCLIENT | SC_SEVERITY_MAJOR,
   /**< Flex trits converting error */
-  SC_CCLIENT_JSON_CREATE = 0x0A | SC_MODULE_CCLIENT | SC_SEVERITY_MAJOR,
+  SC_CCLIENT_JSON_CREATE = 0x08 | SC_MODULE_CCLIENT | SC_SEVERITY_MAJOR,
   /**< json create object error, might OOM. */
 
   // Serializer module
@@ -118,8 +115,6 @@ typedef enum {
   /**< Message length is out of valid size */
 
   // Cache module
-  SC_CACHE_NULL = 0x01 | SC_MODULE_CACHE | SC_SEVERITY_FATAL,
-  /**< NULL object in cache */
   SC_CACHE_FAILED_RESPONSE = 0x02 | SC_MODULE_CACHE | SC_SEVERITY_FATAL,
   /**< Failed in cache operations */
   SC_CACHE_OFF = 0x03 | SC_MODULE_CACHE | SC_SEVERITY_MINOR,
@@ -130,151 +125,126 @@ typedef enum {
   /**< Failed to lock or unlock cache operations */
 
   // MAM module
-  SC_MAM_NULL = 0x01 | SC_MODULE_MAM | SC_SEVERITY_FATAL,
-  /**< NULL object in mam */
-  SC_MAM_NOT_FOUND = 0x02 | SC_MODULE_MAM | SC_SEVERITY_FATAL,
+  SC_MAM_NOT_FOUND = 0x01 | SC_MODULE_MAM | SC_SEVERITY_FATAL,
   /**< Empty result from mam */
-  SC_MAM_FAILED_INIT = 0x03 | SC_MODULE_MAM | SC_SEVERITY_FATAL,
+  SC_MAM_FAILED_INIT = 0x02 | SC_MODULE_MAM | SC_SEVERITY_FATAL,
   /**< Error in mam initialization */
-  SC_MAM_FAILED_RESPONSE = 0x04 | SC_MODULE_MAM | SC_SEVERITY_FATAL,
+  SC_MAM_FAILED_RESPONSE = 0x03 | SC_MODULE_MAM | SC_SEVERITY_FATAL,
   /**< Error in mam response */
-  SC_MAM_FAILED_DESTROYED = 0x05 | SC_MODULE_MAM | SC_SEVERITY_FATAL,
+  SC_MAM_FAILED_DESTROYED = 0x04 | SC_MODULE_MAM | SC_SEVERITY_FATAL,
   /**< Error in mam destroy */
-  SC_MAM_NO_PAYLOAD = 0x06 | SC_MODULE_MAM | SC_SEVERITY_FATAL,
+  SC_MAM_NO_PAYLOAD = 0x05 | SC_MODULE_MAM | SC_SEVERITY_FATAL,
   /**< No payload in the MAM message with assigning IDs */
-  SC_MAM_FAILED_WRITE = 0x07 | SC_MODULE_MAM | SC_SEVERITY_FATAL,
-  /**< Failed to write in MAM */
-  SC_MAM_FILE_SAVE = 0x08 | SC_MODULE_MAM | SC_SEVERITY_FATAL,
+  SC_MAM_FAILED_WRITE = 0x06 | SC_MODULE_MAM | SC_SEVERITY_FATAL,
+  /**< Failed to write MAM packet */
+  SC_MAM_FILE_SAVE = 0x07 | SC_MODULE_MAM | SC_SEVERITY_FATAL,
   /**< Failed to save MAM file */
-  SC_MAM_ALL_MSS_KEYS_USED = 0x09 | SC_MODULE_MAM | SC_SEVERITY_FATAL,
+  SC_MAM_ALL_MSS_KEYS_USED = 0x08 | SC_MODULE_MAM | SC_SEVERITY_FATAL,
   /**< All MSS private keys of current given parameters are used */
-  SC_MAM_FAILED_CREATE_OR_GET_ID = 0x0A | SC_MODULE_MAM | SC_SEVERITY_FATAL,
+  SC_MAM_FAILED_CREATE_OR_GET_ID = 0x09 | SC_MODULE_MAM | SC_SEVERITY_FATAL,
   /**< Failed to created/get chid or epid or msg_id in MAM */
-  SC_MAM_FAILED_WRITE_HEADER = 0x0B | SC_MODULE_MAM | SC_SEVERITY_FATAL,
+  SC_MAM_FAILED_WRITE_HEADER = 0x0A | SC_MODULE_MAM | SC_SEVERITY_FATAL,
   /**< Failed to write header in MAM */
-  SC_MAM_MESSAGE_NOT_FOUND = 0x0C | SC_MODULE_MAM | SC_SEVERITY_FATAL,
-  /**< Can't find message in the assign bundle */
-  SC_MAM_INVAID_CHID_OR_EPID = 0x0E | SC_MODULE_MAM | SC_SEVERITY_FATAL,
+  SC_MAM_READ_MESSAGE_ERROR = 0x0B | SC_MODULE_MAM | SC_SEVERITY_FATAL,
+  /**< Met error when reading MAM message from bundle */
+  SC_MAM_INVAID_CHID_OR_EPID = 0x0C | SC_MODULE_MAM | SC_SEVERITY_FATAL,
   /**< Failed to add trusted channel ID or endpoint ID */
-  SC_MAM_EXCEEDED_CHID_ITER = 0x0F | SC_MODULE_MAM | SC_SEVERITY_FATAL,
+  SC_MAM_EXCEEDED_CHID_ITER = 0x0D | SC_MODULE_MAM | SC_SEVERITY_FATAL,
   /**< Too much iteration for finding a starting chid */
 
-  // response module
-  SC_RES_NULL = 0x01 | SC_MODULE_RES | SC_SEVERITY_FATAL,
-  /**< NULL object in response */
-
   // configuration module
-  SC_CONF_NULL = 0x01 | SC_MODULE_CONF | SC_SEVERITY_FATAL,
-  /**< NULL object in configuration */
-  SC_CONF_MISSING_ARGUMENT = 0x02 | SC_MODULE_CONF | SC_SEVERITY_FATAL,
+  SC_CONF_MISSING_ARGUMENT = 0x01 | SC_MODULE_CONF | SC_SEVERITY_FATAL,
   /**< No argument in CLI */
-  SC_CONF_UNKNOWN_OPTION = 0x03 | SC_MODULE_CONF | SC_SEVERITY_FATAL,
+  SC_CONF_UNKNOWN_OPTION = 0x02 | SC_MODULE_CONF | SC_SEVERITY_FATAL,
   /**< undefined option in CLI */
-  SC_CONF_LOCK_INIT = 0x04 | SC_MODULE_CONF | SC_SEVERITY_FATAL,
+  SC_CONF_LOCK_INIT = 0x03 | SC_MODULE_CONF | SC_SEVERITY_FATAL,
   /**< Failed to init lock */
-  SC_CONF_LOCK_DESTROY = 0x05 | SC_MODULE_CONF | SC_SEVERITY_FATAL,
+  SC_CONF_LOCK_DESTROY = 0x04 | SC_MODULE_CONF | SC_SEVERITY_FATAL,
   /**< Failed to destroy lock */
-  SC_CONF_PARSER_ERROR = 0x06 | SC_MODULE_CONF | SC_SEVERITY_FATAL,
+  SC_CONF_PARSER_ERROR = 0x05 | SC_MODULE_CONF | SC_SEVERITY_FATAL,
   /**< Failed to initialize yaml parser */
-  SC_CONF_FOPEN_ERROR = 0x07 | SC_MODULE_CONF | SC_SEVERITY_FATAL,
+  SC_CONF_FOPEN_ERROR = 0x06 | SC_MODULE_CONF | SC_SEVERITY_FATAL,
   /**< Failed to open file */
 
   // UTILS module
-  /**< NULL object in utils */
-  SC_UTILS_WRONG_REQUEST_OBJ = 0x01 | SC_MODULE_UTILS | SC_SEVERITY_FATAL,
-  /**< Wrong TA request object */
+  SC_UTILS_WRONG_INPUT_ARG = 0x01 | SC_MODULE_UTILS | SC_SEVERITY_FATAL,
+  /**< Wrong utilities input object */
   SC_UTILS_TIMER_ERROR = 0x02 | SC_MODULE_UTILS | SC_SEVERITY_FATAL,
   /**< Errors occurred in timer function */
   SC_UTILS_TIMER_EXPIRED = 0x03 | SC_MODULE_UTILS | SC_SEVERITY_FATAL,
-  /**< Failed to send message */
-  SC_UTILS_HTTPS_SEND_ERROR = 0x04 | SC_MODULE_UTILS | SC_SEVERITY_FATAL,
-  /**< HTTPS module initialize error */
-  SC_UTILS_HTTPS_INIT_ERROR = 0x05 | SC_MODULE_UTILS | SC_SEVERITY_FATAL,
-  /**< HTTPS X509 certificate parse error */
-  SC_UTILS_HTTPS_X509_ERROR = 0x06 | SC_MODULE_UTILS | SC_SEVERITY_FATAL,
-  /**< HTTPS initial connection error */
-  SC_UTILS_HTTPS_CONN_ERROR = 0x07 | SC_MODULE_UTILS | SC_SEVERITY_FATAL,
-  /**< HTTPS setting SSL config error */
-  SC_UTILS_HTTPS_SSL_ERROR = 0x08 | SC_MODULE_UTILS | SC_SEVERITY_FATAL,
-  /**< HTTPS response error */
-  SC_UTILS_HTTPS_RESPONSE_ERROR = 0x09 | SC_MODULE_UTILS | SC_SEVERITY_FATAL,
-  /**< Error occurred when serializing message */
-  SC_UTILS_TEXT_SERIALIZE = 0x0A | SC_MODULE_UTILS | SC_SEVERITY_FATAL,
-  /**< Error occurred when deserializing message */
-  SC_UTILS_TEXT_DESERIALIZE = 0x0B | SC_MODULE_UTILS | SC_SEVERITY_FATAL,
-  /**< Out of memory error */
-  SC_UTILS_OOM_ERROR = 0x0C | SC_MODULE_UTILS | SC_SEVERITY_FATAL,
-  /**< Overflow error */
-  SC_UTILS_OVERFLOW_ERROR = 0x0D | SC_MODULE_UTILS | SC_SEVERITY_FATAL,
-  /**< Error occurred when encrypting or descrypting message */
-  SC_UTILS_CIPHER_ERROR = 0x0E | SC_MODULE_UTILS | SC_SEVERITY_FATAL,
   /**< Timer expired */
+  SC_UTILS_HTTPS_SEND_ERROR = 0x04 | SC_MODULE_UTILS | SC_SEVERITY_FATAL,
+  /**< Failed to send message */
+  SC_UTILS_HTTPS_INIT_ERROR = 0x05 | SC_MODULE_UTILS | SC_SEVERITY_FATAL,
+  /**< HTTPS module initialize error */
+  SC_UTILS_HTTPS_X509_ERROR = 0x06 | SC_MODULE_UTILS | SC_SEVERITY_FATAL,
+  /**< HTTPS X509 certificate parse error */
+  SC_UTILS_HTTPS_CONN_ERROR = 0x07 | SC_MODULE_UTILS | SC_SEVERITY_FATAL,
+  /**< HTTPS initial connection error */
+  SC_UTILS_HTTPS_SSL_ERROR = 0x08 | SC_MODULE_UTILS | SC_SEVERITY_FATAL,
+  /**< HTTPS setting SSL config error */
+  SC_UTILS_HTTPS_RESPONSE_ERROR = 0x09 | SC_MODULE_UTILS | SC_SEVERITY_FATAL,
+  /**< HTTPS response error */
+  SC_UTILS_TEXT_SERIALIZE = 0x0A | SC_MODULE_UTILS | SC_SEVERITY_FATAL,
+  /**< Error occurred when serializing message */
+  SC_UTILS_TEXT_DESERIALIZE = 0x0B | SC_MODULE_UTILS | SC_SEVERITY_FATAL,
+  /**< Error occurred when deserializing message */
+  SC_UTILS_OVERFLOW_ERROR = 0x0C | SC_MODULE_UTILS | SC_SEVERITY_FATAL,
+  /**< Overflow error */
+  SC_UTILS_CIPHER_ERROR = 0x0D | SC_MODULE_UTILS | SC_SEVERITY_FATAL,
+  /**< Error occurred when encrypting or descrypting message */
 
   // HTTP module
-  SC_HTTP_OOM = 0x01 | SC_MODULE_HTTP | SC_SEVERITY_FATAL,
-  /**< Failed to create http object */
-  SC_HTTP_NULL = 0x02 | SC_MODULE_HTTP | SC_SEVERITY_FATAL,
-  /**< NULL object in http */
-  SC_HTTP_INVALID_REGEX = 0x03 | SC_MODULE_HTTP | SC_SEVERITY_MAJOR,
+  SC_HTTP_INVALID_REGEX = 0x01 | SC_MODULE_HTTP | SC_SEVERITY_MAJOR,
   /**< Invalid URL regular expression rule in http */
-  SC_HTTP_URL_NOT_MATCH = 0x04 | SC_MODULE_HTTP | SC_SEVERITY_MAJOR,
+  SC_HTTP_URL_NOT_MATCH = 0x02 | SC_MODULE_HTTP | SC_SEVERITY_MAJOR,
   /**< URL doesn't match regular expression rule */
-  SC_HTTP_URL_PARSE_ERROR = 0x05 | SC_MODULE_HTTP | SC_SEVERITY_MAJOR,
+  SC_HTTP_URL_PARSE_ERROR = 0x03 | SC_MODULE_HTTP | SC_SEVERITY_MAJOR,
   /**< Proxy API command not match */
-  SC_HTTP_COMMAND_NOT_MATCH = 0x06 | SC_MODULE_HTTP | SC_SEVERITY_MAJOR,
+  SC_HTTP_COMMAND_NOT_MATCH = 0x04 | SC_MODULE_HTTP | SC_SEVERITY_MAJOR,
   /**< URL parameter parsing error */
 
   // MQTT module
-  SC_MQTT_OOM = 0x01 | SC_MODULE_MQTT | SC_SEVERITY_FATAL,
-  /**< Failed to create MQTT object */
-  SC_MQTT_NULL = 0x02 | SC_MODULE_MQTT | SC_SEVERITY_FATAL,
-  /**< NULL object in MQTT */
-  SC_MQTT_INIT = 0x03 | SC_MODULE_MQTT | SC_SEVERITY_MAJOR,
+  SC_MQTT_INIT = 0x01 | SC_MODULE_MQTT | SC_SEVERITY_MAJOR,
   /**< Error during initialization in MQTT */
-  SC_MOSQ_OBJ_INIT_ERROR = 0x04 | SC_MODULE_MQTT | SC_SEVERITY_MAJOR,
+  SC_MQTT_MOSQ_OBJ_INIT_ERROR = 0x02 | SC_MODULE_MQTT | SC_SEVERITY_MAJOR,
   /**< Error in initializing mosquitto object */
-  SC_MQTT_TOPIC_SET = 0x05 | SC_MODULE_MQTT | SC_SEVERITY_MAJOR,
+  SC_MQTT_TOPIC_SET = 0x03 | SC_MODULE_MQTT | SC_SEVERITY_MAJOR,
   /**< Error in setting topic in MQTT */
-  SC_MQTT_OPT_SET = 0x06 | SC_MODULE_MQTT | SC_SEVERITY_MAJOR,
+  SC_MQTT_OPT_SET = 0x04 | SC_MODULE_MQTT | SC_SEVERITY_MAJOR,
   /**< Error in setting options of `struct mosquitto` object */
-  SC_CLIENT_CONNECT = 0x07 | SC_MODULE_MQTT | SC_SEVERITY_MAJOR,
+  SC_MQTT_CONNECT = 0x05 | SC_MODULE_MQTT | SC_SEVERITY_MAJOR,
   /**< Error in connecting to broker */
-  SC_MQTT_INVALID_TAG = 0x08 | SC_MODULE_MQTT | SC_SEVERITY_MAJOR,
+  SC_MQTT_INVALID_TAG = 0x06 | SC_MODULE_MQTT | SC_SEVERITY_MAJOR,
   /**< Received invalid tag length in MQTT */
 
   // STORAGE module
-  SC_STORAGE_OOM = 0x01 | SC_MODULE_STORAGE | SC_SEVERITY_FATAL,
-  /**< Failed to create storage object */
-  SC_STORAGE_CONNECT_FAIL = 0x02 | SC_MODULE_STORAGE | SC_SEVERITY_MAJOR,
+  SC_STORAGE_CONNECT_FAIL = 0x01 | SC_MODULE_STORAGE | SC_SEVERITY_MAJOR,
   /**< Failed to connect ScyllaDB node */
-  SC_STORAGE_INVALID_INPUT = 0x03 | SC_MODULE_STORAGE | SC_SEVERITY_MAJOR,
+  SC_STORAGE_INVALID_INPUT = 0x02 | SC_MODULE_STORAGE | SC_SEVERITY_MAJOR,
   /**< Invalid input parameter, e.g., null pointer */
-  SC_STORAGE_CASSANDRA_QUERY_FAIL = 0x04 | SC_MODULE_STORAGE | SC_SEVERITY_MAJOR,
+  SC_STORAGE_CASSANDRA_QUERY_FAIL = 0x03 | SC_MODULE_STORAGE | SC_SEVERITY_MAJOR,
   /**< Failed to execute Cassandra query */
 
   // Core module
-  SC_CORE_OOM = 0x01 | SC_MODULE_CORE | SC_SEVERITY_FATAL,
-  /**< Failed to create core object */
-  SC_CORE_NULL = 0x02 | SC_MODULE_CORE | SC_SEVERITY_FATAL,
-  /**< NULL object in core */
-  SC_CORE_IRI_UNSYNC = 0x03 | SC_MODULE_CORE | SC_SEVERITY_FATAL,
+  SC_CORE_IRI_UNSYNC = 0x01 | SC_MODULE_CORE | SC_SEVERITY_FATAL,
   /**< IRI host is not synchronized */
 
   // Endpoint module
-  /**< Failed to initialize the device  */
   SC_ENDPOINT_DEVICE_INIT = 0x01 | SC_MODULE_ENDPOINT | SC_SEVERITY_FATAL,
-  /**< Failed to finalize the device */
+  /**< Failed to initialize the device */
   SC_ENDPOINT_DEVICE_FINI = 0x02 | SC_MODULE_ENDPOINT | SC_SEVERITY_FATAL,
-  /**< Uart error occurred in device component */
+  /**< Failed to finalize the device */
   SC_ENDPOINT_UART = 0x03 | SC_MODULE_ENDPOINT | SC_SEVERITY_FATAL,
-  /**< Error occurred inside secure storage */
+  /**< UART error occurred in device component */
   SC_ENDPOINT_SEC_FAULT = 0x04 | SC_MODULE_ENDPOINT | SC_SEVERITY_MINOR,
-  /**< Error occurred when item not found inside secure storage */
+  /**< Error occurred inside secure storage */
   SC_ENDPOINT_SEC_ITEM_NOT_FOUND = 0x05 | SC_MODULE_ENDPOINT | SC_SEVERITY_MINOR,
-  /**< Error occurred when the secure storage service is unavailable */
+  /**< Item not found inside secure storage */
   SC_ENDPOINT_SEC_UNAVAILABLE = 0x06 | SC_MODULE_ENDPOINT | SC_SEVERITY_MINOR,
-  /**< Error occurred when the sending transfer message */
+  /**< Secure storage service is unavailable */
   SC_ENDPOINT_SEND_TRANSFER = 0x07 | SC_MODULE_ENDPOINT | SC_SEVERITY_FATAL,
+  /**< Error occurred when the sending transfer message */
 
 } status_t;
 

--- a/connectivity/common.c
+++ b/connectivity/common.c
@@ -23,8 +23,8 @@ int conn_logger_release() {
 
 status_t api_path_matcher(char const *const path, char *const regex_rule) {
   if (regex_rule == NULL) {
-    ta_log_error("%s\n", ta_error_to_string(SC_HTTP_NULL));
-    return SC_HTTP_NULL;
+    ta_log_error("%s\n", ta_error_to_string(SC_NULL));
+    return SC_NULL;
   }
   regex_t reg;
   regmatch_t pmatch;

--- a/connectivity/common.h
+++ b/connectivity/common.h
@@ -26,7 +26,7 @@ extern "C" {
  * @param[in] regex_rule Regex rule
  *
  * @return
- * - SC_HTTP_NULL if regular expression is NULL
+ * - SC_NULL if regular expression is NULL
  * - SC_HTTP_INVALID_REGEX if failed to compile regular expression
  * - SC_HTTP_URL_NOT_MATCH if regular expression does not match the given path
  * - SC_OK on success

--- a/connectivity/http/http.c
+++ b/connectivity/http/http.c
@@ -35,8 +35,8 @@ int http_logger_release() {
 
 static status_t ta_get_url_parameter(char const *const url, int index, char **param) {
   if (param == NULL) {
-    ta_log_error("%s\n", ta_error_to_string(SC_HTTP_NULL));
-    return SC_HTTP_NULL;
+    ta_log_error("%s\n", ta_error_to_string(SC_NULL));
+    return SC_NULL;
   }
   if (index < 0) {
     ta_log_warning("Index lower than 0, automatically set index to 0 instead.\n");
@@ -64,8 +64,8 @@ static status_t ta_get_url_parameter(char const *const url, int index, char **pa
   int token_len = strlen(tmp);
   *param = (char *)malloc(token_len * sizeof(char));
   if (param == NULL) {
-    ta_log_error("%s\n", ta_error_to_string(SC_HTTP_OOM));
-    return SC_HTTP_OOM;
+    ta_log_error("%s\n", ta_error_to_string(SC_OOM));
+    return SC_OOM;
   }
   strncpy(*param, tmp, token_len);
   return SC_OK;
@@ -321,11 +321,11 @@ static int request_log(void *cls, const struct sockaddr *addr, socklen_t addrlen
 static status_t build_request(ta_http_request_t *req, const char *data, size_t size) {
   if (req == NULL || data == NULL) {
     ta_log_error("Illegal NULL pointer\n");
-    return SC_TA_NULL;
+    return SC_NULL;
   }
   if (size == 0) {
     ta_log_error("Illegal data size : 0\n");
-    return SC_TA_NULL;
+    return SC_NULL;
   }
   if (size + req->request_len >= MAX_REQUEST_LEN) {
     req->answer_string = strdup(STR_HTTP_REQUEST_SIZE_EXCEED);
@@ -336,7 +336,7 @@ static status_t build_request(ta_http_request_t *req, const char *data, size_t s
   if (request == NULL) {
     req->answer_string = strdup(STR_HTTP_INTERNAL_SERVICE_ERROR);
     req->answer_code = MHD_HTTP_INTERNAL_SERVER_ERROR;
-    return SC_TA_OOM;
+    return SC_OOM;
   }
   if (req->request != NULL) {
     memcpy(request, req->request, req->request_len);
@@ -450,8 +450,8 @@ cleanup:
 
 status_t ta_http_init(ta_http_t *const http, ta_core_t *const core) {
   if (http == NULL) {
-    ta_log_error("%s\n", ta_error_to_string(SC_HTTP_NULL));
-    return SC_HTTP_NULL;
+    ta_log_error("%s\n", ta_error_to_string(SC_NULL));
+    return SC_NULL;
   }
 
   http->core = core;
@@ -460,8 +460,8 @@ status_t ta_http_init(ta_http_t *const http, ta_core_t *const core) {
 
 status_t ta_http_start(ta_http_t *const http) {
   if (http == NULL) {
-    ta_log_error("%s\n", ta_error_to_string(SC_HTTP_NULL));
-    return SC_HTTP_NULL;
+    ta_log_error("%s\n", ta_error_to_string(SC_NULL));
+    return SC_NULL;
   }
 
   http->daemon = MHD_start_daemon(MHD_USE_EPOLL_INTERNAL_THREAD | MHD_USE_ERROR_LOG | MHD_USE_DEBUG,
@@ -469,15 +469,15 @@ status_t ta_http_start(ta_http_t *const http) {
                                   MHD_OPTION_THREAD_POOL_SIZE, http->core->ta_conf.http_tpool_size, MHD_OPTION_END);
   if (http->daemon == NULL) {
     ta_log_error("%s\n", strerror(errno));
-    return SC_HTTP_OOM;
+    return SC_OOM;
   }
   return SC_OK;
 }
 
 status_t ta_http_stop(ta_http_t *const http) {
   if (http == NULL) {
-    ta_log_error("%s\n", ta_error_to_string(SC_HTTP_NULL));
-    return SC_HTTP_NULL;
+    ta_log_error("%s\n", ta_error_to_string(SC_NULL));
+    return SC_NULL;
   }
 
   MHD_stop_daemon(http->daemon);

--- a/connectivity/mqtt/duplex_callback.c
+++ b/connectivity/mqtt/duplex_callback.c
@@ -47,8 +47,8 @@ status_t check_valid_tag(char *tag) {
 
 static status_t mqtt_request_handler(mosq_config_t *cfg, char *subscribe_topic, char *req) {
   if (cfg == NULL || subscribe_topic == NULL || req == NULL) {
-    ta_log_error("%s\n", ta_error_to_string(SC_MQTT_NULL));
-    return SC_MQTT_NULL;
+    ta_log_error("%s\n", ta_error_to_string(SC_NULL));
+    return SC_NULL;
   }
 
   status_t ret = SC_OK;
@@ -177,8 +177,8 @@ static void log_callback_duplex_func(struct mosquitto *mosq, void *obj, int leve
 
 status_t duplex_callback_func_set(struct mosquitto *mosq) {
   if (mosq == NULL) {
-    ta_log_error("%s\n", ta_error_to_string(SC_MQTT_NULL));
-    return SC_MQTT_NULL;
+    ta_log_error("%s\n", ta_error_to_string(SC_NULL));
+    return SC_NULL;
   }
 
   mosquitto_log_callback_set(mosq, log_callback_duplex_func);

--- a/connectivity/mqtt/duplex_utils.c
+++ b/connectivity/mqtt/duplex_utils.c
@@ -32,8 +32,8 @@ int mqtt_utils_logger_release() {
 status_t duplex_config_init(struct mosquitto **config_mosq, mosq_config_t *config_cfg) {
   status_t ret = SC_OK;
   if (config_mosq == NULL || config_cfg == NULL) {
-    ta_log_error("%s\n", ta_error_to_string(SC_MQTT_NULL));
-    return SC_MQTT_NULL;
+    ta_log_error("%s\n", ta_error_to_string(SC_NULL));
+    return SC_NULL;
   }
 
   init_mosq_config(config_cfg, client_duplex);
@@ -56,7 +56,7 @@ status_t duplex_config_init(struct mosquitto **config_mosq, mosq_config_t *confi
         ta_log_error("%s\n", "Invalid id");
         break;
     }
-    return SC_MOSQ_OBJ_INIT_ERROR;
+    return SC_MQTT_MOSQ_OBJ_INIT_ERROR;
   }
 
   ret = mosq_opts_set(*config_mosq, config_cfg);
@@ -67,8 +67,8 @@ status_t duplex_config_init(struct mosquitto **config_mosq, mosq_config_t *confi
 status_t gossip_channel_set(mosq_config_t *channel_cfg, char *host, char *sub_topic, char *pub_topic) {
   status_t ret = SC_OK;
   if (channel_cfg == NULL || (host == NULL && sub_topic == NULL && pub_topic == NULL)) {
-    ta_log_error("%s\n", ta_error_to_string(SC_MQTT_NULL));
-    return SC_MQTT_NULL;
+    ta_log_error("%s\n", ta_error_to_string(SC_NULL));
+    return SC_NULL;
   }
 
   if (host) {
@@ -95,8 +95,8 @@ status_t gossip_api_channels_set(mosq_config_t *channel_cfg, char *host, char *r
   status_t ret = SC_OK;
 
   if (channel_cfg == NULL || host == NULL || root_path == NULL) {
-    ta_log_error("%s\n", ta_error_to_string(SC_MQTT_NULL));
-    return SC_MQTT_NULL;
+    ta_log_error("%s\n", ta_error_to_string(SC_NULL));
+    return SC_NULL;
   }
 
   channel_cfg->general_config->host = strdup(host);
@@ -114,7 +114,7 @@ status_t gossip_api_channels_set(mosq_config_t *channel_cfg, char *host, char *r
     sub_topic_len = root_path_len + 1 + api_name_len;
     sub_topic = (char *)malloc(sub_topic_len + 1);
     if (sub_topic == NULL) {
-      ret = SC_MQTT_OOM;
+      ret = SC_OOM;
       ta_log_error("%s\n", ta_error_to_string(ret));
       goto done;
     }
@@ -137,8 +137,8 @@ done:
 
 status_t gossip_message_set(mosq_config_t *cfg, char *message) {
   if (cfg == NULL || message == NULL) {
-    ta_log_error("%s\n", ta_error_to_string(SC_MQTT_NULL));
-    return SC_MQTT_NULL;
+    ta_log_error("%s\n", ta_error_to_string(SC_NULL));
+    return SC_NULL;
   }
 
   cfg->pub_config->message = strdup(message);
@@ -150,8 +150,8 @@ status_t gossip_message_set(mosq_config_t *cfg, char *message) {
 status_t duplex_client_start(struct mosquitto *mosq, mosq_config_t *cfg) {
   status_t ret = MOSQ_ERR_SUCCESS;
   if (mosq == NULL || cfg == NULL) {
-    ta_log_error("%s\n", ta_error_to_string(SC_MQTT_NULL));
-    return SC_MQTT_NULL;
+    ta_log_error("%s\n", ta_error_to_string(SC_NULL));
+    return SC_NULL;
   }
 
   cfg->general_config->client_type = client_sub;

--- a/connectivity/mqtt/mqtt_common.c
+++ b/connectivity/mqtt/mqtt_common.c
@@ -35,8 +35,8 @@ static int mosquitto__parse_socks_url(mosq_config_t *cfg, char *url);
 status_t init_mosq_config(mosq_config_t *cfg, client_type_t client_type) {
   status_t ret = SC_OK;
   if (cfg == NULL) {
-    ta_log_error("%s\n", ta_error_to_string(SC_MQTT_NULL));
-    return SC_MQTT_NULL;
+    ta_log_error("%s\n", ta_error_to_string(SC_NULL));
+    return SC_NULL;
   }
 
   memset(cfg, 0, sizeof(mosq_config_t));
@@ -44,7 +44,7 @@ status_t init_mosq_config(mosq_config_t *cfg, client_type_t client_type) {
   cfg->general_config = (mosq_general_config_t *)malloc(sizeof(mosq_general_config_t));
   cfg->property_config = (mosq_property_config_t *)malloc(sizeof(mosq_property_config_t));
   if (cfg->general_config == NULL || cfg->property_config == NULL) {
-    ret = SC_MQTT_OOM;
+    ret = SC_OOM;
     ta_log_error("%s\n", ta_error_to_string(ret));
     goto oom_err;
   }
@@ -54,7 +54,7 @@ status_t init_mosq_config(mosq_config_t *cfg, client_type_t client_type) {
 #ifdef WITH_TLS
   cfg->tls_config = (mosq_tls_config_t *)malloc(sizeof(mosq_tls_config_t));
   if (cfg->tls_config == NULL) {
-    ret = SC_MQTT_OOM;
+    ret = SC_OOM;
     ta_log_error("%s\n", ta_error_to_string(ret));
     goto oom_err;
   }
@@ -64,7 +64,7 @@ status_t init_mosq_config(mosq_config_t *cfg, client_type_t client_type) {
 #ifdef WITH_SOCKS
   cfg->socks_config = (mosq_socks_config_t *)malloc(sizeof(mosq_socks_config_t));
   if (cfg->socks_config == NULL) {
-    ret = SC_MQTT_OOM;
+    ret = SC_OOM;
     ta_log_error("%s\n", ta_error_to_string(ret));
     goto oom_err;
   }
@@ -74,7 +74,7 @@ status_t init_mosq_config(mosq_config_t *cfg, client_type_t client_type) {
   if ((client_type == client_pub) || (client_type == client_duplex)) {
     cfg->pub_config = (mosq_pub_config_t *)malloc(sizeof(mosq_pub_config_t));
     if (cfg->pub_config == NULL) {
-      ret = SC_MQTT_OOM;
+      ret = SC_OOM;
       ta_log_error("%s\n", ta_error_to_string(ret));
       goto oom_err;
     }
@@ -84,7 +84,7 @@ status_t init_mosq_config(mosq_config_t *cfg, client_type_t client_type) {
   if ((client_type == client_sub) || (client_type == client_duplex)) {
     cfg->sub_config = (mosq_sub_config_t *)malloc(sizeof(mosq_sub_config_t));
     if (cfg->sub_config == NULL) {
-      ret = SC_MQTT_OOM;
+      ret = SC_OOM;
       ta_log_error("%s\n", ta_error_to_string(ret));
       goto oom_err;
     }
@@ -118,8 +118,8 @@ oom_err:
 
 status_t mosq_config_free(mosq_config_t *cfg) {
   if (cfg == NULL) {
-    ta_log_error("%s\n", ta_error_to_string(SC_MQTT_NULL));
-    return SC_MQTT_NULL;
+    ta_log_error("%s\n", ta_error_to_string(SC_NULL));
+    return SC_NULL;
   }
 
   if (cfg->general_config->client_type == client_pub || cfg->general_config->client_type == client_duplex) {
@@ -182,8 +182,8 @@ status_t mosq_config_free(mosq_config_t *cfg) {
 
 status_t cfg_add_topic(mosq_config_t *cfg, client_type_t client_type, char *topic) {
   if (cfg == NULL) {
-    ta_log_error("%s\n", ta_error_to_string(SC_MQTT_NULL));
-    return SC_MQTT_NULL;
+    ta_log_error("%s\n", ta_error_to_string(SC_NULL));
+    return SC_NULL;
   }
 
   if (mosquitto_validate_utf8(topic, strlen(topic))) {
@@ -205,8 +205,8 @@ status_t cfg_add_topic(mosq_config_t *cfg, client_type_t client_type, char *topi
     cfg->sub_config->topic_count++;
     cfg->sub_config->topics = realloc(cfg->sub_config->topics, cfg->sub_config->topic_count * sizeof(char *));
     if (!cfg->sub_config->topics) {
-      ta_log_error("%s\n", ta_error_to_string(SC_MQTT_OOM));
-      return SC_MQTT_OOM;
+      ta_log_error("%s\n", ta_error_to_string(SC_OOM));
+      return SC_OOM;
     }
     cfg->sub_config->topics[cfg->sub_config->topic_count - 1] = strdup(topic);
   }
@@ -215,8 +215,8 @@ status_t cfg_add_topic(mosq_config_t *cfg, client_type_t client_type, char *topi
 
 status_t mosq_opts_set(struct mosquitto *mosq, mosq_config_t *cfg) {
   if (mosq == NULL || cfg == NULL) {
-    ta_log_error("%s\n", ta_error_to_string(SC_MQTT_NULL));
-    return SC_MQTT_NULL;
+    ta_log_error("%s\n", ta_error_to_string(SC_NULL));
+    return SC_NULL;
   }
 #if defined(WITH_TLS) || defined(WITH_SOCKS)
   mosq_retcode_t ret;
@@ -311,8 +311,8 @@ status_t mosq_opts_set(struct mosquitto *mosq, mosq_config_t *cfg) {
 
 status_t generate_client_id(mosq_config_t *cfg) {
   if (cfg == NULL) {
-    ta_log_error("%s\n", ta_error_to_string(SC_MQTT_NULL));
-    return SC_MQTT_NULL;
+    ta_log_error("%s\n", ta_error_to_string(SC_NULL));
+    return SC_NULL;
   }
 
   srand(time(NULL));
@@ -324,9 +324,9 @@ status_t generate_client_id(mosq_config_t *cfg) {
   }
   cfg->general_config->id = (char *)malloc(sizeof(char) * ID_LEN);
   if (!cfg->general_config->id) {
-    ta_log_error("%s\n", ta_error_to_string(SC_MQTT_OOM));
+    ta_log_error("%s\n", ta_error_to_string(SC_OOM));
     mosquitto_lib_cleanup();
-    return SC_MQTT_OOM;
+    return SC_OOM;
   }
 
   strncpy(cfg->general_config->id, id, sizeof(char) * ID_LEN);
@@ -336,8 +336,8 @@ status_t generate_client_id(mosq_config_t *cfg) {
 
 status_t mosq_client_connect(struct mosquitto *mosq, mosq_config_t *cfg) {
   if (mosq == NULL || cfg == NULL) {
-    ta_log_error("%s\n", ta_error_to_string(SC_MQTT_NULL));
-    return SC_MQTT_NULL;
+    ta_log_error("%s\n", ta_error_to_string(SC_NULL));
+    return SC_NULL;
   }
 
   mosq_retcode_t ret;
@@ -383,7 +383,7 @@ status_t mosq_client_connect(struct mosquitto *mosq, mosq_config_t *cfg) {
       }
     }
     mosquitto_lib_cleanup();
-    return SC_CLIENT_CONNECT;
+    return SC_MQTT_CONNECT;
   }
   return SC_OK;
 }

--- a/connectivity/mqtt/pub_utils.c
+++ b/connectivity/mqtt/pub_utils.c
@@ -30,8 +30,8 @@ int mqtt_pub_logger_release() {
 mosq_retcode_t publish_message(struct mosquitto *mosq, mosq_config_t *cfg, int *mid, const char *topic, int payloadlen,
                                void *payload, int qos, bool retain) {
   if (mosq == NULL || cfg == NULL) {
-    ta_log_error("%s\n", ta_error_to_string(SC_MQTT_NULL));
-    return SC_MQTT_NULL;
+    ta_log_error("%s\n", ta_error_to_string(SC_NULL));
+    return SC_NULL;
   }
 
   if (cfg->general_config->protocol_version == MQTT_PROTOCOL_V5 && cfg->pub_config->first_publish == false) {
@@ -105,8 +105,8 @@ void publish_callback_pub_func(struct mosquitto *mosq, void *obj, int mid, int r
 
 status_t publish_loop(struct mosquitto *mosq) {
   if (mosq == NULL) {
-    ta_log_error("%s\n", ta_error_to_string(SC_MQTT_NULL));
-    return SC_MQTT_NULL;
+    ta_log_error("%s\n", ta_error_to_string(SC_NULL));
+    return SC_NULL;
   }
   mosq_retcode_t ret = MOSQ_ERR_SUCCESS;
 
@@ -118,8 +118,8 @@ status_t publish_loop(struct mosquitto *mosq) {
 
 status_t init_check_error(mosq_config_t *cfg, client_type_t client_type) {
   if (cfg == NULL) {
-    ta_log_error("%s\n", ta_error_to_string(SC_MQTT_NULL));
-    return SC_MQTT_NULL;
+    ta_log_error("%s\n", ta_error_to_string(SC_NULL));
+    return SC_NULL;
   }
   status_t ret = SC_OK;
 
@@ -187,8 +187,8 @@ status_t init_check_error(mosq_config_t *cfg, client_type_t client_type) {
   if (!cfg->general_config->host) {
     cfg->general_config->host = strdup("localhost");
     if (!cfg->general_config->host) {
-      ta_log_error("%s\n", ta_error_to_string(SC_MQTT_OOM));
-      return SC_MQTT_OOM;
+      ta_log_error("%s\n", ta_error_to_string(SC_OOM));
+      return SC_OOM;
     }
   }
 

--- a/connectivity/mqtt/sub_utils.c
+++ b/connectivity/mqtt/sub_utils.c
@@ -29,8 +29,8 @@ int mqtt_sub_logger_release() {
 
 static status_t dump_message(mosq_config_t *cfg, const struct mosquitto_message *message) {
   if (cfg == NULL || message == NULL || message->payload == NULL || message->payloadlen == 0) {
-    ta_log_error("%s\n", ta_error_to_string(SC_MQTT_NULL));
-    return SC_MQTT_NULL;
+    ta_log_error("%s\n", ta_error_to_string(SC_NULL));
+    return SC_NULL;
   }
 
   cfg->sub_config->recv_message = strdup(message->payload);

--- a/endpoint/endpoint_core.h
+++ b/endpoint/endpoint_core.h
@@ -38,7 +38,7 @@ void endpoint_destroy(void);
  * @param[in] next_address Next address to be sent inside message
  * @param[in] private_key Private key from device
  * @param[in] device_id Device id from device
- * @param[in/out] iv Initialization vector, must be read/write. The length of iv must be AES_IV_SIZE @see #ta_cipher_ctx
+ * @param[in,out] iv Initialization vector, must be read/write. The length of iv must be AES_IV_SIZE @see #ta_cipher_ctx
  *
  * @return #status_t
  */

--- a/reattacher/reattacher_main.c
+++ b/reattacher/reattacher_main.c
@@ -21,7 +21,7 @@
 static status_t init_iota_client_service(iota_client_service_t* const serv) {
   if (serv == NULL) {
     ta_log_error("Invalid NULL pointer\n");
-    return SC_TA_NULL;
+    return SC_NULL;
   }
   serv->http.path = "/";
   serv->http.content_type = "application/json";
@@ -31,7 +31,7 @@ static status_t init_iota_client_service(iota_client_service_t* const serv) {
   serv->serializer_type = SR_JSON;
   if (iota_client_core_init(serv) != RC_OK) {
     ta_log_error("Failed to connect to IRI.\n");
-    return SC_TA_OOM;
+    return SC_OOM;
   }
   return SC_OK;
 }

--- a/storage/scylladb_client.c
+++ b/storage/scylladb_client.c
@@ -59,11 +59,11 @@ static CassError connect_session(CassSession* session, const CassCluster* cluste
 status_t db_client_service_init(db_client_service_t* service, db_client_usage_t usage) {
   if (service == NULL) {
     ta_log_error("NULL pointer to ScyllaDB client service for connection endpoint(s)\n");
-    return SC_TA_NULL;
+    return SC_NULL;
   }
   if (service->host == NULL) {
     ta_log_error("NULL pointer to ScyllaDB hostname\n");
-    return SC_TA_NULL;
+    return SC_NULL;
   }
 
   /**< This object is thread-safe. It is best practice to create and reuse a single object per application. */
@@ -83,7 +83,7 @@ status_t db_client_service_init(db_client_service_t* service, db_client_usage_t 
 status_t db_client_service_free(db_client_service_t* service) {
   if (service == NULL) {
     ta_log_error("NULL pointer to ScyllaDB client service for connection endpoint(s)\n");
-    return SC_TA_NULL;
+    return SC_NULL;
   }
   if (service->uuid_gen != NULL) {
     cass_uuid_gen_free(service->uuid_gen);

--- a/storage/scylladb_identity.c
+++ b/storage/scylladb_identity.c
@@ -22,7 +22,7 @@ struct db_identity_s {
 status_t db_show_identity_info(db_identity_t* obj) {
   if (obj == NULL) {
     ta_log_error("Invalid NULL pointer : obj\n");
-    return SC_TA_NULL;
+    return SC_NULL;
   }
   char uuid_string[DB_UUID_STRING_LENGTH];
   char hash[DB_NUM_TRYTES_HASH + 1];
@@ -37,8 +37,8 @@ status_t db_show_identity_info(db_identity_t* obj) {
 status_t db_identity_new(db_identity_t** obj) {
   *obj = (db_identity_t*)malloc(sizeof(struct db_identity_s));
   if (NULL == *obj) {
-    ta_log_error("SC_STORAGE_OOM\n");
-    return SC_STORAGE_OOM;
+    ta_log_error("SC_OOM\n");
+    return SC_OOM;
   }
 
   return SC_OK;
@@ -52,11 +52,11 @@ void db_identity_free(db_identity_t** obj) {
 status_t db_set_identity_uuid(db_identity_t* obj, CassUuid* in) {
   if (obj == NULL) {
     ta_log_error("NULL pointer to ScyllaDB identity object\n");
-    return SC_TA_NULL;
+    return SC_NULL;
   }
   if (in == NULL) {
     ta_log_error("NULL pointer to uuid\n");
-    return SC_TA_NULL;
+    return SC_NULL;
   }
   /**< The version number is in the most significant 4 bits of the timestamp */
   int version = (in->time_and_version) >> 60;
@@ -72,11 +72,11 @@ status_t db_set_identity_uuid(db_identity_t* obj, CassUuid* in) {
 status_t db_get_identity_uuid_string(const db_identity_t* obj, char* res_uuid_string) {
   if (obj == NULL) {
     ta_log_error("NULL pointer to ScyllaDB identity object\n");
-    return SC_TA_NULL;
+    return SC_NULL;
   }
   if (res_uuid_string == NULL) {
     ta_log_error("NULL pointer to uuid string\n");
-    return SC_TA_NULL;
+    return SC_NULL;
   }
   cass_uuid_string(obj->uuid, res_uuid_string);
   return SC_OK;
@@ -85,7 +85,7 @@ status_t db_get_identity_uuid_string(const db_identity_t* obj, char* res_uuid_st
 status_t db_set_identity_status(db_identity_t* obj, cass_int8_t status) {
   if (obj == NULL) {
     ta_log_error("NULL pointer to ScyllaDB identity object\n");
-    return SC_TA_NULL;
+    return SC_NULL;
   }
   if (status < 0 || status >= NUM_OF_TXN_STATUS) {
     ta_log_error("invalid status : %d\n", status);
@@ -106,7 +106,7 @@ cass_int8_t db_ret_identity_status(const db_identity_t* obj) {
 status_t db_set_identity_timestamp(db_identity_t* obj, cass_int64_t ts) {
   if (obj == NULL) {
     ta_log_error("NULL pointer to ScyllaDB identity object\n");
-    return SC_TA_NULL;
+    return SC_NULL;
   }
   obj->timestamp = ts;
   return SC_OK;
@@ -123,7 +123,7 @@ cass_int64_t db_ret_identity_timestamp(const db_identity_t* obj) {
 cass_int64_t db_ret_identity_time_elapsed(db_identity_t* obj) {
   if (obj == NULL) {
     ta_log_error("NULL pointer to ScyllaDB identity object\n");
-    return SC_TA_NULL;
+    return SC_NULL;
   }
   return (cass_int64_t)time(NULL) - obj->timestamp;
 }
@@ -131,11 +131,11 @@ cass_int64_t db_ret_identity_time_elapsed(db_identity_t* obj) {
 status_t db_set_identity_hash(db_identity_t* obj, const cass_byte_t* hash, size_t length) {
   if (obj == NULL) {
     ta_log_error("NULL pointer to ScyllaDB identity object\n");
-    return SC_TA_NULL;
+    return SC_NULL;
   }
   if (hash == NULL) {
     ta_log_error("NULL pointer to hash to insert into identity table\n");
-    return SC_TA_NULL;
+    return SC_NULL;
   }
   if (length != DB_NUM_TRYTES_HASH) {
     ta_log_error("%s\n", ta_error_to_string(SC_STORAGE_INVALID_INPUT));
@@ -235,7 +235,7 @@ status_t db_init_identity_keyspace(db_client_service_t* service, bool need_trunc
   char* use_query = NULL;
   if (service == NULL) {
     ta_log_error("NULL pointer to ScyllaDB client service for connection endpoint(s)\n");
-    return SC_TA_NULL;
+    return SC_NULL;
   }
   if ((ret = create_keyspace(service->session, keyspace_name)) != SC_OK) {
     ta_log_error("create %s keyspace fail\n", keyspace_name);
@@ -272,11 +272,11 @@ status_t db_insert_identity_table(db_client_service_t* service, db_identity_t* o
   const char* query = "UPDATE identity Set ts = ?, status = ?, hash =? Where id = ?";
   if (service == NULL) {
     ta_log_error("NULL pointer to ScyllaDB client service for connection endpoint(s)");
-    return SC_TA_NULL;
+    return SC_NULL;
   }
   if (obj == NULL) {
     ta_log_error("NULL pointer to ScyllaDB identity object\n");
-    return SC_TA_NULL;
+    return SC_NULL;
   }
 
   if (prepare_query(service->session, query, &insert_prepared) != CASS_OK) {

--- a/storage/scylladb_identity.h
+++ b/storage/scylladb_identity.h
@@ -62,7 +62,7 @@ static inline void db_identity_array_free(db_identity_array_t** const db_identit
  *
  * @return
  * - SC_OK on success
- * - SC_STORAGE_OOM on error
+ * - SC_OOM on error
  */
 status_t db_identity_new(db_identity_t** obj);
 
@@ -80,7 +80,7 @@ void db_identity_free(db_identity_t** obj);
  * @param[in] in pointer to CassUuid to be set into db_identity_t
  * @return
  * - SC_OK on success
- * - SC_TA_NULL/SC_STORAGE_INVALID_INPUT on error
+ * - SC_NULL/SC_STORAGE_INVALID_INPUT on error
  */
 status_t db_set_identity_uuid(db_identity_t* obj, CassUuid* in);
 
@@ -114,7 +114,7 @@ cass_int64_t db_ret_identity_time_elapsed(db_identity_t* obj);
  * @param[in] status status to be set into db_identity_t
  * @return
  * - SC_OK on success
- * - SC_TA_NULL/SC_STORAGE_INVALID_INPUT on error
+ * - SC_NULL/SC_STORAGE_INVALID_INPUT on error
  */
 status_t db_set_identity_status(db_identity_t* obj, cass_int8_t status);
 
@@ -137,7 +137,7 @@ cass_int8_t db_ret_identity_status(const db_identity_t* obj);
  * @param[in] length size of hash
  * @return
  * - SC_OK on success
- * - SC_TA_NULL/SC_STORAGE_INVALID_INPUT on error
+ * - SC_NULL/SC_STORAGE_INVALID_INPUT on error
  */
 status_t db_set_identity_hash(db_identity_t* obj, const cass_byte_t* hash, size_t length);
 
@@ -200,7 +200,7 @@ status_t db_get_identity_objs_by_status(db_client_service_t* service, cass_int8_
  * @param[in] ts timestamp to be set into db_identity_t
  * @return
  * - SC_OK on success
- * - SC_TA_NULL/SC_STORAGE_INVALID_INPUT on error
+ * - SC_NULL/SC_STORAGE_INVALID_INPUT on error
  */
 status_t db_set_identity_timestamp(db_identity_t* obj, cass_int64_t ts);
 
@@ -261,7 +261,7 @@ status_t db_insert_identity_table(db_client_service_t* service, db_identity_t* o
  * @param[in] obj pointer to db_identity_t
  * @return
  * - SC_OK on success
- * - SC_TA_NULL/SC_STORAGE_INVALID_INPUT on error
+ * - SC_NULL/SC_STORAGE_INVALID_INPUT on error
  */
 status_t db_show_identity_info(db_identity_t* obj);
 

--- a/storage/scylladb_permanode.c
+++ b/storage/scylladb_permanode.c
@@ -76,11 +76,11 @@ static status_t insert_transaction(CassSession* session, const tryte_t* hash, co
 
   if (session == NULL) {
     ta_log_error("NULL pointer to ScyllaDB client session for connection endpoint(s)");
-    return SC_TA_NULL;
+    return SC_NULL;
   }
   if (hash == NULL || trytes == NULL) {
     ta_log_error("NULL trytes pointer\n");
-    return SC_TA_NULL;
+    return SC_NULL;
   }
 
   if (prepare_query(session, query, &prepared) != CASS_OK) {
@@ -137,7 +137,7 @@ static status_t insert_approvee(CassSession* session, const tryte_t* hash, const
 
   if (hash == NULL || approvee == NULL) {
     ta_log_error("NULL pointer to ScyllaDB transaction object\n");
-    return SC_TA_NULL;
+    return SC_NULL;
   }
 
   char* query = "UPDATE transaction SET approvees = approvees + ? WHERE hash = ?";
@@ -200,7 +200,7 @@ static status_t push_collection_into_queue(CassSession* session, CassStatement* 
       const cass_byte_t* buf;
       cass_value_get_bytes(cass_iterator_get_value(items_iterator), &buf, &len);
       if (hash243_queue_push(res_queue, (flex_trit_t*)buf) != RC_OK) {
-        ret = SC_STORAGE_OOM;
+        ret = SC_OOM;
         ta_log_error("%s\n", ta_error_to_string(ret));
         goto end_iterate;
       }
@@ -249,7 +249,7 @@ static status_t get_count(CassSession* session, CassStatement* statement, get_in
     }
     if (get_inclusion_states_res_states_add(res, (count > 0)) != RC_OK) {
       ta_log_error("Fail to push buf into queue\n");
-      ret = SC_STORAGE_OOM;
+      ret = SC_OOM;
       goto end_iterate;
     }
     ret = SC_OK;
@@ -294,7 +294,7 @@ static status_t push_columns_into_queue(CassSession* session, CassStatement* sta
     }
     if (hash243_queue_push(res_queue, (flex_trit_t*)buf) != RC_OK) {
       ta_log_error("Fail to push buf into queue\n");
-      ret = SC_STORAGE_OOM;
+      ret = SC_OOM;
       goto end_iterate;
     }
     ret = SC_OK;
@@ -337,8 +337,8 @@ static status_t get_trytes(CassSession* session, CassStatement* statement, hash8
       goto end_iterate;
     }
     if (hash8019_queue_push(res_queue, (flex_trit_t const* const)buf) != RC_OK) {
-      ta_log_error("%s\n", "SC_STORAGE_OOM");
-      ret = SC_STORAGE_OOM;
+      ta_log_error("%s\n", "SC_OOM");
+      ret = SC_OOM;
     }
     ret = SC_OK;
   }
@@ -485,7 +485,7 @@ status_t db_get_transactions_by_bundle(const db_client_service_t* service, hash2
                                        const flex_trit_t* bundle) {
   if (service == NULL || res == NULL || bundle == NULL) {
     ta_log_error("Invalid NULL pointer\n");
-    return SC_TA_NULL;
+    return SC_NULL;
   }
   return get_hash_from_transaction_table(service->session, res, "bundle", bundle, NUM_TRYTES_BUNDLE);
 }
@@ -494,7 +494,7 @@ status_t db_get_transactions_by_address(const db_client_service_t* service, hash
                                         const flex_trit_t* address) {
   if (service == NULL || res == NULL || address == NULL) {
     ta_log_error("Invalid NULL pointer\n");
-    return SC_TA_NULL;
+    return SC_NULL;
   }
   return get_hash_from_transaction_table(service->session, res, "address", address, NUM_TRYTES_ADDRESS);
 }
@@ -502,7 +502,7 @@ status_t db_get_transactions_by_address(const db_client_service_t* service, hash
 status_t db_get_transactions_by_tag(const db_client_service_t* service, hash243_queue_t* res, const flex_trit_t* tag) {
   if (service == NULL || res == NULL || tag == NULL) {
     ta_log_error("Invalid NULL pointer\n");
-    return SC_TA_NULL;
+    return SC_NULL;
   }
   return get_hash_from_transaction_table(service->session, res, "tag", tag, NUM_TRYTES_OBSOLETE_TAG);
 }
@@ -510,7 +510,7 @@ status_t db_get_transactions_by_tag(const db_client_service_t* service, hash243_
 status_t db_get_approvee(const db_client_service_t* service, hash243_queue_t* res, const flex_trit_t* hash) {
   if (service == NULL || res == NULL || hash == NULL) {
     ta_log_error("Invalid NULL pointer\n");
-    return SC_TA_NULL;
+    return SC_NULL;
   }
   return get_approvee_from_transaction_table(service->session, res, hash);
 }
@@ -518,7 +518,7 @@ status_t db_get_approvee(const db_client_service_t* service, hash243_queue_t* re
 status_t db_get_trytes(const db_client_service_t* service, hash8019_queue_t* res, const flex_trit_t* hash) {
   if (service == NULL || res == NULL || hash == NULL) {
     ta_log_error("Invalid NULL pointer\n");
-    return SC_TA_NULL;
+    return SC_NULL;
   }
   return get_trytes_from_transaction_table(service->session, res, hash);
 }
@@ -562,7 +562,7 @@ status_t db_client_get_trytes(const db_client_service_t* service, get_trytes_req
   hash243_queue_t itr243 = NULL;
   if (!service || !req || !res) {
     ta_log_error("Invalid NULL pointer\n");
-    return SC_TA_NULL;
+    return SC_NULL;
   }
   CDL_FOREACH(req->hashes, itr243) {
     ret = db_get_trytes(service, &res->trytes, itr243->hash);
@@ -580,7 +580,7 @@ status_t db_client_get_inclusion_states(const db_client_service_t* service, get_
 
   if (!service || !req || !res) {
     ta_log_error("Invalid NULL pointer\n");
-    return SC_TA_NULL;
+    return SC_NULL;
   }
   CDL_FOREACH(req->transactions, itr243) {
     ret = get_inclusion_status_from_transaction_table(service->session, res, itr243->hash);
@@ -604,7 +604,7 @@ status_t db_client_get_transaction_objects(const db_client_service_t* service, c
   get_trytes_res_t* out_trytes = get_trytes_res_new();
 
   if (!out_trytes) {
-    ret = SC_TA_OOM;
+    ret = SC_OOM;
     ta_log_error("Create get trytes response failed\n");
     goto done;
   }
@@ -633,7 +633,7 @@ status_t db_permanode_keyspace_init(const db_client_service_t* service, bool nee
 
   if (service == NULL) {
     ta_log_error("NULL pointer to ScyllaDB client service for connection endpoint(s)\n");
-    return SC_TA_NULL;
+    return SC_NULL;
   }
   if ((ret = create_keyspace(service->session, keyspace_name)) != SC_OK) {
     ta_log_error("%s\n", "Create permanent keyspace failed");

--- a/storage/scylladb_utils.c
+++ b/storage/scylladb_utils.c
@@ -87,7 +87,7 @@ CassError execute_statement(CassSession* session, CassStatement* statement) {
 status_t make_query(char** result, const char* head_desc, const char* position, const char* left_desc) {
   if (head_desc == NULL || position == NULL || left_desc == NULL) {
     ta_log_error("NULL pointer to CQL query\n");
-    return SC_TA_NULL;
+    return SC_NULL;
   }
   size_t head_len = strlen(head_desc);
   size_t pos_len = strlen(position);
@@ -95,8 +95,8 @@ status_t make_query(char** result, const char* head_desc, const char* position, 
   size_t result_len = head_len + pos_len + left_len + 1;
   *result = malloc(result_len * sizeof(char));
   if (*result == NULL) {
-    ta_log_error("%s\n", "SC_STORAGE_OOM");
-    return SC_STORAGE_OOM;
+    ta_log_error("%s\n", "SC_OOM");
+    return SC_OOM;
   }
   memcpy(*result, head_desc, head_len);
   memcpy(*result + head_len, position, pos_len);

--- a/tests/api/driver_core.c
+++ b/tests/api/driver_core.c
@@ -20,8 +20,8 @@ status_t prepare_transfer(const iota_config_t* const iconf, const iota_client_se
   transfer_array_t* transfers = transfer_array_new();
   transfer_t transfer[req_txn_num];
   if (transfers == NULL) {
-    ret = SC_CCLIENT_OOM;
-    printf("%s\n", "SC_CCLIENT_OOM");
+    ret = SC_OOM;
+    printf("%s\n", "SC_OOM");
     goto done;
   }
 
@@ -31,8 +31,8 @@ status_t prepare_transfer(const iota_config_t* const iconf, const iota_client_se
     transfer[i].msg_len = req[i]->msg_len;
 
     if (transfer_message_set_trytes(&transfer[i], req[i]->message, transfer[i].msg_len) != RC_OK) {
-      ret = SC_CCLIENT_OOM;
-      printf("%s\n", ta_error_to_string(SC_CCLIENT_OOM));
+      ret = SC_OOM;
+      printf("%s\n", ta_error_to_string(SC_OOM));
       goto done;
     }
     memcpy(transfer[i].address, hash243_queue_peek(req[i]->address), FLEX_TRIT_SIZE_243);

--- a/utils/bundle_array.h
+++ b/utils/bundle_array.h
@@ -85,7 +85,7 @@ static inline size_t bundle_array_size(bundle_array_t const *const bundle_array)
  */
 static inline status_t bundle_array_add(bundle_array_t *const bundle_array, bundle_transactions_t const *const bundle) {
   if (!bundle || !bundle_array) {
-    return SC_TA_NULL;
+    return SC_NULL;
   }
 
   utarray_push_back(bundle_array, bundle);

--- a/utils/cache/backend_redis.c
+++ b/utils/cache/backend_redis.c
@@ -43,8 +43,8 @@ int br_logger_release() {
 static status_t redis_del(redisContext* c, const char* const key) {
   status_t ret = SC_OK;
   if (key == NULL) {
-    ta_log_error("%s\n", ta_error_to_string(SC_CACHE_NULL));
-    return SC_CACHE_NULL;
+    ta_log_error("%s\n", ta_error_to_string(SC_NULL));
+    return SC_NULL;
   }
 
   redisReply* reply = redisCommand(c, "DEL %s", key);
@@ -60,8 +60,8 @@ static status_t redis_del(redisContext* c, const char* const key) {
 static status_t redis_get(redisContext* c, const char* const key, char* res) {
   status_t ret = SC_OK;
   if (key == NULL) {
-    ta_log_error("%s\n", ta_error_to_string(SC_CACHE_NULL));
-    return SC_CACHE_NULL;
+    ta_log_error("%s\n", ta_error_to_string(SC_NULL));
+    return SC_NULL;
   }
 
   redisReply* reply = redisCommand(c, "GET %s", key);
@@ -81,8 +81,8 @@ static status_t redis_set(redisContext* c, const char* const key, const int key_
                           const int value_size, const int timeout) {
   status_t ret = SC_OK;
   if (c == NULL || key == NULL || value == NULL) {
-    ta_log_error("%s\n", ta_error_to_string(SC_CACHE_NULL));
-    return SC_CACHE_NULL;
+    ta_log_error("%s\n", ta_error_to_string(SC_NULL));
+    return SC_NULL;
   }
 
   redisReply* reply = NULL;
@@ -104,8 +104,8 @@ static status_t redis_list_push(redisContext* c, const char* const key, const in
                                 const int value_size) {
   status_t ret = SC_OK;
   if (c == NULL || key == NULL || value == NULL) {
-    ta_log_error("%s\n", ta_error_to_string(SC_CACHE_NULL));
-    return SC_CACHE_NULL;
+    ta_log_error("%s\n", ta_error_to_string(SC_NULL));
+    return SC_NULL;
   }
 
   redisReply* reply = NULL;
@@ -122,8 +122,8 @@ static status_t redis_list_push(redisContext* c, const char* const key, const in
 static status_t redis_list_at(redisContext* c, const char* const key, const int index, const int res_len, char* res) {
   status_t ret = SC_OK;
   if (key == NULL) {
-    ta_log_error("%s\n", ta_error_to_string(SC_CACHE_NULL));
-    return SC_CACHE_NULL;
+    ta_log_error("%s\n", ta_error_to_string(SC_NULL));
+    return SC_NULL;
   }
 
   redisReply* reply = redisCommand(c, "LINDEX %s %d", key, index);
@@ -142,8 +142,8 @@ static status_t redis_list_at(redisContext* c, const char* const key, const int 
 static status_t redis_list_peek(redisContext* c, const char* const key, const int res_len, char* res) {
   status_t ret = SC_OK;
   if (key == NULL) {
-    ta_log_error("%s\n", ta_error_to_string(SC_CACHE_NULL));
-    return SC_CACHE_NULL;
+    ta_log_error("%s\n", ta_error_to_string(SC_NULL));
+    return SC_NULL;
   }
 
   redisReply* reply = redisCommand(c, "LINDEX %s %d", key, 0);
@@ -162,8 +162,8 @@ static status_t redis_list_peek(redisContext* c, const char* const key, const in
 static status_t redis_list_size(redisContext* c, const char* const key, int* len) {
   status_t ret = SC_OK;
   if (key == NULL) {
-    ta_log_error("%s\n", ta_error_to_string(SC_CACHE_NULL));
-    return SC_CACHE_NULL;
+    ta_log_error("%s\n", ta_error_to_string(SC_NULL));
+    return SC_NULL;
   }
 
   redisReply* reply = redisCommand(c, "LLEN %s", key);
@@ -183,8 +183,8 @@ static status_t redis_list_exist(redisContext* c, const char* const key, const c
                                  bool* exist) {
   status_t ret = SC_OK;
   if (key == NULL || value == NULL) {
-    ta_log_error("%s\n", ta_error_to_string(SC_CACHE_NULL));
-    return SC_CACHE_NULL;
+    ta_log_error("%s\n", ta_error_to_string(SC_NULL));
+    return SC_NULL;
   }
   char res[value_len + 1];
   int len = 0;
@@ -212,8 +212,8 @@ static status_t redis_list_exist(redisContext* c, const char* const key, const c
 static status_t redis_list_pop(redisContext* c, const char* const key, char* res) {
   status_t ret = SC_OK;
   if (key == NULL) {
-    ta_log_error("%s\n", ta_error_to_string(SC_CACHE_NULL));
-    return SC_CACHE_NULL;
+    ta_log_error("%s\n", ta_error_to_string(SC_NULL));
+    return SC_NULL;
   }
 
   redisReply* reply = redisCommand(c, "LPOP %s", key);

--- a/utils/cache/cache.h
+++ b/utils/cache/cache.h
@@ -51,7 +51,7 @@ int br_logger_release();
 /**
  * @brief Initiate cache module. This function can be called in 'config.c' only.
  *
- * @param rwlock[in/out] Read/Write lock object.
+ * @param rwlock[in,out] Read/Write lock object.
  * @param input_state[in] Whether cache server should be activated
  * @param host[in] cache server host
  * @param port[in] cache server port
@@ -64,7 +64,7 @@ bool cache_init(pthread_rwlock_t** rwlock, bool input_state, const char* host, i
 /**
  * @brief Stop interacting with cache module. This function can be called in 'config.c' only.
  *
- * @param rwlock[in/out] Read/Write lock object.
+ * @param rwlock[in,out] Read/Write lock object.
  */
 void cache_stop(pthread_rwlock_t** rwlock);
 

--- a/utils/char_buffer_str.h
+++ b/utils/char_buffer_str.h
@@ -29,12 +29,12 @@ extern "C" {
  */
 static inline status_t str_from_char_buffer(char_buffer_t* char_buff, char** json_result) {
   if (char_buff == NULL) {
-    return SC_TA_NULL;
+    return SC_NULL;
   }
 
   *json_result = strdup(char_buff->data);
   if (*json_result == NULL) {
-    return SC_TA_OOM;
+    return SC_OOM;
   }
 
   return SC_OK;

--- a/utils/connectivity/conn_http.c
+++ b/utils/connectivity/conn_http.c
@@ -229,7 +229,7 @@ status_t set_post_request(char const *const path, char const *const host, const 
       strlen(post_req_format) + strlen(path) + strlen(host) + MAX_PORT_LEN + MAX_CONTENT_LENGTH_LEN + strlen(req_body);
   *out = (char *)malloc(sizeof(char) * out_len);
   if (!*out) {
-    return SC_UTILS_OOM_ERROR;
+    return SC_OOM;
   }
   snprintf(*out, out_len, post_req_format, path, host, port, (int)strlen(req_body), req_body);
 
@@ -245,7 +245,7 @@ status_t set_get_request(char const *const path, char const *const host, const u
   size_t out_len = strlen(get_req_format) + strlen(path) + strlen(host) + MAX_PORT_LEN;
   *out = (char *)malloc(sizeof(char) * out_len);
   if (!*out) {
-    return SC_UTILS_OOM_ERROR;
+    return SC_OOM;
   }
   snprintf(*out, out_len, get_req_format, path, host, port);
 

--- a/utils/connectivity/conn_http.h
+++ b/utils/connectivity/conn_http.h
@@ -117,7 +117,7 @@ status_t http_close(connect_info_t *const info);
  *
  * @return
  * - #SC_OK on success
- * - #SC_UTILS_OOM_ERROR failed on out of memory error
+ * - #SC_OOM failed on out of memory error
  * - non-zero on error
  * @see #status_t
  */
@@ -134,7 +134,7 @@ status_t set_post_request(char const *const path, char const *const host, const 
  *
  * @return
  * - #SC_OK on success
- * - #SC_UTILS_OOM_ERROR failed on out of memory error
+ * - #SC_OOM failed on out of memory error
  * - non-zero on error
  * @see #status_t
  */

--- a/utils/fill_nines.h
+++ b/utils/fill_nines.h
@@ -41,7 +41,7 @@ extern "C" {
  */
 static inline status_t fill_nines(char* new_str, const char* const old_str, size_t new_str_len) {
   if (!new_str || !old_str || new_str_len != NUM_TRYTES_TAG) {
-    return SC_SERIALIZER_NULL;
+    return SC_NULL;
   }
 
   int old_str_len = strlen(old_str);
@@ -51,7 +51,7 @@ static inline status_t fill_nines(char* new_str, const char* const old_str, size
   if (diff) {
     memset((new_str + old_str_len), '9', diff);
   } else {
-    return SC_UTILS_WRONG_REQUEST_OBJ;
+    return SC_UTILS_WRONG_INPUT_ARG;
   }
   new_str[new_str_len] = '\0';
 

--- a/utils/text_serializer.h
+++ b/utils/text_serializer.h
@@ -41,7 +41,7 @@ status_t serialize_msg(const ta_cipher_ctx *ctx, char *out_msg, size_t *out_msg_
  * @brief Deserialize message from serialize_msg
  *
  * @param[in] msg Pointer to serialize message
- * @param[in/out] ctx The cipher context to be deserialized
+ * @param[in,out] ctx The cipher context to be deserialized
  *
  * @return
  * - SC_OK on success


### PR DESCRIPTION
Add missing status code description in 'ta_error_to_string()'
in 'ta_error.c'. Some typos status code are fixed, too.

Close #635 