### PR TITLE
fix(core): Limit the maximun response fetch by tag 

### DIFF
--- a/accelerator/config.h
+++ b/accelerator/config.h
@@ -63,6 +63,7 @@ extern "C" {
 #define DONE_LIST_NAME "done_txn_buff_list"
 #define CACHE_MAX_CAPACITY 170 * 1024 * 1024  // default to 170MB
 #define HEALTH_TRACK_PERIOD 1800              // Check every half hour in default
+#define RESULT_SET_LIMIT 100  // The maximun returned transaction object number when querying transaction object by tag
 
 /** @name Redis connection config */
 /** @{ */

--- a/accelerator/core/apis.c
+++ b/accelerator/core/apis.c
@@ -78,6 +78,11 @@ status_t api_find_transaction_objects(const iota_client_service_t* const service
     goto done;
   }
 
+  // Limit the returned transaction objects less equal than 'RESULT_SET_LIMIT'
+  while (hash243_queue_count(req->hashes) > RESULT_SET_LIMIT) {
+    hash243_queue_pop(&req->hashes);
+  }
+
   ret = ta_find_transaction_objects(service, req, res);
   if (ret) {
     ta_log_error("%d\n", ret);

--- a/accelerator/core/core.c
+++ b/accelerator/core/core.c
@@ -239,7 +239,12 @@ status_t ta_find_transactions_obj_by_tag(const iota_client_service_t* const serv
     goto done;
   }
 
-  hash243_queue_copy(&obj_req->hashes, txn_res->hashes, hash243_queue_count(txn_res->hashes));
+  int txn_res_len = hash243_queue_count(txn_res->hashes);
+  for (int i = 0; i < RESULT_SET_LIMIT && i < txn_res_len; i++) {
+    hash243_queue_entry_t* tmp_queue_entry = hash243_queue_pop(&txn_res->hashes);
+    hash243_queue_push(&obj_req->hashes, tmp_queue_entry->hash);
+    free(tmp_queue_entry);
+  }
 
   ret = ta_find_transaction_objects(service, obj_req, res);
   if (ret) {


### PR DESCRIPTION
Querying 'find_transasction_obj_by_tag' with a tag which has huge amount of
relating transactions would cause cclient failed to deserialize the
response.
Now, tangle-accelerator would respond 100 transaction objects in
maximum.

Closes #656
Fixes #652