### PR TITLE
feat(endpoint): Improve endpoint build instructions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -100,4 +100,4 @@ pem/*.inc
 resolv.conf
 output_base/
 _build_endpoint/
-endpoint.wp77xx.update
+endpoint.*.update

--- a/docs/endpoint.md
+++ b/docs/endpoint.md
@@ -1,18 +1,149 @@
 # Endpoint
+
 The endpoint is one of the components provided by Tangle-accelerator, running on a resource-constrained network connectivity module. The embedded devices can send messages to blockchain network (Tangle) with a connectivity module loaded endpoint. The message would be transmitted to connectivity module through UART. Message would be encrypted and send to tangle.
 
 # Streaming Message Channel Implementation
+
 The encrypted message would be sent to Tangle with a streaming message channel API. The streaming message channel API would ensure the order of messages in the channel. The user who wants to fetch/send message to Tangle needs to provide `data_id`, `key` and `protocol` to identify a specific message.
 A message sent by endpoint needs to be encrypted locally, which avoids message being peeked and modified. 
 
-# How to use
-```
-$ bazel build //endpoint:wp7702
-$ bazel build //endpoint:sim
+# How to build endpoint
+
+## Setup Legato application framework development environment 
+
+The endpoint uses the Legato application framework as based runtime system. Developers need to set up the Sierra development environment to build endpoint as specific target.
+
+### How to build endpoint application for wp77xx
+
+[Leaf](https://docs.legato.io/latest/toolsLeaf.html) is a workspace manager that will download, install and configure the required software packages for a Legato development environment.
+
+#### prerequisite packages required by leaf
+
+```shell
+$ sudo apt install \
+    python3-argcomplete \
+    python3-colorama \
+    python3-gnupg \
+    python3-jsonschema \
+    python3-requests \
+    gnupg \
+    bash-completion \
+    xz-utils
 ```
 
-## HTTPS Connection Support
-The endpoint uses http connection as default. The message which sent to tangle-accelerator has been encrypted. So the HTTP connection would not be unsafe. To build with https connection support, add `--define https=enable` option.
+Install leaf
+
+```shell
+$ curl -sLO https://downloads.sierrawireless.com/tools/leaf/leaf_latest.deb && sudo dpkg -i leaf_latest.deb
 ```
-$ bazel build --define https=enable //endpoint:wp7702
+
+Create a workspace
+
+```shell
+$ mkdir -p workspace
+$ cd workspace
+```
+
+Setup the wp77xx target profile
+
+```shell
+$ leaf setup legato-stable -p swi-wp77_3.0.0
+```
+
+Finally, make the wp77xx endpoint target. Be careful with the directory of tangle-accelerator. It should be located within the workspace directory.
+
+```shell
+$ git clone https://github.com/DLTcollab/tangle-accelerator.git
+$ cd tangle-accelerator
+$ make TARGET=wp77xx legato # build endpoint as wp77xx target
+$ make TESTS=true TARGET=wp77xx legato # build endpoint as wp77xx target in test mode
+```
+
+### How to build endpoint application for native target
+
+Install required packages:
+
+```shell
+$ sudo apt-get install -y   \
+    autoconf                \
+    automake                \
+    bash                    \
+    bc                      \
+    bison                   \
+    bsdiff                  \
+    build-essential         \
+    chrpath                 \
+    cmake                   \
+    cpio                    \
+    diffstat                \
+    flex                    \
+    gawk                    \
+    gcovr                   \
+    git                     \
+    gperf                   \
+    iputils-ping            \
+    libbz2-dev              \
+    libcurl4-gnutls-dev     \
+    libncurses5-dev         \
+    libncursesw5-dev        \
+    libsdl-dev              \
+    libssl-dev              \
+    libtool                 \
+    libxml2-utils           \
+    ninja-build             \
+    python                  \
+    python-git              \
+    python-jinja2           \
+    python-pkg-resources    \
+    python3                 \
+    texinfo                 \
+    unzip                   \
+    wget                    \
+    zlib1g-dev
+```
+
+Create a workspace
+
+```shell
+$ mkdir -p workspace
+$ cd workspace
+```
+
+Clone a specific version of `legato`. The `19.07.0` is the preferred stable version.
+
+```shell
+$ repo init -u git://github.com/legatoproject/manifest -m legato/releases/19.07.0.xml # specific legato 19.07.0 version
+$ repo sync
+```
+
+Build legato as native target
+
+```shell
+$ cd legato
+$ make localhost
+```
+
+Checkout the shell to legato shell
+
+```shell
+$ source framework/tools/scripts/configlegatoenv
+```
+
+Finally, use GNU Make to build endpoint application at the root directory of tangle-accelerator.
+
+```shell
+$ cd tangle-accelerator
+$ make legato # build endpoint as native target
+```
+
+The endpoint will be built at `endpoint/_build_endpoint/localhost/app/endpoint/staging/read-only/bin/endpoint`
+
+## HTTPS Connection Support
+
+The endpoint uses HTTP connection as default. The message sent to tangle-accelerator has been encrypted, so the HTTP connection would not be unsafe. To build with HTTPS connection support, add `ENFORCE_EP_HTTPS=true` option.
+
+For HTTPS connection support, the PEM file should also be set. The default pem file is located at `pem/cert.pem`. If the `PEM` is not set, the build system will use the default pem. The endpoint will verify the connection server with the trusted certificate from the pem file. The default pem is only for the build system. The user should provide the certificate from the server you want to connect. See pem/README.md for more information. 
+
+```shell
+$ make ENFORCE_EP_HTTPS=true PEM=/path/to/pem legato
 ```

--- a/endpoint/BUILD
+++ b/endpoint/BUILD
@@ -25,9 +25,9 @@ cc_binary(
         "endpoint_core.h",
     ],
     defines = [
-        "TA_HOST=\"localhost\"",
-        "TA_PORT=\"443\"",
-        "TA_SSL_SEED=\"nonce\"",
+        "ENDPOINT_HOST=\"localhost\"",
+        "ENDPOINT_PORT=\"443\"",
+        "ENDPOINT_SSL_SEED=\"nonce\"",
     ],
     linkshared = True,
     deps = [

--- a/endpoint/endpointComp/endpoint.c
+++ b/endpoint/endpointComp/endpoint.c
@@ -8,9 +8,10 @@
 
 #include "endpoint.h"
 
-#include "legato.h"
-
+#include "common/ta_errors.h"
 #include "endpoint/endpoint_core.h"
+#include "le_test.h"
+#include "legato.h"
 #include "utils/cipher.h"
 
 #define TEST_VALUE 0
@@ -102,8 +103,16 @@ COMPONENT_INIT {
   memcpy(iv, test_iv, AES_IV_SIZE);
   srand(time(NULL));
 
+#ifdef ENABLE_ENDPOINT_TEST
+  LE_TEST_INIT;
+  LE_TEST_INFO("=== ENDPOINT TEST BEGIN ===");
+  LE_TEST(SC_OK == send_transaction_information(value, message, message_fmt, tag, address, next_address, private_key,
+                                                device_id, iv));
+  LE_TEST_EXIT;
+#else
   while (true) {
     send_transaction_information(value, message, message_fmt, tag, address, next_address, private_key, device_id, iv);
     sleep(10);
   }
+#endif
 }

--- a/endpoint/platform/simulator/build.mk
+++ b/endpoint/platform/simulator/build.mk
@@ -1,0 +1,8 @@
+# Copyright (C) 2019-2020 BiiLabs Co., Ltd. and Contributors
+# All Rights Reserved.
+# This is free software; you can redistribute it and/or modify it under the
+# terms of the MIT license. A copy of the license can be found in the file
+# "LICENSE" at the root of this distribution.
+
+platform-build-command = \
+	cd endpoint && mkapp -v -t localhost -C -DENABLE_ENDPOINT_TEST $(ENDPOINT_CFLAGS) endpoint.adef;

--- a/endpoint/platform/wp77xx/build.mk
+++ b/endpoint/platform/wp77xx/build.mk
@@ -1,0 +1,8 @@
+# Copyright (C) 2019-2020 BiiLabs Co., Ltd. and Contributors
+# All Rights Reserved.
+# This is free software; you can redistribute it and/or modify it under the
+# terms of the MIT license. A copy of the license can be found in the file
+# "LICENSE" at the root of this distribution.
+
+platform-build-command = \
+	cd endpoint && leaf shell -c "mkapp -v -t wp77xx $(ENDPOINT_CFLAGS) endpoint.adef"

--- a/hooks/formatter
+++ b/hooks/formatter
@@ -1,11 +1,11 @@
 #!/bin/bash
 
-for file in $(find $(git rev-parse --show-toplevel) | grep -E "\.(c|cc|cpp|h|hh|hpp|m|mm)\$" | grep -Ev "/third_party/")
+for file in $(find $(git rev-parse --show-toplevel) | egrep "\.(c|cc|cpp|h|hh|hpp|m|mm)\$" | egrep -v "third_party|output_base");
 do
   clang-format -style=file -fallback-style=none -i $file
 done
 
-for file in $(find $(git rev-parse --show-toplevel) | grep -E "\BUILD\$" | grep -Ev "/third_party/")
+for file in $(find $(git rev-parse --show-toplevel) | egrep "\BUILD\$" | egrep -v "third_party|output_base" )
 do
   buildifier $file
 done


### PR DESCRIPTION
This commit adds the build instructions for generating endpoint test
or app with different target. For compatibility with legato framework,
we use the GNU Make build system to build endpoint. Use "make legato"
to generate endpoint app.

The macro TARGET intends to the target to generate. The default TARGET
is the platform on your development host. Set the TARGET like
TARGET=wp77xx to generate specific platform endpoint app.

The macro ENABLE_ENDPOINT_TEST is for generating the endpoint app in test mode.
Set ENABLE_ENDPOINT_TEST=true to enable generating test mode endpoint app.

The endpoint uses the sierra framework as based runtime system.
Developers need to set up the sierra development environment
to build endpoint as specific target. See docs/endpoint.md for
more information.

The default port has been modified to pass the test on buildkite.

Close #591