### PR TITLE
refactor(WORKSPACE): Migrate IOTA library to iota.c

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,8 +35,6 @@ legato: cert
 	#        The 'build' option is for getting the header file like 'mam/mam/mam_endpoint_t_set.h',
 	#        which can not be downloaded when the 'fetch' option is used.
 	bazel --output_base=$(OUTPUT_BASE_DIR) build //endpoint:libendpoint.so
-	# Add the soft link for handling the preprocessing of header file path inclusion like Bazel does
-	ln -f -s ./lib/high/Keccak/FIPS202 ./$(OUTPUT_BASE_DIR)/external/keccak/keccak
 	# Generate endpoint Legato app
 	(cd endpoint && leaf shell -c "mkapp -v -t wp77xx endpoint.adef")
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -3,7 +3,7 @@ load("//third_party:third_party.bzl", "third_party_deps")
 
 git_repository(
     name = "rules_iota",
-    commit = "e08b0038f376d6c82b80f5283bb0a86648bb58dc",
+    commit = "2d15c55f12cff0db106f45866312f61314c583cd",
     remote = "https://github.com/iotaledger/rules_iota.git",
 )
 
@@ -14,9 +14,21 @@ git_repository(
 )
 
 git_repository(
-    name = "entangled",
-    commit = "fe3929b8ac6e7377eed82b83aad96369b42d0641",
-    remote = "https://github.com/DLTcollab/entangled",
+    name = "iota.c",
+    commit = "fd9d67989dc5161117b39a9a3351afcfb118bcad",
+    remote = "https://github.com/iotaledger/iota.c.git",
+)
+
+git_repository(
+    name = "org_iota_common",
+    commit = "c644b7715662dc7b73191ae964f4ede06ee6c975",
+    remote = "https://github.com/iotaledger/iota_common.git",
+)
+
+git_repository(
+    name = "mam.c",
+    commit = "fca24aa8f98e535c6af9feea3394bdeea555d0d3",
+    remote = "https://github.com/iotaledger/mam.c.git",
 )
 
 git_repository(

--- a/accelerator/BUILD
+++ b/accelerator/BUILD
@@ -21,7 +21,7 @@ cc_binary(
     deps = [
         ":ta_config",
         "//connectivity/http",
-        "@entangled//utils/handles:signal",
+        "@org_iota_common//utils/handles:signal",
     ] + select({
         ":mqtt_enable": [
             "//connectivity/mqtt",
@@ -42,7 +42,8 @@ cc_library(
         ":build_option",
         "//utils/cache",
         "//utils:cpuinfo",
-        "@entangled//cclient/api",
+        "@iota.c//cclient/api:api",
+        "@iota.c//cclient:service",
         "@yaml",
     ] + select({
         ":db_enable": ["//storage"],

--- a/accelerator/config.h
+++ b/accelerator/config.h
@@ -16,6 +16,7 @@
 #include "accelerator/core/pow.h"
 #include "cclient/api/core/core_api.h"
 #include "cclient/api/extended/extended_api.h"
+#include "cclient/service.h"
 #include "utils/cpuinfo.h"
 #ifdef DB_ENABLE
 #include "storage/ta_storage.h"

--- a/accelerator/core/BUILD
+++ b/accelerator/core/BUILD
@@ -24,9 +24,9 @@ cc_library(
         "//accelerator/core/serializer",
         "//utils:char_buffer_str",
         "//utils:hash_algo_djb2",
-        "@entangled//cclient/api",
-        "@entangled//cclient/request:requests",
-        "@entangled//cclient/response:responses",
+        "@iota.c//cclient/api",
+        "@iota.c//cclient/request:requests",
+        "@iota.c//cclient/response:responses",
     ],
 )
 
@@ -48,9 +48,9 @@ cc_library(
         "//utils:char_buffer_str",
         "//utils:timer",
         "@com_github_uthash//:uthash",
-        "@entangled//cclient/api",
-        "@entangled//utils:time",
-        "@entangled//utils/containers/hash:hash243_set",
+        "@iota.c//cclient/api",
+        "@org_iota_common//utils:time",
+        "@org_iota_common//utils/containers/hash:hash243_set",
     ],
 )
 
@@ -65,9 +65,9 @@ cc_library(
         "//accelerator/core/response",
         "//utils:fill_nines",
         "//utils:tryte_byte_conv",
-        "@entangled//common/trinary:flex_trit",
-        "@entangled//mam/api",
-        "@entangled//utils/containers/hash:hash_array",
+        "@mam.c//mam/api",
+        "@org_iota_common//common/trinary:flex_trit",
+        "@org_iota_common//utils/containers/hash:hash_array",
     ],
 )
 
@@ -81,9 +81,9 @@ cc_library(
         "//common:ta_logger",
         "//third_party:dcurl",
         "@com_github_uthash//:uthash",
-        "@entangled//common/helpers:digest",
-        "@entangled//common/model:bundle",
-        "@entangled//common/trinary:flex_trit",
-        "@entangled//utils:time",
+        "@org_iota_common//common/helpers:digest",
+        "@org_iota_common//common/model:bundle",
+        "@org_iota_common//common/trinary:flex_trit",
+        "@org_iota_common//utils:time",
     ],
 )

--- a/accelerator/core/core.c
+++ b/accelerator/core/core.c
@@ -538,7 +538,7 @@ status_t ta_update_iri_connection(ta_config_t* const ta_conf, iota_client_servic
   for (int i = 0; i < MAX_IRI_LIST_ELEMENTS && ta_conf->iota_host_list[i]; i++) {
     // update new IRI host
 
-    service->http.host = ta_conf->iota_host_list[i];
+    strncpy(service->http.host, ta_conf->iota_host_list[i], HOST_MAX_LEN);
     service->http.port = ta_conf->iota_port_list[i];
     ta_log_info("Try to connect to %s:%d\n", service->http.host, service->http.port);
 

--- a/accelerator/core/mam_core.c
+++ b/accelerator/core/mam_core.c
@@ -667,6 +667,7 @@ status_t ta_recv_mam_message(const iota_config_t *const iconf, const iota_client
   mam_api_t mam;
   bundle_array_t *bundle_array = NULL;
   bundle_array_new(&bundle_array);
+  mam_pk_t_set_t init_trusted_ch = NULL;
   recv_mam_data_id_mam_v1_t *data_id = (recv_mam_data_id_mam_v1_t *)req->data_id;
   recv_mam_key_mam_v1_t *key = (recv_mam_key_mam_v1_t *)req->key;
   if (mam_api_init(&mam, (tryte_t *)iconf->seed) != RC_OK) {
@@ -720,7 +721,6 @@ status_t ta_recv_mam_message(const iota_config_t *const iconf, const iota_client
   }
 
   // Copy the trusted_channel_pks, before fetching the information from MAM.
-  mam_pk_t_set_t init_trusted_ch = NULL;
   mam_pk_t_set_entry_t *curr_entry = NULL;
   mam_pk_t_set_entry_t *tmp_entry = NULL;
   HASH_ITER(hh, mam.trusted_channel_pks, curr_entry, tmp_entry) {

--- a/accelerator/core/request/BUILD
+++ b/accelerator/core/request/BUILD
@@ -10,10 +10,10 @@ cc_library(
     visibility = ["//visibility:public"],
     deps = [
         "//common",
-        "@entangled//common:errors",
-        "@entangled//common/model:transaction",
-        "@entangled//common/trinary:tryte",
-        "@entangled//utils/containers/hash:hash243_queue",
-        "@entangled//utils/containers/hash:hash81_queue",
+        "@org_iota_common//common:errors",
+        "@org_iota_common//common/model:transaction",
+        "@org_iota_common//common/trinary:tryte",
+        "@org_iota_common//utils/containers/hash:hash243_queue",
+        "@org_iota_common//utils/containers/hash:hash81_queue",
     ],
 )

--- a/accelerator/core/response/BUILD
+++ b/accelerator/core/response/BUILD
@@ -11,11 +11,11 @@ cc_library(
     deps = [
         "//common",
         "//accelerator:build_option",
-        "@entangled//common:errors",
-        "@entangled//common/model:transaction",
-        "@entangled//mam/mam:message",
-        "@entangled//utils/containers/hash:hash243_queue",
-        "@entangled//utils/containers/hash:hash243_stack",
+        "@org_iota_common//common:errors",
+        "@org_iota_common//common/model:transaction",
+        "@mam.c//mam/mam:message",
+        "@org_iota_common//utils/containers/hash:hash243_queue",
+        "@org_iota_common//utils/containers/hash:hash243_stack",
     ] + select({
         "//accelerator:db_enable": ["//storage"],
         "//conditions:default": [],

--- a/common/BUILD
+++ b/common/BUILD
@@ -6,6 +6,7 @@ cc_library(
         "macros",
         ":debug",
         ":ta_errors",
+        ":ta_logger",
     ],
 )
 
@@ -21,7 +22,7 @@ cc_library(
     defines = ["LOGGER_ENABLE"],
     deps = [
         ":ta_errors",
-        "@entangled//utils:logger_helper",
+        "@org_iota_common//utils:logger_helper",
     ],
 )
 
@@ -29,11 +30,11 @@ cc_library(
     name = "macros",
     hdrs = ["macros.h"],
     deps = [
-        "@entangled//common/model:transaction",
-        "@entangled//common/trinary:tryte",
-        "@entangled//mam/mam:message",
-        "@entangled//utils/containers/hash:hash243_stack",
-        "@entangled//utils/containers/hash:hash_array",
+        "@mam.c//mam/mam:message",
+        "@org_iota_common//common/model:transaction",
+        "@org_iota_common//common/trinary:tryte",
+        "@org_iota_common//utils/containers/hash:hash243_stack",
+        "@org_iota_common//utils/containers/hash:hash_array",
     ],
 )
 
@@ -43,7 +44,7 @@ cc_library(
     hdrs = ["debug.h"],
     deps = [
         ":ta_logger",
-        "@entangled//common/model:bundle",
-        "@entangled//common/model:transaction",
+        "@org_iota_common//common/model:bundle",
+        "@org_iota_common//common/model:transaction",
     ],
 )

--- a/connectivity/http/BUILD
+++ b/connectivity/http/BUILD
@@ -7,7 +7,7 @@ cc_library(
         "//accelerator/core:apis",
         "//accelerator/core:proxy_apis",
         "//connectivity:common",
-        "@entangled//utils:macros",
         "@libmicrohttpd",
+        "@org_iota_common//utils:macros",
     ],
 )

--- a/connectivity/mqtt/BUILD
+++ b/connectivity/mqtt/BUILD
@@ -15,7 +15,7 @@ cc_library(
         "//common",
         "//common:ta_errors",
         "//connectivity:common",
-        "@entangled//common/model:transaction",
+        "@org_iota_common//common/model:transaction",
     ],
 )
 

--- a/endpoint/BUILD
+++ b/endpoint/BUILD
@@ -9,7 +9,8 @@ cc_library(
     ],
     visibility = ["//visibility:public"],
     deps = [
-        "//common",
+        "//common:ta_errors",
+        "//common:ta_logger",
         "//utils:cipher",
         "//utils:https",
         "//utils:text_serializer",
@@ -24,7 +25,8 @@ cc_test(
     ],
     deps = [
         ":endpoint_core",
-        "//common",
+        "//common:ta_errors",
+        "//common:ta_logger",
         "//tests:test_define",
     ],
 )
@@ -42,7 +44,8 @@ cc_binary(
     ],
     linkshared = True,
     deps = [
-        "//common",
+        "//common:ta_errors",
+        "//common:ta_logger",
         "//utils:cipher",
         "//utils:https",
         "//utils:text_serializer",

--- a/endpoint/endpointComp/Component.cdef
+++ b/endpoint/endpointComp/Component.cdef
@@ -2,7 +2,7 @@ sources:
 {
     ${CURDIR}/../endpoint_core.c
 
-    ${CURDIR}/../../output_base/external/entangled/utils/logger_helper.c
+    ${CURDIR}/../../output_base/external/org_iota_common/utils/logger_helper.c
 
     ${CURDIR}/../../output_base/external/http_parser/http_parser.c
 
@@ -76,32 +76,12 @@ cflags:
     -I${CURDIR}/../..
 
     // The header files under this directory are downloaded only when the corresponding 'bazel build' command is used
-    -I${CURDIR}/../../output_base/execroot/__main__/bazel-out/k8-fastbuild/bin/external/entangled
+    -I${CURDIR}/../../output_base/execroot/__main__/bazel-out/k8-fastbuild/bin/external/org_iota_common
 
     -I${CURDIR}/../../output_base/external/com_github_uthash/src
     -I${CURDIR}/../../output_base/external/com_github_embear_logger/include
-    -I${CURDIR}/../../output_base/external/entangled
+    -I${CURDIR}/../../output_base/external/org_iota_common
     -I${CURDIR}/../../output_base/external/http_parser
-    -I${CURDIR}/../../output_base/external/keccak
-    -I${CURDIR}/../../output_base/external/keccak/lib/high/Keccak
-    -I${CURDIR}/../../output_base/external/keccak/lib/common
-    -I${CURDIR}/../../output_base/external/keccak/lib/low/KeccakP-1600/OptimizedAVX512a
-    -I${CURDIR}/../../output_base/external/keccak/lib/low/KeccakP-1600/OptimizedAsmX86-64
-    -I${CURDIR}/../../output_base/external/keccak/lib/low/KeccakP-1600/Inplace32BI
-    -I${CURDIR}/../../output_base/external/keccak/lib/low/KeccakP-1600/OptimizedXOP
-    -I${CURDIR}/../../output_base/external/keccak/lib/low/KeccakP-1600/OptimizedAVX512c
-    -I${CURDIR}/../../output_base/external/keccak/lib/low/KeccakP-1600/Optimized32biAsmARM
-    -I${CURDIR}/../../output_base/external/keccak/lib/low/KeccakP-1600/OptimizedAsmAVR8
-    -I${CURDIR}/../../output_base/external/keccak/lib/low/KeccakP-1600/OptimizedAVX2
-    -I${CURDIR}/../../output_base/external/keccak/lib/low/KeccakP-1600/OptimizedAsmARM
-    -I${CURDIR}/../../output_base/external/keccak/lib/low/KeccakP-1600/Compact64
-    -I${CURDIR}/../../output_base/external/keccak/lib/low/KeccakP-1600/Reference
-    -I${CURDIR}/../../output_base/external/keccak/lib/low/KeccakP-1600/Optimized64/CompiledByGCC474forNehalem
-    -I${CURDIR}/../../output_base/external/keccak/lib/low/KeccakP-1600/Optimized64/CompiledByGCC474forHaswell
-    -I${CURDIR}/../../output_base/external/keccak/lib/low/KeccakP-1600/Optimized64
-    -I${CURDIR}/../../output_base/external/keccak/lib/low/KeccakP-1600/Optimized64/CompiledByGCC474forSandyBridge
-    -I${CURDIR}/../../output_base/external/keccak/lib/low/KeccakP-1600/Reference32BI
-    -I${CURDIR}/../../output_base/external/keccak/lib/low/KeccakP-1600/Optimized64AsmARM
     -I${CURDIR}/../../output_base/external/mbedtls_2_16_6/include
 }
 

--- a/endpoint/hal/BUILD
+++ b/endpoint/hal/BUILD
@@ -5,6 +5,6 @@ cc_library(
     srcs = ["device.c"],
     hdrs = ["device.h"],
     deps = [
-        "//common",
+        "//common:ta_errors",
     ],
 )

--- a/endpoint/test_endpoint_core.c
+++ b/endpoint/test_endpoint_core.c
@@ -10,7 +10,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <time.h>
-#include "common/macros.h"
 #include "common/ta_errors.h"
 #include "endpoint_core.h"
 #include "tests/test_define.h"

--- a/reattacher/BUILD
+++ b/reattacher/BUILD
@@ -4,6 +4,6 @@ cc_binary(
     deps = [
         "//accelerator:ta_config",
         "//storage",
-        "@entangled//cclient/api",
+        "@iota.c//cclient/api",
     ],
 )

--- a/storage/BUILD
+++ b/storage/BUILD
@@ -41,10 +41,10 @@ cc_library(
     deps = [
         ":scylladb_client",
         "@com_github_uthash//:uthash",
-        "@entangled//cclient/request:requests",
-        "@entangled//cclient/response:responses",
-        "@entangled//utils/containers/hash:hash243_queue",
-        "@entangled//utils/containers/hash:hash8019_queue",
+        "@iota.c//cclient/request:requests",
+        "@iota.c//cclient/response:responses",
+        "@org_iota_common//utils/containers/hash:hash243_queue",
+        "@org_iota_common//utils/containers/hash:hash8019_queue",
     ],
 )
 
@@ -55,6 +55,6 @@ cc_library(
     linkopts = ["-lcassandra"],
     deps = [
         "//common",
-        "@entangled//common/model:bundle",
+        "@org_iota_common//common/model:bundle",
     ],
 )

--- a/utils/BUILD
+++ b/utils/BUILD
@@ -5,7 +5,7 @@ cc_library(
     srcs = ["fill_nines.h"],
     deps = [
         "//common:ta_errors",
-        "@entangled//common/model:transaction",
+        "@org_iota_common//common/model:transaction",
     ],
 )
 
@@ -15,7 +15,7 @@ cc_library(
     deps = [
         "//common:ta_errors",
         "@com_github_uthash//:uthash",
-        "@entangled//common/model:bundle",
+        "@org_iota_common//common/model:bundle",
     ],
 )
 
@@ -41,7 +41,7 @@ cc_library(
 cc_library(
     name = "char_buffer_str",
     srcs = ["char_buffer_str.h"],
-    deps = ["@entangled//utils:char_buffer"],
+    deps = ["@org_iota_common//utils:char_buffer"],
 )
 
 cc_library(
@@ -71,7 +71,7 @@ cc_library(
     hdrs = ["text_serializer.h"],
     deps = [
         ":cipher",
-        "//common",
+        "//common:ta_errors",
     ],
 )
 

--- a/utils/cache/BUILD
+++ b/utils/cache/BUILD
@@ -7,7 +7,7 @@ cc_library(
     deps = [
         "//common:ta_errors",
         "//common:ta_logger",
-        "@entangled//common/trinary:flex_trit",
         "@hiredis",
+        "@org_iota_common//common/trinary:flex_trit",
     ],
 )

--- a/utils/connectivity/BUILD
+++ b/utils/connectivity/BUILD
@@ -7,7 +7,8 @@ cc_library(
         "conn_http.h",
     ],
     deps = [
-        "//common",
+        "//common:ta_errors",
+        "//common:ta_logger",
         "//pem:cert",
         "@http_parser",
         "@mbedtls_2_16_6",

--- a/utils/text_serializer.c
+++ b/utils/text_serializer.c
@@ -11,12 +11,13 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include "common/macros.h"
 #include "utils/cipher.h"
 
 #define IV_LEN 16
 #define UINT32_LEN 10
 #define UINT64_LEN 20
+#define STR_HELPER(num) #num
+#define STR(num) STR_HELPER(num)
 
 status_t serialize_msg(const ta_cipher_ctx *ctx, char *out_msg, size_t *out_msg_len) {
   /* FIXME: Provide some checks here */


### PR DESCRIPTION
To support some critical fixes in lastest IOTA C language library,
we should migrate the dependent library from 'entangled' to 'iota.c'

close #650