### PR TITLE
feat: Runtime commmand line interface

### DIFF
--- a/accelerator/BUILD
+++ b/accelerator/BUILD
@@ -20,6 +20,7 @@ cc_binary(
     }),
     deps = [
         ":ta_config",
+        ":ta_cli",
         "//connectivity/http",
         "@org_iota_common//utils/handles:signal",
     ] + select({
@@ -31,6 +32,19 @@ cc_binary(
 )
 
 cc_library(
+    name = "ta_cli",
+    srcs = ["runtime_cli.c"],
+    hdrs = ["runtime_cli.h"],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":ta_config",
+        "//common:ta_logger",
+        "//utils/cache",
+        "@org_iota_common//utils:macros",
+    ],
+)
+
+cc_library(
     name = "ta_config",
     srcs = ["config.c"],
     hdrs = ["config.h"],
@@ -39,6 +53,7 @@ cc_library(
         ":cli_info",
         "//accelerator/core:pow",
         "//common",
+        "//utils:timer",
         ":build_option",
         "//utils/cache",
         "//utils:cpuinfo",

--- a/accelerator/cli_info.h
+++ b/accelerator/cli_info.h
@@ -18,13 +18,14 @@ extern "C" {
 
 /**
  * @file accelerator/cli_info.h
- * @brief Message and options for tangled-accelerator configures
+ * @brief Message and options for tangle-accelerator configuration
  */
 
 typedef enum ta_cli_arg_value_e {
   /** tangle-accelerator */
   TA_HOST_CLI = 127,
   TA_PORT_CLI,
+  RUNTIME_CLI,
 
   /** IOTA full node */
   NODE_HOST_CLI,
@@ -97,6 +98,7 @@ static struct ta_cli_argument_s {
     {"done_list", required_argument, NULL, DONE_LIST, "Set the value of `done_list_name`"},
     {"cache_capacity", required_argument, NULL, CACHE_CAPACITY, "Set the maximum capacity of caching server"},
     {"quiet", no_argument, NULL, QUIET, "Disable logger"},
+    {"runtime_cli", no_argument, NULL, RUNTIME_CLI, "Enable runtime command line"},
     {NULL, 0, NULL, 0, NULL}};
 
 static const int cli_cmd_num = ARRAY_SIZE(ta_cli_arguments_g);

--- a/accelerator/config.h
+++ b/accelerator/config.h
@@ -92,9 +92,16 @@ typedef struct ta_config_s {
   char* mqtt_topic_root; /**< The topic root of MQTT topic */
 #endif
   uint8_t http_tpool_size; /**< Thread count of tangle-accelerator instance */
-  bool proxy_passthrough;  /**< Pass proxy api directly without processing */
-  bool gtta;               /**< The option to turn on or off GTTA. The default value is true which enabling GTTA */
+  uint32_t cli_options;    /**< Command line options */
 } ta_config_t;
+
+/** Command line options */
+enum {
+  CLI_PROXY_PASSTHROUGH = 1 << 0, /**< Pass proxy api directly without processing */
+  CLI_GTTA = 1 << 1,        /**< The option to turn on or off GTTA. The default value is true which enabling GTTA */
+  CLI_RUNTIME_CLI = 1 << 2, /**< The option to turn on or off runtime command line functionality. False by default */
+  CLI_QUIET_MODE = 1 << 3,  /**< The option to turn on or off quiet mode. False by default */
+};
 
 /** struct type of iota configuration */
 typedef struct iota_config_s {
@@ -210,6 +217,15 @@ status_t ta_core_set(ta_core_t* const core);
 void ta_core_destroy(ta_core_t* const core);
 
 /**
+ * @brief Switch logger verbose level between quiet level and verbose level
+ *
+ * @param[in] quiet Switch to quiet mode or not
+ * @param[in] init Initialization or not
+ * @param[in] conf Tangle-accelerator configuration variables
+ */
+void ta_logger_switch(bool quiet, bool init, ta_config_t* conf);
+
+/**
  * @brief Initializes iota_client_service
  *
  * @param[in] service IOTA client service
@@ -228,6 +244,18 @@ status_t ta_set_iota_client_service(iota_client_service_t* service, char const* 
  * @brief Notify other process with unix domain socket
  */
 void notification_trigger();
+
+/**
+ * @brief Check whether a command line option is enabled or not
+ *
+ * @param[in] ta_config Tangle-accelerator configuration variables
+ * @param[in] option The option to be checked
+ *
+ * @return
+ * - true if the option is enabled
+ * - false if the option is not enabled
+ */
+bool is_option_enabled(const ta_config_t* const ta_config, uint32_t option);
 
 #ifdef __cplusplus
 }

--- a/accelerator/core/apis.c
+++ b/accelerator/core/apis.c
@@ -19,11 +19,6 @@ void apis_logger_init() { logger_id = logger_helper_enable(APIS_LOGGER, LOGGER_D
 
 int apis_logger_release() {
   logger_helper_release(logger_id);
-  if (logger_helper_destroy() != RC_OK) {
-    ta_log_error("Destroying logger failed %s.\n", APIS_LOGGER);
-    return EXIT_FAILURE;
-  }
-
   return 0;
 }
 

--- a/accelerator/core/apis.h
+++ b/accelerator/core/apis.h
@@ -27,20 +27,6 @@ extern "C" {
  */
 
 /**
- * Initialize logger
- */
-void apis_logger_init();
-
-/**
- * Release logger
- *
- * @return
- * - zero on success
- * - EXIT_FAILURE on error
- */
-int apis_logger_release();
-
-/**
  * @brief Dump tangle accelerator information.
  *
  * @param[in] info Tangle-accelerator configuration variables

--- a/accelerator/core/core.c
+++ b/accelerator/core/core.c
@@ -17,11 +17,6 @@ void cc_logger_init() { logger_id = logger_helper_enable(CC_LOGGER, LOGGER_DEBUG
 
 int cc_logger_release() {
   logger_helper_release(logger_id);
-  if (logger_helper_destroy() != RC_OK) {
-    ta_log_error("Destroying logger failed %s.\n", CC_LOGGER);
-    return EXIT_FAILURE;
-  }
-
   return 0;
 }
 
@@ -76,7 +71,7 @@ status_t ta_send_trytes(const ta_config_t* const info, const iota_config_t* cons
     ta_log_error("%s\n", ta_error_to_string(ret));
     goto done;
   }
-  if (info->gtta) {
+  if (is_option_enabled(info, CLI_GTTA)) {
     get_transactions_to_approve_req_set_depth(tx_approve_req, iconf->milestone_depth);
     if (iota_client_get_transactions_to_approve(service, tx_approve_req, tx_approve_res)) {
       ret = SC_CCLIENT_FAILED_RESPONSE;

--- a/accelerator/core/core.h
+++ b/accelerator/core/core.h
@@ -36,20 +36,6 @@ extern "C" {
  */
 
 /**
- * Initialize logger
- */
-void cc_logger_init();
-
-/**
- * Release logger
- *
- * @return
- * - zero on success
- * - EXIT_FAILURE on error
- */
-int cc_logger_release();
-
-/**
  * @brief Send transfer to tangle.
  *
  * Build the transfer bundle from request and broadcast to the tangle. Input

--- a/accelerator/core/mam_core.c
+++ b/accelerator/core/mam_core.c
@@ -25,11 +25,6 @@ void ta_mam_logger_init() { logger_id = logger_helper_enable(MAM_LOGGER, LOGGER_
 
 int ta_mam_logger_release() {
   logger_helper_release(logger_id);
-  if (logger_helper_destroy() != RC_OK) {
-    ta_log_error("Destroying logger failed %s.\n", MAM_LOGGER);
-    return EXIT_FAILURE;
-  }
-
   return 0;
 }
 

--- a/accelerator/core/pow.c
+++ b/accelerator/core/pow.c
@@ -20,11 +20,6 @@ void pow_logger_init() { logger_id = logger_helper_enable(POW_LOGGER, LOGGER_DEB
 
 int pow_logger_release() {
   logger_helper_release(logger_id);
-  if (logger_helper_destroy() != RC_OK) {
-    ta_log_error("Destroying logger failed %s.\n", POW_LOGGER);
-    return EXIT_FAILURE;
-  }
-
   return 0;
 }
 

--- a/accelerator/core/pow.h
+++ b/accelerator/core/pow.h
@@ -26,20 +26,6 @@ extern "C" {
  */
 
 /**
- * Initialize logger
- */
-void pow_logger_init();
-
-/**
- * Release logger
- *
- * @return
- * - zero on success
- * - EXIT_FAILURE on error
- */
-int pow_logger_release();
-
-/**
  * Initiate pow module
  */
 void pow_init();

--- a/accelerator/core/proxy_apis.c
+++ b/accelerator/core/proxy_apis.c
@@ -18,11 +18,6 @@ void proxy_apis_logger_init() { logger_id = logger_helper_enable(PROXY_APIS_LOGG
 
 int proxy_apis_logger_release() {
   logger_helper_release(logger_id);
-  if (logger_helper_destroy() != RC_OK) {
-    ta_log_error("Destroying logger failed %s.\n", PROXY_APIS_LOGGER);
-    return EXIT_FAILURE;
-  }
-
   return 0;
 }
 
@@ -253,7 +248,7 @@ done:
 status_t proxy_api_wrapper(const ta_config_t* const iconf, const iota_client_service_t* const service,
                            const char* const obj, char** json_result) {
   status_t ret = SC_OK;
-  if (iconf->proxy_passthrough) {
+  if (is_option_enabled(iconf, CLI_PROXY_PASSTHROUGH)) {
     char_buffer_t* res_buff = char_buffer_new();
     char_buffer_t* req_buff = char_buffer_new();
     char_buffer_set(req_buff, obj);

--- a/accelerator/core/serializer/serializer.c
+++ b/accelerator/core/serializer/serializer.c
@@ -21,11 +21,6 @@ void serializer_logger_init() { logger_id = logger_helper_enable(SERI_LOGGER, LO
 
 int serializer_logger_release() {
   logger_helper_release(logger_id);
-  if (logger_helper_destroy() != RC_OK) {
-    ta_log_error("Destroying logger failed %s.\n", SERI_LOGGER);
-    return EXIT_FAILURE;
-  }
-
   return 0;
 }
 
@@ -47,7 +42,7 @@ status_t ta_get_info_serialize(char** obj, ta_config_t* const ta_config, iota_co
   cJSON_AddNumberToObject(json_root, "redis_port", cache->port);
   cJSON_AddNumberToObject(json_root, "milestone_depth", tangle->milestone_depth);
   cJSON_AddNumberToObject(json_root, "mwm", tangle->mwm);
-  cJSON_AddBoolToObject(json_root, "quiet", quiet_mode);
+  cJSON_AddBoolToObject(json_root, "quiet", is_option_enabled(ta_config, CLI_QUIET_MODE));
 
   *obj = cJSON_PrintUnformatted(json_root);
   if (*obj == NULL) {

--- a/accelerator/core/serializer/serializer.h
+++ b/accelerator/core/serializer/serializer.h
@@ -47,20 +47,6 @@ extern "C" {
 /** @} */
 
 /**
- * Initialize logger
- */
-void serializer_logger_init();
-
-/**
- * Release logger
- *
- * @return
- * - zero on success
- * - EXIT_FAILURE on error
- */
-int serializer_logger_release();
-
-/**
  * @brief Serialize tangle accelerator info into JSON
  *
  * @param[out] obj Tangle-accelerator info in JSON

--- a/accelerator/mqtt_main.c
+++ b/accelerator/mqtt_main.c
@@ -41,28 +41,9 @@ int main(int argc, char *argv[]) {
     ta_log_error("Configure failed %s.\n", CONN_MQTT_LOGGER);
     return EXIT_FAILURE;
   }
+  ta_mqtt_init(&ta_core);
 
-  // Disable loggers when quiet mode is on
-  if (quiet_mode) {
-    // Destroy logger when quiet mode is on
-    logger_helper_release(logger_id);
-    if (logger_helper_destroy() != RC_OK) {
-      ta_log_error("Destroying logger failed %s.\n", CONN_MQTT_LOGGER);
-      return EXIT_FAILURE;
-    }
-  } else {
-    mqtt_utils_logger_init();
-    mqtt_common_logger_init();
-    mqtt_callback_logger_init();
-    mqtt_pub_logger_init();
-    mqtt_sub_logger_init();
-    apis_logger_init();
-    cc_logger_init();
-    pow_logger_init();
-    timer_logger_init();
-    // Enable backend_redis logger
-    br_logger_init();
-  }
+  ta_logger_switch(is_option_enabled(&ta_core.ta_conf, CLI_QUIET_MODE), true, &(ta_core.ta_conf));
 
   // Initialize `mosq` and `cfg`
   // if we want to operate this program under multi-threading, see https://github.com/eclipse/mosquitto/issues/450
@@ -103,23 +84,6 @@ done:
   mosquitto_destroy(mosq);
   mosquitto_lib_cleanup();
   mosq_config_free(&cfg);
-
-  if (quiet_mode == false) {
-    mqtt_utils_logger_release();
-    mqtt_common_logger_release();
-    mqtt_callback_logger_release();
-    mqtt_pub_logger_release();
-    mqtt_sub_logger_release();
-    apis_logger_release();
-    cc_logger_release();
-    serializer_logger_release();
-    pow_logger_release();
-    timer_logger_release();
-    br_logger_release();
-    logger_helper_release(logger_id);
-    if (logger_helper_destroy() != RC_OK) {
-      return EXIT_FAILURE;
-    }
-  }
+  ta_logger_switch(true, false, &(ta_core.ta_conf));
   return ret;
 }

--- a/accelerator/runtime_cli.c
+++ b/accelerator/runtime_cli.c
@@ -1,0 +1,241 @@
+/*
+ * Copyright (C) 2020 BiiLabs Co., Ltd. and Contributors
+ * All Rights Reserved.
+ * This is free software; you can redistribute it and/or modify it under the
+ * terms of the MIT license. A copy of the license can be found in the file
+ * "LICENSE" at the root of this distribution.
+ */
+
+#include "runtime_cli.h"
+#include <stdbool.h>
+#include "config.h"
+#include "utils/cache/cache.h"
+#include "utils/macros.h"
+
+static ta_core_t *ta_core;
+
+/* Forward declaration for state definition and functions */
+static ta_cli_list_t start_state, redis_state, redis_memory_state, logger_state;
+static void do_help(char *);
+static void do_logger_switch(char *);
+static void do_logger_status(char *);
+static void do_redis_memory_set(char *);
+static void do_redis_memory_get(char *);
+static void handle_command(char *);
+static ta_cli_list_t *ta_state_ptr; /* Static global state pointer */
+
+/* Thread for runtime command line utility */
+void *cli_routine(void *arg) {
+  ta_core = (ta_core_t *)arg;
+  UNUSED(arg);
+  char command[128];
+  while (true) {
+    printf("Command> ");
+    fgets(command, 128, stdin);
+    command[strlen(command) - 1] = '\0';
+    if (strlen(command) == 0) continue;
+
+    /* Initialize the state then process the command */
+    ta_state_ptr = &start_state;
+    handle_command(command);
+  }
+  return NULL;
+}
+
+/* Start of state definitions */
+static ta_cli_list_t start_state = {
+    .size = 2,
+    {
+        {
+            .name = "logger",
+            .type = CMD_STATE,
+            .next_state = &logger_state,
+            .describe = "Logger related operations",
+            .example = "",
+        },
+        {
+            .name = "redis",
+            .type = CMD_STATE,
+            .next_state = &redis_state,
+            .describe = "Redis related operations",
+            .example = "",
+        },
+    },
+};
+static ta_cli_list_t redis_state = {
+    .size = 1,
+    {
+        {
+            .name = "capacity",
+            .type = CMD_STATE,
+            .next_state = &redis_memory_state,
+            .describe = "Redis memory capacity related operations",
+            .example = "",
+        },
+    },
+};
+static ta_cli_list_t redis_memory_state = {
+    .size = 2,
+    {
+        {
+            .name = "get",
+            .fn = do_redis_memory_get,
+            .type = CMD_LAST,
+            .describe = "Get Redis memory capacity",
+            .example = "redis capacity get",
+        },
+        {
+            .name = "set",
+            .fn = do_redis_memory_set,
+            .type = CMD_LAST,
+            .describe = "Set Redis memory capacity",
+            .example = "redis capacity set [limit]",
+        },
+    },
+};
+static ta_cli_list_t logger_state = {
+    .size = 2,
+    {
+        {
+            .name = "switch",
+            .fn = do_logger_switch,
+            .type = CMD_LAST,
+            .describe = "Switch on/off logger",
+            .example = "logger switch [on/off]",
+        },
+        {
+            .name = "status",
+            .fn = do_logger_status,
+            .type = CMD_LAST,
+            .describe = "Show current logger status",
+            .example = "logger status",
+        },
+    },
+};
+/* End of state definitions */
+
+/**
+ * @brief Extract one subcommand from given string
+ *
+ * The orig parameter is sliced to be the remaining string, e.g.
+ *
+ * orig(input) = extracted + " " + orig(output)
+ *
+ * @param[in,out] orig The original string to be extracted
+ * @param[out] extracted The string extracted from orig.
+ *
+ * @returns
+ * - True if the given string can be separated to two strings
+ * - False if the given string cannot be separated to two strings
+ */
+static bool extract_one(char **orig, char **extracted) {
+  /* strtok_r is MT-safe while strtok is not */
+  *extracted = strtok_r(*orig, " ", orig);
+  if (*extracted == NULL) {
+    return false;
+  }
+  return true;
+}
+
+/**
+ * @brief Handle the command
+ *
+ * This function first extracts one subcommand from the original command, then find one
+ * matching name according to the current state (maintained by `ta_state_ptr`).
+ *
+ * If matched, determine whether the state type is CMD_LAST (to execute function) or
+ * CMD_STATE (to step to next state).
+ *
+ * If not matched, print help message of current state.
+ *
+ */
+static void handle_command(char *str) {
+  char *cmd;
+
+  if (extract_one(&str, &cmd)) {
+    bool matched = false;
+    for (size_t i = 0; i < ta_state_ptr->size; ++i) {
+      ta_cli_cmd list_cmd = ta_state_ptr->list[i];
+      if (!strncmp(list_cmd.name, cmd, 128)) {
+        if (list_cmd.type == CMD_LAST) {
+          list_cmd.fn(str);
+          matched = true;
+          break;
+        } else if (list_cmd.type == CMD_STATE) {
+          ta_state_ptr = list_cmd.next_state;
+          handle_command(str);
+          matched = true;
+          break;
+        }
+      }
+    }
+    if (!matched) do_help("");
+  } else {
+    do_help("");
+  }
+}
+
+/**
+ * @brief Print help messages
+ */
+static void do_help(char *cmd) {
+  UNUSED(cmd);
+  for (size_t i = 0; i < ta_state_ptr->size; ++i) {
+    ta_cli_cmd list_cmd = ta_state_ptr->list[i];
+    printf("%s: %s", list_cmd.name, list_cmd.describe);
+
+    if (list_cmd.type == CMD_LAST) {
+      printf(" (example: %s)", list_cmd.example);
+    }
+    printf("\n\n");
+  }
+}
+
+/**
+ * @brief Print example usage
+ */
+static void do_example(char *name) {
+  for (size_t i = 0; i < ta_state_ptr->size; ++i) {
+    if (!strncmp(ta_state_ptr->list[i].name, name, 128)) {
+      printf("Usage: %s\n", ta_state_ptr->list[i].example);
+    }
+  }
+}
+
+static void do_logger_status(char *cmd) {
+  UNUSED(cmd);
+  printf("%s\n", is_option_enabled(&ta_core->ta_conf, CLI_QUIET_MODE) ? "quiet" : "verbose");
+}
+
+static void do_logger_switch(char *cmd) {
+  char *selection;
+  if (extract_one(&cmd, &selection)) {
+    if (!strncmp(selection, "on", 2)) {
+      ta_logger_switch(false, false, &ta_core->ta_conf);
+      return;
+    } else if (!strncmp(selection, "off", 3)) {
+      ta_logger_switch(true, false, &ta_core->ta_conf);
+      return;
+    }
+  } else {
+    do_example("switch");
+  }
+}
+
+static void do_redis_memory_set(char *cmd) {
+  char *selection;
+  if (extract_one(&cmd, &selection)) {
+    if (cache_set_capacity(selection) != 1) {
+      printf("Cache module not enabled\n");
+    }
+  } else {
+    do_example("set");
+  }
+}
+
+static void do_redis_memory_get(char *cmd) {
+  UNUSED(cmd);
+  if (cache_get_capacity() != 1) {
+    printf("Cache module not enabled\n");
+  }
+}

--- a/accelerator/runtime_cli.h
+++ b/accelerator/runtime_cli.h
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2020 BiiLabs Co., Ltd. and Contributors
+ * All Rights Reserved.
+ * This is free software; you can redistribute it and/or modify it under the
+ * terms of the MIT license. A copy of the license can be found in the file
+ * "LICENSE" at the root of this distribution.
+ */
+
+#ifndef ACCELERATOR_RUNTIME_CLI_H
+#define ACCELERATOR_RUNTIME_CLI_H
+
+#include <stdbool.h>
+#include <stdio.h>
+#include <string.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @file accelerator/runtime_cli.h
+ * @brief Runtime command-line utility
+ */
+
+/**
+ * @brief Runtime command-line utility thread
+ */
+void *cli_routine(void *arg);
+
+/**
+ * @brief Command state types in state machine
+ */
+enum {
+  CMD_LAST,  /**< The last subcommand, could be followed by zero or more parameters */
+  CMD_STATE, /**< Subcommands expected, should step to next state according to `next_state` */
+};
+struct cli_cmd;
+struct cli_list;
+
+/**
+ * @brief Structure that holds the information of a (sub)command.
+ */
+typedef struct cli_cmd {
+  const char *name;     /**< Name of the command */
+  const char *describe; /**< Detailed description of the command */
+  const char *example;  /**< Example usage of the command (should be empty string literal if not needed */
+  const int type;       /**< Command state types */
+  union {
+    struct cli_list *next_state; /**< Determine the next state to step (CMD_STATE) */
+    void (*fn)(char *cmd);       /**< Determine the function to call (CMD_LAST) */
+  };
+} ta_cli_cmd;
+
+/**
+ * @brief Structure that holds the information of a state
+ *
+ * We define the different states using `ta_cli_list_t`,
+ * each state can determine whether to step to next state (CMD_STATE)
+ * or stop (CMD_LAST).
+ */
+typedef struct cli_list {
+  const size_t size;           /**< Number of (sub)commands in the state */
+  const struct cli_cmd list[]; /**< Array of (sub)commands */
+} ta_cli_list_t;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/common/debug.c
+++ b/common/debug.c
@@ -19,11 +19,6 @@ void debug_logger_init() { logger_id = logger_helper_enable(DEBUG_LOGGER, LOGGER
 
 int debug_logger_release() {
   logger_helper_release(logger_id);
-  if (logger_helper_destroy() != RC_OK) {
-    ta_log_error("Destroying logger failed %s.\n", DEBUG_LOGGER);
-    return EXIT_FAILURE;
-  }
-
   return 0;
 }
 

--- a/common/logger.h
+++ b/common/logger.h
@@ -66,7 +66,233 @@ static inline status_t ta_logger_init() {
     fflush(stdout);                                                     \
   } while (0)
 
-bool quiet_mode; /**< flag of quiet mode */
+#ifdef MQTT_ENABLE
+/**
+ * @brief Initialize MQTT utils logger
+ *
+ * This function is implemented in connectivity/mqtt/duplex_utils.c
+ */
+void mqtt_utils_logger_init();
+/**
+ * @brief Release MQTT utils logger
+ *
+ * This function is implemented in connectivity/mqtt/duplex_utils.c
+ *
+ * @return
+ * - zero on success
+ * - EXIT_FAILURE on error
+ */
+int mqtt_utils_logger_release();
+
+/**
+ * @brief Initialize MQTT common logger
+ *
+ * This function is implemented in connectivity/mqtt/mqtt_common.c
+ */
+void mqtt_common_logger_init();
+/**
+ * @brief Release MQTT common logger
+ *
+ * This function is implemented in connectivity/mqtt/mqtt_common.c
+ *
+ * @return
+ * - zero on success
+ * - EXIT_FAILURE on error
+ */
+int mqtt_common_logger_release();
+
+/**
+ * @brief Initialize MQTT callback logger
+ *
+ * This function is implemented in connectivity/mqtt/duplex_callback.c
+ */
+void mqtt_callback_logger_init();
+/**
+ * @brief Release MQTT callback logger
+ *
+ * This function is implemented in connectivity/mqtt/duplex_callback.c
+ *
+ * @return
+ * - zero on success
+ * - EXIT_FAILURE on error
+ */
+int mqtt_callback_logger_release();
+
+/**
+ * @brief Initialize MQTT pub logger
+ *
+ * This function is implemented in connectivity/mqtt/pub_utils.c
+ */
+void mqtt_pub_logger_init();
+/**
+ * @brief Release MQTT pub logger
+ *
+ * This function is implemented in connectivity/mqtt/pub_utils.c
+ *
+ * @return
+ * - zero on success
+ * - EXIT_FAILURE on error
+ */
+int mqtt_pub_logger_release();
+
+/**
+ * @brief Initialize MQTT sub logger
+ *
+ * This function is implemented in connectivity/mqtt/sub_utils.c
+ */
+void mqtt_sub_logger_init();
+/**
+ * @brief Release MQTT sub logger
+ *
+ * This function is implemented in connectivity/mqtt/sub_utils.c
+ *
+ * @return
+ * - zero on success
+ * - EXIT_FAILURE on error
+ */
+int mqtt_sub_logger_release();
+#else
+/**
+ * @brief Initialize http logger
+ *
+ * This function is implemented in connectivity/http/http.c
+ */
+void http_logger_init();
+/**
+ * @brief Release conn logger
+ *
+ * This function is implemented in connectivity/http/http.c
+ *
+ * @return
+ * - zero on success
+ * - EXIT_FAILURE on error
+ */
+int http_logger_release();
+#endif /* MQTT_ENABLE */
+
+/**
+ * @brief Initialize conn logger
+ *
+ * This function is implemented in connectivity/common.c
+ */
+void conn_logger_init();
+/**
+ * @brief Release conn logger
+ *
+ * This function is implemented in connectivity/common.c
+ *
+ * @return
+ * - zero on success
+ * - EXIT_FAILURE on error
+ */
+int conn_logger_release();
+
+/**
+ * @brief Initialize apis logger
+ *
+ * This function is implemented in accelerator/core/apis.c
+ */
+void apis_logger_init();
+
+/**
+ * @brief Release apis logger
+ *
+ * This function is implemented in accelerator/core/apis.c
+ *
+ * @return
+ * - zero on success
+ * - EXIT_FAILURE on error
+ */
+int apis_logger_release();
+
+/**
+ * @brief Initialize core logger
+ *
+ * This function is implemented in accelerator/core/core.c
+ */
+void cc_logger_init();
+
+/**
+ * @brief Release logger
+ *
+ * This function is implemented in accelerator/core/core.c
+ *
+ * @return
+ * - zero on success
+ * - EXIT_FAILURE on error
+ */
+int cc_logger_release();
+
+/**
+ * @brief Initialize serializer logger
+ *
+ * This function is implemented in accelerator/core/serializer/serializer.c
+ */
+void serializer_logger_init();
+
+/**
+ * @brief Release serializer logger
+ *
+ * This function is implemented in accelerator/core/serializer/serializer.c
+ *
+ * @return
+ * - zero on success
+ * - EXIT_FAILURE on error
+ */
+int serializer_logger_release();
+
+/**
+ * @brief Initialize PoW logger
+ *
+ * This function is implemented in accelerator/core/pow.c
+ */
+void pow_logger_init();
+
+/**
+ * @brief Release PoW logger
+ *
+ * This function is implemented in accelerator/core/pow.c
+ *
+ * @return
+ * - zero on success
+ * - EXIT_FAILURE on error
+ */
+int pow_logger_release();
+
+/**
+ * @brief Initialize timer logger
+ *
+ * This function is implemented in utils/timer.c
+ */
+void timer_logger_init();
+/**
+ * @brief Release timer logger
+ *
+ * This function is implemented in utils/timer.c
+ *
+ * @return
+ * - zero on success
+ * - EXIT_FAILURE on error
+ */
+int timer_logger_release();
+
+/**
+ * @brief Initialize backend_redis logger
+ *
+ * This function is implemented in utils/cache/backend_redis.c
+ */
+void br_logger_init();
+
+/**
+ * @brief Release logger
+ *
+ * This function is implemented in utils/cache/backend_redis.c
+ *
+ * @return
+ * - zero on success
+ * - EXIT_FAILURE on error
+ */
+int br_logger_release();
 
 #ifdef __cplusplus
 }

--- a/connectivity/common.c
+++ b/connectivity/common.c
@@ -13,11 +13,7 @@ static logger_id_t logger_id;
 void conn_logger_init() { logger_id = logger_helper_enable(CONN_LOGGER, LOGGER_DEBUG, true); }
 
 int conn_logger_release() {
-  if (logger_helper_destroy() != RC_OK) {
-    ta_log_error("Destroying logger failed %s.\n", CONN_LOGGER);
-    return EXIT_FAILURE;
-  }
-
+  logger_helper_release(logger_id);
   return 0;
 }
 

--- a/connectivity/common.h
+++ b/connectivity/common.h
@@ -42,8 +42,6 @@ status_t api_path_matcher(char const *const path, char *const regex_rule);
  * @return HTTP status code
  */
 status_t set_response_content(status_t ret, char **json_result);
-void conn_logger_init();
-int conn_logger_release();
 
 #ifdef __cplusplus
 }

--- a/connectivity/http/http.c
+++ b/connectivity/http/http.c
@@ -25,11 +25,6 @@ void http_logger_init() { logger_id = logger_helper_enable(HTTP_LOGGER, LOGGER_D
 
 int http_logger_release() {
   logger_helper_release(logger_id);
-  if (logger_helper_destroy() != RC_OK) {
-    ta_log_error("Destroying logger failed %s.\n", HTTP_LOGGER);
-    return EXIT_FAILURE;
-  }
-
   return 0;
 }
 

--- a/connectivity/http/http.h
+++ b/connectivity/http/http.h
@@ -20,20 +20,6 @@ typedef struct ta_http_s {
 } ta_http_t;
 
 /**
- * Initialize logger
- */
-void http_logger_init();
-
-/**
- * Release logger
- *
- * @return
- * - zero on success
- * - EXIT_FAILURE on error
- */
-int http_logger_release();
-
-/**
  * Initializes an HTTP API
  *
  * @param http The HTTP status object

--- a/connectivity/mqtt/duplex_callback.h
+++ b/connectivity/mqtt/duplex_callback.h
@@ -23,22 +23,11 @@ extern "C" {
  */
 
 /**
- * @brief Initialize logger
- */
-void mqtt_callback_logger_init();
-
-/**
- * @brief Release logger
+ * @breif Initialize ta_core
  *
- * @return
- * - zero on success
- * - EXIT_FAILURE on error
+ * @param[in] core `struct ta_core_t` object
  */
-int mqtt_callback_logger_release();
-
-/**
- * @file connectivity/mqtt/duplex_callback.h
- */
+void ta_mqtt_init(ta_core_t *const core);
 
 /**
  * @brief Interface for functions setting callback functions.

--- a/connectivity/mqtt/duplex_utils.h
+++ b/connectivity/mqtt/duplex_utils.h
@@ -22,20 +22,6 @@ extern "C" {
  */
 
 /**
- * @brief Initialize logger
- */
-void mqtt_utils_logger_init();
-
-/**
- * @brief Release logger
- *
- * @return
- * - zero on success
- * - EXIT_FAILURE on error
- */
-int mqtt_utils_logger_release();
-
-/**
  * @brief Initialize `mosq_config_t` object for a duplex client.
  *
  * @param[in] config_mosq pointer of pointer of `struct mosquitto` object

--- a/connectivity/mqtt/mqtt_common.h
+++ b/connectivity/mqtt/mqtt_common.h
@@ -122,20 +122,6 @@ typedef struct mosq_config_s {
 } mosq_config_t;
 
 /**
- * @brief Initialize logger
- */
-void mqtt_common_logger_init();
-
-/**
- * @brief Release logger
- *
- * @return
- * - zero on success
- * - EXIT_FAILURE on error
- */
-int mqtt_common_logger_release();
-
-/**
  * @brief Initialize `mosq_config_t` object
  *
  * @param[in] cfg `mosq_config_t` object

--- a/connectivity/mqtt/pub_utils.h
+++ b/connectivity/mqtt/pub_utils.h
@@ -25,20 +25,6 @@ extern "C" {
  */
 
 /**
- * @brief Initialize logger
- */
-void mqtt_pub_logger_init();
-
-/**
- * @brief Release logger
- *
- * @return
- * - zero on success
- * - EXIT_FAILURE on error
- */
-int mqtt_pub_logger_release();
-
-/**
  * @brief Connect callback function of publisher.
  *
  * This callback function is called when the broker sends a CONNACK message in response to a connection owned by

--- a/connectivity/mqtt/sub_utils.h
+++ b/connectivity/mqtt/sub_utils.h
@@ -22,20 +22,6 @@ extern "C" {
  */
 
 /**
- * @brief Initialize logger
- */
-void mqtt_sub_logger_init();
-
-/**
- * @brief Release logger
- *
- * @return
- * - zero on success
- * - EXIT_FAILURE on error
- */
-int mqtt_sub_logger_release();
-
-/**
  * @brief Publish callback function of subscriber.
  *
  * when a message initiated with <mosquitto_publish> has been sent to the broker. This callback will be called both if

--- a/endpoint/unit-test/BUILD
+++ b/endpoint/unit-test/BUILD
@@ -6,6 +6,7 @@ cc_test(
     deps = [
         "//endpoint:https",
         "//endpoint/connectivity:conn_http",
+        "//tests:logger_lib",
         "//tests:test_define",
     ],
 )
@@ -19,6 +20,7 @@ cc_test(
         "//common:ta_errors",
         "//common:ta_logger",
         "//endpoint:endpoint_core",
+        "//tests:logger_lib",
         "//tests:test_define",
     ],
 )

--- a/storage/scylladb_utils.c
+++ b/storage/scylladb_utils.c
@@ -17,10 +17,6 @@ void scylladb_logger_init() { logger_id = logger_helper_enable(SCYLLADB_LOGGER, 
 
 int scylladb_logger_release() {
   logger_helper_release(logger_id);
-  if (logger_helper_destroy() != RC_OK) {
-    log_critical(logger_id, "%s.\n", SCYLLADB_LOGGER);
-    return EXIT_FAILURE;
-  }
   return 0;
 }
 

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -18,3 +18,15 @@ cc_library(
         "//common",
     ],
 )
+
+cc_library(
+    name = "logger_lib",
+    visibility = [
+        "//endpoint/unit-test:__pkg__",
+        "//tests:__subpackages__",
+    ],
+    deps = select({
+        "//accelerator:mqtt_enable": ["//connectivity/mqtt"],
+        "//conditions:default": ["//connectivity/http"],
+    }),
+)

--- a/tests/api/BUILD
+++ b/tests/api/BUILD
@@ -7,6 +7,7 @@ cc_test(
         "//accelerator/core:apis",
         "//accelerator/core:proxy_apis",
         "//tests:common",
+        "//tests:logger_lib",
         "//tests:test_define",
         "@cJSON",
     ],
@@ -16,12 +17,16 @@ cc_binary(
     name = "driver_stat",
     srcs = [
         "driver.c",
-    ],
+    ] + select({
+        "//accelerator:mqtt_enable": ["//connectivity/mqtt"],
+        "//conditions:default": ["//connectivity/http"],
+    }),
     defines = ["ENABLE_STAT"],
     deps = [
         "//accelerator/core:apis",
         "//accelerator/core:proxy_apis",
         "//tests:common",
+        "//tests:logger_lib",
         "//tests:test_define",
         "@cJSON",
     ],
@@ -35,6 +40,7 @@ cc_test(
     deps = [
         "//accelerator/core",
         "//tests:common",
+        "//tests:logger_lib",
         "//tests:test_define",
     ],
 )
@@ -49,6 +55,7 @@ cc_test(
         "//accelerator/core:proxy_apis",
         "//common",
         "//tests:common",
+        "//tests:logger_lib",
         "//tests:test_define",
     ],
 )

--- a/tests/api/driver.c
+++ b/tests/api/driver.c
@@ -237,14 +237,11 @@ int main(int argc, char* argv[]) {
   if (ta_logger_init() != SC_OK) {
     return EXIT_FAILURE;
   }
-  apis_logger_init();
-  cc_logger_init();
-  pow_logger_init();
-  timer_logger_init();
 
   ta_core_default_init(&ta_core);
   driver_core_cli_init(&ta_core, argc, argv, &test_case);
   ta_core_set(&ta_core);
+  ta_logger_switch(false, true, &ta_core.ta_conf);
 
   printf("Total samples for each API test: %d\n", TEST_COUNT);
   RUN_TEST(test_send_transfer);

--- a/tests/api/driver_core.c
+++ b/tests/api/driver_core.c
@@ -214,13 +214,11 @@ int main(int argc, char* argv[]) {
   if (ta_logger_init() != SC_OK) {
     return EXIT_FAILURE;
   }
-  cc_logger_init();
-  pow_logger_init();
-  timer_logger_init();
 
   ta_core_default_init(&ta_core);
   driver_core_cli_init(&ta_core, argc, argv, NULL);
   ta_core_set(&ta_core);
+  ta_logger_switch(false, true, &ta_core.ta_conf);
 
   UNITY_BEGIN();
   RUN_TEST(test_broadcast_buffered_txn);

--- a/tests/api/mam_test.c
+++ b/tests/api/mam_test.c
@@ -238,15 +238,12 @@ int main(int argc, char* argv[]) {
   if (ta_logger_init() != SC_OK) {
     return EXIT_FAILURE;
   }
-  apis_logger_init();
   ta_mam_logger_init();
-  cc_logger_init();
-  pow_logger_init();
-  timer_logger_init();
 
   ta_core_default_init(&ta_core);
   ta_core_cli_init(&ta_core, argc, argv);
   ta_core_set(&ta_core);
+  ta_logger_switch(false, true, &ta_core.ta_conf);
 
   printf("Total samples for each API test: %d\n", TEST_COUNT);
   RUN_TEST(test_send_mam_message);

--- a/tests/unit-test/BUILD
+++ b/tests/unit-test/BUILD
@@ -5,6 +5,7 @@ cc_test(
     ],
     linkopts = ["-luuid"],
     deps = [
+        "//tests:logger_lib",
         "//tests:test_define",
         "//utils/cache",
         "@unity",
@@ -19,6 +20,7 @@ cc_test(
     deps = [
         "//accelerator/core/serializer",
         "//tests:common",
+        "//tests:logger_lib",
         "//tests:test_define",
     ],
 )
@@ -30,15 +32,19 @@ cc_test(
     ],
     deps = [
         "//accelerator/core:pow",
+        "//tests:logger_lib",
         "//tests:test_define",
     ],
 )
 
 cc_test(
     name = "test_scylladb",
-    srcs = ["test_scylladb.c"],
+    srcs = [
+        "test_scylladb.c",
+    ],
     deps = [
         "//storage",
+        "//tests:logger_lib",
         "//tests:test_define",
     ],
 )
@@ -49,6 +55,8 @@ cc_test(
         "test_timer.c",
     ],
     deps = [
+        "//connectivity/http",
+        "//tests:logger_lib",
         "//tests:test_define",
         "//utils:timer",
     ],
@@ -62,6 +70,7 @@ cc_test(
     deps = [
         "//endpoint:cipher",
         "//endpoint:text_serializer",
+        "//tests:logger_lib",
         "//tests:test_define",
     ],
 )
@@ -73,6 +82,7 @@ cc_test(
     ],
     deps = [
         "//endpoint:cipher",
+        "//tests:logger_lib",
         "//tests:test_define",
     ],
 )
@@ -83,6 +93,7 @@ cc_test(
         "test_tryte_byte_conv.c",
     ],
     deps = [
+        "//tests:logger_lib",
         "//tests:test_define",
         "//utils:tryte_byte_conv",
     ],

--- a/utils/cache/cache.h
+++ b/utils/cache/cache.h
@@ -35,20 +35,6 @@ typedef struct {
 } cache_t;
 
 /**
- * Initialize logger
- */
-void br_logger_init();
-
-/**
- * Release logger
- *
- * @return
- * - zero on success
- * - EXIT_FAILURE on error
- */
-int br_logger_release();
-
-/**
  * @brief Initiate cache module. This function can be called in 'config.c' only.
  *
  * @param[in,out] rwlock Read/Write lock object.
@@ -196,6 +182,24 @@ status_t cache_list_pop(const char* const key, char* res);
  * - -1 on error
  */
 long int cache_occupied_space();
+
+/**
+ * @brief Set maximum memory limit of Redis
+ *
+ * @return
+ * - SC_CACHE_OFF if cache module is not enabled
+ * - 1 if cache module is enabled
+ */
+long int cache_set_capacity(char* size);
+
+/**
+ * @brief Get maximum memory limit of Redis
+ *
+ * @return
+ * - SC_CACHE_OFF if cache module is not enabled
+ * - 1 if cache module is enabled
+ */
+long int cache_get_capacity();
 
 #ifdef __cplusplus
 }

--- a/utils/timer.c
+++ b/utils/timer.c
@@ -22,11 +22,6 @@ void timer_logger_init() { logger_id = logger_helper_enable(TIMER_LOGGER, LOGGER
 
 int timer_logger_release() {
   logger_helper_release(logger_id);
-  if (logger_helper_destroy() != RC_OK) {
-    ta_log_error("Destroying logger failed %s.\n", TIMER_LOGGER);
-    return EXIT_FAILURE;
-  }
-
   return 0;
 }
 

--- a/utils/timer.h
+++ b/utils/timer.h
@@ -28,20 +28,6 @@ extern "C" {
 #include <sys/time.h>
 #include "common/ta_errors.h"
 
-/**
- * Initialize logger
- */
-void timer_logger_init();
-
-/**
- * Release logger
- *
- * @return
- * - zero on success
- * - EXIT_FAILURE on error
- */
-int timer_logger_release();
-
 typedef struct _ta_timer_t ta_timer_t;
 
 /**


### PR DESCRIPTION
Closes #357, closes #589.

- Moved logger initialize/release declaration to `common/logger.h` to have
better control of logger functions (we can know what logger could be
enabled by inspecting `logger.h`).

- Wrapped the logger initialize/release functions so we can
enable/disable verbose mode at ease in runtime-cli utility.

- Implement runtime command line utility

The runtime command line utility is a separated from the main thread.
The commands are maintained by several states defined in
`runtime_cli.c`. We also have a static global pointer indicating which
state we are at now.

Take the states in `runtime_cli.c` for example, we are at `start_state`
in the beginning. Everytime we need to `handle_commands`, we will
extract one more string (separated by spaces), and find if the command
names in current state matches the string.

Upon matching, we will then determine if current command needs more
subcommand. If so, the command type would be `CMD_STATE` and
`ta_state_ptr` would be assigned to `next_state`.

On the other hand, if current command reaches the end and is expecting
zero or more parameters, the type would be `CMD_LAST`, and will execute
the specified function `fn`.

If no command names match, the program will simply print help messages
according to the current state `ta_state_ptr` points to.

Runtime-cli can be enabled by adding `--runtime_cli` argument.