### PR TITLE
test(endpoint): Provide automated test script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -101,3 +101,5 @@ resolv.conf
 output_base/
 _build_endpoint/
 endpoint.*.update
+.repo
+legato/

--- a/docs/endpoint.md
+++ b/docs/endpoint.md
@@ -106,37 +106,9 @@ $ sudo apt-get install -y   \
     zlib1g-dev
 ```
 
-Create a workspace
+Use GNU Make to build endpoint application at the root directory of tangle-accelerator.
 
 ```shell
-$ mkdir -p workspace
-$ cd workspace
-```
-
-Clone a specific version of `legato`. The `19.07.0` is the preferred stable version.
-
-```shell
-$ repo init -u git://github.com/legatoproject/manifest -m legato/releases/19.07.0.xml # specific legato 19.07.0 version
-$ repo sync
-```
-
-Build legato as native target
-
-```shell
-$ cd legato
-$ make localhost
-```
-
-Checkout the shell to legato shell
-
-```shell
-$ source framework/tools/scripts/configlegatoenv
-```
-
-Finally, use GNU Make to build endpoint application at the root directory of tangle-accelerator.
-
-```shell
-$ cd tangle-accelerator
 $ make legato # build endpoint as native target
 ```
 

--- a/endpoint/build-legato.sh
+++ b/endpoint/build-legato.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+set -uo pipefail
+
+COMMON_FILE="tests/endpoint/common.sh"
+
+if [ ! -f "$COMMON_FILE" ]
+then
+    echo "$COMMON_FILE is not exists."
+    echo "Always execute this script in top-level directory."
+    exit 1
+fi
+source $COMMON_FILE
+
+download_legato_repo
+build_legato_repo

--- a/endpoint/platform/simulator/build.mk
+++ b/endpoint/platform/simulator/build.mk
@@ -4,5 +4,10 @@
 # terms of the MIT license. A copy of the license can be found in the file
 # "LICENSE" at the root of this distribution.
 
+export LEGATO_ROOT := $(PWD)/legato
+export PATH := $(LEGATO_ROOT)/bin:$(LEGATO_ROOT)build/localhost/framework/bin:$(PATH)
+export LEGATO_TARGET := localhost
+
 platform-build-command = \
+	sh -c "endpoint/build-legato.sh"; \
 	cd endpoint && mkapp -v -t localhost -C -DENABLE_ENDPOINT_TEST $(LEGATO_FLAGS) endpoint.adef;

--- a/tests/endpoint/common.sh
+++ b/tests/endpoint/common.sh
@@ -1,0 +1,32 @@
+LEGATO_VERSION="20.04.0"
+
+function download_legato_repo(){
+    echo "Downloading Legato AF"
+    repo init -u git://github.com/legatoproject/manifest -m legato/releases/${LEGATO_VERSION}.xml
+    repo sync
+}
+
+function build_legato_repo(){
+    if [ ! -d "legato" ]; then
+        echo "Please download the Legato AF first"
+        exit 1
+    fi
+
+    if [ ! -f "legato/Makefile" ]; then
+        echo "The Makefile inside legato project is missing"
+        echo "Please remove the legato directory and download Legato AF again."
+        exit 1
+    fi
+
+    echo "Building Legato AF"
+    make -C legato localhost
+}
+
+function setup_leaf(){
+    if ! which "leaf"
+    then 
+        echo "Please install Legato leaf first"
+        exit 1
+    fi
+    leaf --non-interactive setup legato-latest -p "$1"
+}

--- a/tests/endpoint/test-WP77.sh
+++ b/tests/endpoint/test-WP77.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+set -uo pipefail
+
+COMMON_FILE="tests/endpoint/common.sh"
+
+if [ ! -f "$COMMON_FILE" ]
+then
+    echo "$COMMON_FILE is not exists."
+    exit 1
+fi
+source $COMMON_FILE
+
+# setup WP77 leaf shell
+setup_leaf "swi-wp77_3.4.0"
+
+make TESTS=true TARGET=wp77xx EP_TA_HOST=node.deviceproof.org EP_TA_PORT=5566 legato && \
+tar zcf endpoint.tgz endpoint/_build_endpoint/wp77xx/app/endpoint/staging/read-only/

--- a/tests/endpoint/test-endpoint.sh
+++ b/tests/endpoint/test-endpoint.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+set -uo pipefail
+
+# Create endpoint app
+make EP_TA_HOST=node.deviceproof.org EP_TA_PORT=5566 legato
+
+# Run endpoint app test here
+endpoint/_build_endpoint/localhost/app/endpoint/staging/read-only/bin/endpoint


### PR DESCRIPTION
This commit provided two script for endpoint automated test on
buildkite.

The "test-endpoint.sh" will test the endpoint app
on development platform.

The "test-WP77.sh" will generate the endpoint app and
pack the binary which can be uploaded on to WP77XX target.

The build command for development platform has been changed.
Use "make legato" to generate native app.

Close #691
