### PR TITLE
feat(endpoint): Specify host-port pair and SSL seed at runtime

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,18 @@ ifeq ($(TESTS), true)
 	ENDPOINT_CFLAGS += -C -DENABLE_ENDPOINT_TEST
 endif
 
+ifdef EP_TA_HOST
+	ENDPOINT_CFLAGS += -C -DEP_TA_HOST=${EP_TA_HOST}
+endif
+
+ifdef EP_TA_PORT
+	ENDPOINT_CFLAGS += -C -DEP_TA_PORT=${EP_TA_PORT}
+endif
+
+ifdef EP_SSL_SEED
+	ENDPOINT_CFLAGS += -C -DEP_SSL_SEED=${EP_SSL_SEED}
+endif
+
 include endpoint/platform/$(TARGET)/build.mk
 
 all: $(DEPS) cert

--- a/endpoint/BUILD
+++ b/endpoint/BUILD
@@ -3,9 +3,9 @@ cc_library(
     srcs = ["endpoint_core.c"],
     hdrs = ["endpoint_core.h"],
     defines = [
-        "ENDPOINT_HOST=\"localhost\"",
-        "ENDPOINT_PORT=\"8000\"",
-        "ENDPOINT_SSL_SEED=\"nonce\"",
+        "EP_TA_HOST=localhost",
+        "EP_TA_PORT=8000",
+        "EP_SSL_SEED=nonce",
     ],
     visibility = ["//visibility:public"],
     deps = [
@@ -25,9 +25,9 @@ cc_binary(
         "endpoint_core.h",
     ],
     defines = [
-        "ENDPOINT_HOST=\"localhost\"",
-        "ENDPOINT_PORT=\"443\"",
-        "ENDPOINT_SSL_SEED=\"nonce\"",
+        "EP_TA_HOST=localhost",
+        "EP_TA_PORT=8000",
+        "EP_SSL_SEED=nonce",
     ],
     linkshared = True,
     deps = [

--- a/endpoint/endpointComp/endpoint.c
+++ b/endpoint/endpointComp/endpoint.c
@@ -45,6 +45,9 @@ static void print_help(void) {
       "           [--tag=\"tag\"]\n"
       "           [--addr=\"address\"]\n"
       "           [--next-addr=\"next-address\"]\n"
+      "           [--host=\"host\"]\n"
+      "           [--port=\"port\"]\n"
+      "           [--ssl-seed=\"ssl-seed\"]\n"
       "\n"
       "OPTIONS\n"
       "  -h\n"
@@ -71,6 +74,18 @@ static void print_help(void) {
       "  --next-addr=\"next-address\"\n"
       "    Assign the next address with string for send_transaction_information.\n"
       "    The \"next-address\" should be composed with [9A-Z] and the length should be 81.\n"
+      "\n"
+      "  --host=\"host\"\n"
+      "    Assign the host of the tangle-accelerator for send_transaction_information.\n"
+      "    The default value is NULL.\n"
+      "\n"
+      "  --port=\"port\"\n"
+      "    Assign the port of the tangle-accelerator for send_transaction_information.\n"
+      "    The default value is NULL.\n"
+      "\n"
+      "  --ssl-seed=\"ssl-seed\"\n"
+      "    Assign the random seed of the SSL configuration for send_transaction_information.\n"
+      "    The default value is NULL.\n"
       "\n");
 
   exit(EXIT_SUCCESS);
@@ -81,6 +96,9 @@ COMPONENT_INIT {
   // The current code is a prototype for passing the CI.
   // The initialization of hardware and the input from hardware are not implemented yet.
   int value = TEST_VALUE;
+  const char* host = NULL;
+  const char* port = NULL;
+  const char* ssl_seed = NULL;
   const char* message = TEST_MESSAGE;
   const char* message_fmt = TEST_MESSAGE_FMT;
   const char* tag = TEST_TAG;
@@ -91,6 +109,9 @@ COMPONENT_INIT {
   uint8_t iv[AES_IV_SIZE] = {0};
 
   le_arg_SetIntVar(&value, NULL, "val");
+  le_arg_SetStringVar(&host, NULL, "host");
+  le_arg_SetStringVar(&port, NULL, "port");
+  le_arg_SetStringVar(&ssl_seed, NULL, "ssl-seed");
   le_arg_SetStringVar(&message, NULL, "msg");
   le_arg_SetStringVar(&message_fmt, NULL, "msg-fmt");
   le_arg_SetStringVar(&tag, NULL, "tag");
@@ -106,12 +127,13 @@ COMPONENT_INIT {
 #ifdef ENABLE_ENDPOINT_TEST
   LE_TEST_INIT;
   LE_TEST_INFO("=== ENDPOINT TEST BEGIN ===");
-  LE_TEST(SC_OK == send_transaction_information(value, message, message_fmt, tag, address, next_address, private_key,
-                                                device_id, iv));
+  LE_TEST(SC_OK == send_transaction_information(host, port, ssl_seed, value, message, message_fmt, tag, address,
+                                                next_address, private_key, device_id, iv));
   LE_TEST_EXIT;
 #else
   while (true) {
-    send_transaction_information(value, message, message_fmt, tag, address, next_address, private_key, device_id, iv);
+    send_transaction_information(host, port, ssl_seed, value, message, message_fmt, tag, address, next_address,
+                                 private_key, device_id, iv);
     sleep(10);
   }
 #endif

--- a/endpoint/endpoint_core.h
+++ b/endpoint/endpoint_core.h
@@ -28,6 +28,9 @@ void endpoint_destroy(void);
 /**
  * @brief Send transaction information to tangle accelerator
  *
+ * @param[in] host The host of the tangle-accelerator
+ * @param[in] port The port of the tangle-accelerator
+ * @param[in] ssl_seed The random seed of the SSL configuration
  * @param[in] value Amount of the IOTA currency will be sent
  * @param[in] message Message of the transaction in Trytes format
  * @param[in] message_fmt Treating message field as specified format. Can be one of `ascii` or `trytes`. Default:
@@ -42,7 +45,8 @@ void endpoint_destroy(void);
  *
  * @return #status_t
  */
-status_t send_transaction_information(const int value, const char* message, const char* message_fmt, const char* tag,
+status_t send_transaction_information(const char* host, const char* port, const char* ssl_seed, const int value,
+                                      const char* message, const char* message_fmt, const char* tag,
                                       const char* address, const char* next_address, const uint8_t* private_key,
                                       const char* device_id, uint8_t* iv);
 

--- a/endpoint/unit-test/test_endpoint_core.c
+++ b/endpoint/unit-test/test_endpoint_core.c
@@ -54,8 +54,8 @@ void test_endpoint(void) {
   strftime(time_str, 26, "%Y-%m-%d %H:%M:%S", tm_info);
   gen_rand_trytes(next_addr, ADDR_LEN);
 
-  status_t ret = send_transaction_information(TEST_VALUE, TEST_MESSAGE, TEST_MESSAGE_FMT, TEST_TAG, TEST_ADDRESS,
-                                              (char *)next_addr, test_key, TEST_DEVICE_ID, iv);
+  status_t ret = send_transaction_information(NULL, NULL, NULL, TEST_VALUE, TEST_MESSAGE, TEST_MESSAGE_FMT, TEST_TAG,
+                                              TEST_ADDRESS, (char *)next_addr, test_key, TEST_DEVICE_ID, iv);
   TEST_ASSERT(ret == SC_OK);
 }
 


### PR DESCRIPTION
- Set configuration when executing endpoint application instead of building it.
  The command line option '--host', '--port' and '--ssl-seed" are added.
- Remove the unused macros.
- Change send_transaction_information for passing the host, port and SSL seed.