### PR TITLE
feat(endpoint): Support plain HTTP connection

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ $(DCURL_LIB): $(DCURL_DIR)
 	$(info Modify $^/build/local.mk for your environments.)
 	$(MAKE) -C $^ all
 
-MQTT: $(DCURL_LIB) $(MOSQUITTO_LIB)
+MQTT: $(DCURL_LIB) $(MOSQUITTO_LIB) cert
 $(MOSQUITTO_LIB): $(MOSQUITTO_DIR)
 	git submodule update --init $^
 	@echo

--- a/docs/endpoint.md
+++ b/docs/endpoint.md
@@ -10,3 +10,9 @@ A message sent by endpoint needs to be encrypted locally, which avoids message b
 $ bazel build //endpoint:wp7702
 $ bazel build //endpoint:sim
 ```
+
+## HTTPS Connection Support
+The endpoint uses http connection as default. The message which sent to tangle-accelerator has been encrypted. So the HTTP connection would not be unsafe. To build with https connection support, add `--define https=enable` option.
+```
+$ bazel build --define https=enable //endpoint:wp7702
+```

--- a/tests/unit-test/BUILD
+++ b/tests/unit-test/BUILD
@@ -87,3 +87,14 @@ cc_test(
         "//utils:tryte_byte_conv",
     ],
 )
+
+cc_test(
+    name = "test_http",
+    srcs = [
+        "test_http.c",
+    ],
+    deps = [
+        "//tests:test_define",
+        "//utils/connectivity:conn_http",
+    ],
+)

--- a/tests/unit-test/test_http.c
+++ b/tests/unit-test/test_http.c
@@ -1,0 +1,73 @@
+#include <stdlib.h>
+#include <string.h>
+#include "common/ta_errors.h"
+#include "http_parser.h"
+#include "tests/test_define.h"
+#include "utils/connectivity/conn_http.h"
+
+#define TEST_PORT "8000"
+#define TEST_HOST "localhost"
+#define TEST_GET_REQUEST "GET /address HTTP/1.1\r\nHOST: %s\r\n\r\n"
+#define TEST_API "transaction/"
+
+#define TEST_POST_MESSAGE \
+  "{\
+  \"value\": 0,\
+  \"message\": \"ZBCDKDTCFDTCSCEAQCMDEAHDPCBDVC9DTCRAPCRCRCTC9DTCFDPCHDCDFD\",\
+  \"tag\": \"POWEREDBYTANGLEACCELERATOR9\",\
+  \"address\": \"POWEREDBYTANGLEACCELERATOR9999999999999999999999999999999999999999999999999999999\"\
+}"
+
+#define POST_REQUEST            \
+  "POST /transaction/ HTTP/1.1\r\n\
+Host: " TEST_HOST ":" TEST_PORT \
+  "\r\n\
+Connection: Keep-Alive\r\n\
+Content-Type: application/json\r\n\
+Content-Length: 224\r\n\
+\r\n\
+" TEST_POST_MESSAGE "\r\n\r\n"
+
+#define BUF_SIZE 4096
+
+static char* req = NULL;
+
+void setUp(void) {}
+
+void tearDown(void) { free(req); }
+
+void test_http(void) {
+  connect_info_t info = {.https = false};
+  char post_message[BUF_SIZE] = {0}, response[BUF_SIZE] = {0};
+  http_parser parser;
+  http_parser_settings settings = {};
+  settings.on_body = parser_body_callback;
+
+  snprintf(post_message, BUF_SIZE, "%s", TEST_POST_MESSAGE);
+
+  set_post_request(TEST_API, TEST_HOST, atoi(TEST_PORT), post_message, &req);
+  TEST_ASSERT_EQUAL_INT8_ARRAY(POST_REQUEST, req, sizeof(POST_REQUEST));
+
+  TEST_ASSERT_EQUAL_INT(SC_OK, http_open(&info, "nonce", TEST_HOST, TEST_PORT));
+  TEST_ASSERT_EQUAL_INT(SC_OK, http_send_request(&info, req));
+  TEST_ASSERT_EQUAL_INT(SC_OK, http_read_response(&info, response, sizeof(response) / sizeof(char)));
+  TEST_ASSERT_EQUAL_INT(SC_OK, http_close(&info));
+
+  http_parser_init(&parser, HTTP_RESPONSE);
+  http_parser_execute(&parser, &settings, response, strlen(response));
+
+  TEST_ASSERT_EQUAL_INT(SC_HTTP_OK, parser.status_code);
+}
+
+int main(void) {
+  UNITY_BEGIN();
+  if (ta_logger_init() != SC_OK) {
+    return EXIT_FAILURE;
+  }
+  conn_http_logger_init();
+
+  RUN_TEST(test_http);
+
+  conn_http_logger_release();
+  return UNITY_END();
+}

--- a/utils/BUILD
+++ b/utils/BUILD
@@ -59,10 +59,19 @@ cc_library(
     name = "https",
     srcs = ["https.c"],
     hdrs = ["https.h"],
+    defines = select({
+        ":https_enable": ["ENDPOINT_HTTPS"],
+        "//conditions:default": [],
+    }),
     deps = [
         "//common:ta_errors",
         "//utils/connectivity:conn_http",
     ],
+)
+
+config_setting(
+    name = "https_enable",
+    values = {"define": "https=enable"},
 )
 
 cc_library(

--- a/utils/connectivity/conn_http.c
+++ b/utils/connectivity/conn_http.c
@@ -16,15 +16,30 @@
 #include <string.h>
 #include <sys/socket.h>
 #include <unistd.h>
+#include "common/logger.h"
 #include "pem/ca_crt.inc"
 
 #define MAX_PORT_LEN 5
 #define MAX_CONTENT_LENGTH_LEN 5
 
+#define CONN_HTTP_LOGGER "conn_http"
+
+static logger_id_t logger_id;
+
+void conn_http_logger_init() { logger_id = logger_helper_enable(CONN_HTTP_LOGGER, LOGGER_DEBUG, true); }
+
+int conn_http_logger_release() {
+  logger_helper_release(logger_id);
+  if (logger_helper_destroy() != RC_OK) {
+    ta_log_error("Destroying logger failed %s.\n", CONN_HTTP_LOGGER);
+    return EXIT_FAILURE;
+  }
+
+  return 0;
+}
+
 void mbedtls_debug(void *ctx, int level, const char *file, int line, const char *str) {
-  ((void)level);
-  fprintf((FILE *)ctx, "%s:%04d: %s", file, line, str);
-  fflush((FILE *)ctx);
+  ta_log_debug("%s:%04d: %s", file, line, str);
 }
 
 static status_t free_info_context(connect_info_t *const info) {
@@ -53,15 +68,16 @@ status_t http_open(connect_info_t *const info, char const *const seed_nonce, cha
                    char const *const port) {
   int ret = SC_OK;
 
+  info->net_ctx = (mbedtls_net_context *)malloc(sizeof(mbedtls_net_context));
+  mbedtls_net_init(info->net_ctx);
+
   if (info->https) {
-    info->net_ctx = (mbedtls_net_context *)malloc(sizeof(mbedtls_net_context));
     info->entropy = (mbedtls_entropy_context *)malloc(sizeof(mbedtls_entropy_context));
     info->ctr_drbg = (mbedtls_ctr_drbg_context *)malloc(sizeof(mbedtls_ctr_drbg_context));
     info->ssl_ctx = (mbedtls_ssl_context *)malloc(sizeof(mbedtls_ssl_context));
     info->ssl_config = (mbedtls_ssl_config *)malloc(sizeof(mbedtls_ssl_config));
     info->cacert = (mbedtls_x509_crt *)malloc(sizeof(mbedtls_x509_crt));
 
-    mbedtls_net_init(info->net_ctx);
     mbedtls_ssl_init(info->ssl_ctx);
     mbedtls_ssl_config_init(info->ssl_config);
     mbedtls_x509_crt_init(info->cacert);
@@ -77,7 +93,7 @@ status_t http_open(connect_info_t *const info, char const *const seed_nonce, cha
 
     ret = mbedtls_x509_crt_parse(info->cacert, ca_crt_pem, ca_crt_pem_len);
     if (ret < 0) {
-      printf("error: mbedtls_x509_crt_parse returned -0x%x\n\n", -ret);
+      ta_log_error("mbedtls_x509_crt_parse returned -0x%x\n\n", -ret);
       ret = SC_UTILS_HTTPS_X509_ERROR;
       goto exit;
     }
@@ -85,63 +101,65 @@ status_t http_open(connect_info_t *const info, char const *const seed_nonce, cha
 
   ret = mbedtls_net_connect(info->net_ctx, host, port, MBEDTLS_NET_PROTO_TCP);
   if (ret != 0) {
-    printf("error: mbedtls_net_connect returned %d\n\n", ret);
+    ta_log_error("mbedtls_net_connect returned %d\n\n", ret);
     ret = SC_UTILS_HTTPS_CONN_ERROR;
     goto exit;
   }
 
-  ret = mbedtls_ssl_config_defaults(info->ssl_config, MBEDTLS_SSL_IS_CLIENT, MBEDTLS_SSL_TRANSPORT_STREAM,
-                                    MBEDTLS_SSL_PRESET_DEFAULT);
-  if (ret != 0) {
-    printf("error: mbedtls_ssl_config_defaults returned %d\n\n", ret);
-    ret = SC_UTILS_HTTPS_SSL_ERROR;
-    goto exit;
-  }
-
-  mbedtls_ssl_conf_ca_chain(info->ssl_config, info->cacert, NULL);
-  mbedtls_ssl_conf_authmode(info->ssl_config, MBEDTLS_SSL_VERIFY_REQUIRED);
-
-  mbedtls_ssl_conf_rng(info->ssl_config, mbedtls_ctr_drbg_random, info->ctr_drbg);
-  mbedtls_ssl_conf_dbg(info->ssl_config, mbedtls_debug, stdout);
-
-  ret = mbedtls_ssl_setup(info->ssl_ctx, info->ssl_config);
-  if (ret != 0) {
-    printf("error: mbedtls_ssl_setup returned %d\n\n", ret);
-    ret = SC_UTILS_HTTPS_SSL_ERROR;
-    goto exit;
-  }
-
-  ret = mbedtls_ssl_set_hostname(info->ssl_ctx, host);
-  if (ret != 0) {
-    printf("error: mbedtls_ssl_set_hostname returned %d\n\n", ret);
-    ret = SC_UTILS_HTTPS_SSL_ERROR;
-    goto exit;
-  }
-
-  // Here is Blocking mode
-  mbedtls_ssl_set_bio(info->ssl_ctx, info->net_ctx, mbedtls_net_send, mbedtls_net_recv, mbedtls_net_recv_timeout);
-
-  ret = mbedtls_ssl_handshake(info->ssl_ctx);
-  while (ret != 0) {
-    if (ret != MBEDTLS_ERR_SSL_WANT_READ && ret != MBEDTLS_ERR_SSL_WANT_WRITE) {
-      printf("error: mbedtls_ssl_handshake returned -0x%x\n\n", -ret);
-      mbedtls_ssl_session_reset(info->ssl_ctx);
+  if (info->https) {
+    ret = mbedtls_ssl_config_defaults(info->ssl_config, MBEDTLS_SSL_IS_CLIENT, MBEDTLS_SSL_TRANSPORT_STREAM,
+                                      MBEDTLS_SSL_PRESET_DEFAULT);
+    if (ret != 0) {
+      ta_log_error("mbedtls_ssl_config_defaults returned %d\n\n", ret);
       ret = SC_UTILS_HTTPS_SSL_ERROR;
       goto exit;
     }
-  }
 
-  // Verify the server X.509 certificate
-  uint32_t flags = mbedtls_ssl_get_verify_result(info->ssl_ctx);
-  if (flags != 0) {
-    char vrfy_buf[512];
-    printf("error: Verifying peer X.509 certificate failed\n");
-    mbedtls_x509_crt_verify_info(vrfy_buf, sizeof(vrfy_buf), "", flags);
-    printf("error: %s\n", vrfy_buf);
+    mbedtls_ssl_conf_ca_chain(info->ssl_config, info->cacert, NULL);
+    mbedtls_ssl_conf_authmode(info->ssl_config, MBEDTLS_SSL_VERIFY_REQUIRED);
+
+    mbedtls_ssl_conf_rng(info->ssl_config, mbedtls_ctr_drbg_random, info->ctr_drbg);
+    mbedtls_ssl_conf_dbg(info->ssl_config, mbedtls_debug, stdout);
+
+    ret = mbedtls_ssl_setup(info->ssl_ctx, info->ssl_config);
+    if (ret != 0) {
+      ta_log_error("mbedtls_ssl_setup returned %d\n\n", ret);
+      ret = SC_UTILS_HTTPS_SSL_ERROR;
+      goto exit;
+    }
+
+    ret = mbedtls_ssl_set_hostname(info->ssl_ctx, host);
+    if (ret != 0) {
+      ta_log_error("mbedtls_ssl_set_hostname returned %d\n\n", ret);
+      ret = SC_UTILS_HTTPS_SSL_ERROR;
+      goto exit;
+    }
+
+    // Set up the block I/O for ssl handshake send and receive
+    mbedtls_ssl_set_bio(info->ssl_ctx, info->net_ctx, mbedtls_net_send, mbedtls_net_recv, mbedtls_net_recv_timeout);
+
+    ret = mbedtls_ssl_handshake(info->ssl_ctx);
+    while (ret != 0) {
+      if (ret != MBEDTLS_ERR_SSL_WANT_READ && ret != MBEDTLS_ERR_SSL_WANT_WRITE) {
+        ta_log_error("mbedtls_ssl_handshake returned -0x%x\n\n", -ret);
+        mbedtls_ssl_session_reset(info->ssl_ctx);
+        ret = SC_UTILS_HTTPS_SSL_ERROR;
+        goto exit;
+      }
+    }
+
+    // Verify the server X.509 certificate
+    uint32_t flags = mbedtls_ssl_get_verify_result(info->ssl_ctx);
+    if (flags != 0) {
+      char vrfy_buf[512];
+      ta_log_error("verifying peer X.509 certificate failed\n");
+      mbedtls_x509_crt_verify_info(vrfy_buf, sizeof(vrfy_buf), "", flags);
+      ta_log_error("verifying error message: %s\n", vrfy_buf);
+    }
   }
 
 exit:
-  free_info_context(info);
+  if (ret != SC_OK) free_info_context(info);
   return ret;
 }
 
@@ -153,7 +171,7 @@ status_t http_send_request(connect_info_t *const info, const char *req) {
     if (info->https) {
       ret_len = mbedtls_ssl_write(info->ssl_ctx, (unsigned char *)(req + write_len), (req_len - write_len));
     } else {
-      ret_len = mbedtls_net_send(info->ssl_ctx, (unsigned char *)(req + write_len), (req_len - write_len));
+      ret_len = mbedtls_net_send(info->net_ctx, (unsigned char *)(req + write_len), (req_len - write_len));
     }
 
     if (ret_len == MBEDTLS_ERR_SSL_WANT_WRITE) {
@@ -235,8 +253,6 @@ status_t set_get_request(char const *const path, char const *const host, const u
 }
 
 int parser_body_callback(http_parser *parser, const char *at, size_t length) {
-#ifdef DEBUG
-  printf("HTTP Response: %s\n", at);
-#endif
+  ta_log_debug("HTTP Response: %s\n", at);
   return 0;
 }

--- a/utils/connectivity/conn_http.h
+++ b/utils/connectivity/conn_http.h
@@ -24,7 +24,7 @@ extern "C" {
 #include "mbedtls/ssl.h"
 
 typedef struct {
-  bool https;                         /**< Flag for check info has initialized or not */
+  bool https;                         /**< Flag for check whether SSL connection is enabled or not */
   mbedtls_net_context *net_ctx;       /**< mbedtls_net context                       */
   mbedtls_entropy_context *entropy;   /**< mbedtls_entropy context                    */
   mbedtls_ctr_drbg_context *ctr_drbg; /**< mbedlts_ctr_drbg context                   */
@@ -34,17 +34,31 @@ typedef struct {
 } connect_info_t;
 
 /**
- * @brief Open HTTP connection
- *
- * @param[in, out] info Context for HTTP connection
- * @param[in] seed_nonce Personalization data, that is device-specific identifiers. Can be NULL.
- * @param[in] host HTTP host to connect
- * @param[in] port HTTP port to connect
+ * @brief Initialize logger of conn_http
+ */
+void conn_http_logger_init();
+
+/**
+ * @brief Release logger of conn_http
  *
  * @return
- * - #SC_UTILS_HTTPS_INIT_ERROR failed on HTTP init error
- * - #SC_UTILS_HTTPS_CONN_ERROR failed on HTTP connect error
- * - #SC_UTILS_HTTPS_X509_ERROR failed on HTTP certificate setting error
+ * - zero on success
+ * - EXIT_FAILURE on error
+ */
+int conn_http_logger_release();
+
+/**
+ * @brief Open HTTP(S) connection
+ *
+ * @param[in, out] info Context for HTTP(S) connection
+ * @param[in] seed_nonce Personalization data, that is device-specific identifiers. Can be NULL.
+ * @param[in] host HTTP(S) host to connect
+ * @param[in] port HTTP(S) port to connect
+ *
+ * @return
+ * - #SC_UTILS_HTTPS_INIT_ERROR failed on HTTP(S) init error
+ * - #SC_UTILS_HTTPS_CONN_ERROR failed on HTTP(S) connect error
+ * - #SC_UTILS_HTTPS_X509_ERROR failed on HTTP(S) certificate setting error
  * - #SC_UTILS_HTTPS_SSL_ERROR failed on HTTP ssl setting error
  * - #SC_OK on success
  * @see #status_t
@@ -53,9 +67,9 @@ status_t http_open(connect_info_t *const info, char const *const seed_nonce, cha
                    char const *const port);
 
 /**
- * @brief Send request to HTTP connection
+ * @brief Send request to HTTP(S) connection
  *
- * @param[in] info Context for HTTP connection
+ * @param[in] info Context for HTTP(S) connection
  * @param[in] req Buffer holding the data
  *
  * @return
@@ -66,9 +80,9 @@ status_t http_open(connect_info_t *const info, char const *const seed_nonce, cha
 status_t http_send_request(connect_info_t *const info, const char *req);
 
 /**
- * @brief Read response from HTTP server
+ * @brief Read response from HTTP(S) server
  *
- * @param[in] info Context for HTTP connection
+ * @param[in] info Context for HTTP(S) connection
  * @param[out] res Buffer that will hold the data
  * @param[out] res_len Length of res
  *
@@ -80,9 +94,9 @@ status_t http_send_request(connect_info_t *const info, const char *req);
 status_t http_read_response(connect_info_t *const info, char *res, size_t res_len);
 
 /**
- * @brief Close HTTP connection
+ * @brief Close HTTP(S) connection
  *
- * @param[in] info Context for HTTP connection
+ * @param[in] info Context for HTTP(S) connection
  *
  * @return
  * - #SC_OK on success
@@ -96,8 +110,8 @@ status_t http_close(connect_info_t *const info);
  *
  * @param[in] path API path for POST request to HTTP(S) server, i.e "transaction/". It
  * must be in string.
- * @param[in] host HTTP host to connect
- * @param[in] port HTTP port to connect
+ * @param[in] host HTTP(S) host to connect
+ * @param[in] port HTTP(S) port to connect
  * @param[in] req_body Pointer of POST request body
  * @param[out] out POST request message
  *
@@ -114,8 +128,8 @@ status_t set_post_request(char const *const path, char const *const host, const 
  *
  * @param[in] path API path for GET request to HTTP(S) server, i.e "transaction/". It
  * must be in string.
- * @param[in] host HTTP host to connect
- * @param[in] port HTTP port to connect
+ * @param[in] host HTTP(S) host to connect
+ * @param[in] port HTTP(S) port to connect
  * @param[out] out GET request message
  *
  * @return
@@ -129,8 +143,8 @@ status_t set_get_request(char const *const path, char const *const host, const u
 /**
  * @brief Callback function for http parser
  *
- * @param[in] parser HTTP parser
- * @param[in] at HTTP Message to parse
+ * @param[in] parser HTTP(S) parser
+ * @param[in] at HTTP(S) message to parse
  * @param[in] length Length of text at
  *
  * @return

--- a/utils/https.c
+++ b/utils/https.c
@@ -24,7 +24,12 @@ status_t send_https_msg(char const *host, char const *port, char const *api, con
   http_parser_settings settings;
   settings.on_body = parser_body_callback;
 
+#ifdef ENDPOINT_HTTPS
   connect_info_t info = {.https = true};
+#else
+  connect_info_t info = {.https = false};
+#endif
+
   /* FIXME:Provide some checks here */
   http_open(&info, ssl_seed, host, port);
   http_send_request(&info, req);


### PR DESCRIPTION
The message which sent to tangle-accelerator has been encrypted. So
the HTTP connection would not be unsafe. Support the HTTP connection
would let us setting unit-test for endpoint more easily. The HTTPS
connection still supports. To enable the HTTPS connection, add --define
https=enable when building endpoint. See docs/endpoint.md for more
information.

Close #655