### PR TITLE
fix(endpoint): Fix the undefined symbol

### DIFF
--- a/endpoint/endpointComp/Component.cdef
+++ b/endpoint/endpointComp/Component.cdef
@@ -7,6 +7,7 @@ sources:
     ${CURDIR}/../../output_base/external/http_parser/http_parser.c
 
     ${CURDIR}/../../output_base/external/mbedtls_2_16_6/library/aes.c
+    ${CURDIR}/../../output_base/external/mbedtls_2_16_6/library/aesni.c
     ${CURDIR}/../../output_base/external/mbedtls_2_16_6/library/arc4.c
     ${CURDIR}/../../output_base/external/mbedtls_2_16_6/library/asn1parse.c
     ${CURDIR}/../../output_base/external/mbedtls_2_16_6/library/asn1write.c


### PR DESCRIPTION
Fix the undefined symbol problem when executing the Legato endpoint app.