### PR TITLE
fix(endpoint): Rename conflict macro

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ PEM_DIR = pem
 PEM := $(PEM_DIR)/cert.pem
 OUTPUT_BASE_DIR := output_base
 # Endpoint build target. The default intends to the platform of your development system.
-TARGET := simulator
+EP_TARGET := simulator
 # Build test suite
 TESTS := false
 # Enable endpoint HTTPS connection to tangle-accelerator. 
@@ -43,14 +43,14 @@ ifdef EP_SSL_SEED
 endif
 
 # Pass target into endpoint build process
-LEGATO_FLAGS += -DTARGET=$(TARGET)
+LEGATO_FLAGS += -DEP_TARGET=$(EP_TARGET)
 
 # Prepend the "-C" flag at the beginging for passing cflags into mkapp
 LEGATO_FLAGS := $(foreach flags, $(LEGATO_FLAGS), -C $(flags))
 
 # Include the build command from the specific target
-include endpoint/platform/$(TARGET)/build.mk
-export TARGET
+include endpoint/platform/$(EP_TARGET)/build.mk
+export EP_TARGET
 
 all: $(DEPS) cert
 

--- a/docs/endpoint.md
+++ b/docs/endpoint.md
@@ -59,8 +59,8 @@ For setting `host`, `port` and `ssl seed` during compile-time. Add `EP_TA_HOST=x
 ```shell
 $ git clone https://github.com/DLTcollab/tangle-accelerator.git
 $ cd tangle-accelerator
-$ make TARGET=wp77xx EP_TA_HOST=node.deviceproof.org EP_TA_PORT=5566 legato # build endpoint as wp77xx target, and set the connected host to "node.deviceproof.org" with port 5566
-$ make TESTS=true TARGET=wp77xx EP_TA_HOST=node.deviceproof.org EP_TA_PORT=5566 legato # build endpoint as wp77xx target in test mode
+$ make EP_TARGET=wp77xx EP_TA_HOST=node.deviceproof.org EP_TA_PORT=5566 legato # build endpoint as wp77xx target, and set the connected host to "node.deviceproof.org" with port 5566
+$ make TESTS=true EP_TARGET=wp77xx EP_TA_HOST=node.deviceproof.org EP_TA_PORT=5566 legato # build endpoint as wp77xx target in test mode
 ```
 
 #### How to build endpoint application for native target

--- a/endpoint/endpointComp/Component.cdef
+++ b/endpoint/endpointComp/Component.cdef
@@ -4,7 +4,7 @@ sources:
     ${CURDIR}/../hal/device.c
     
     // include the specific platform
-    ${CURDIR}/../platform/${TARGET}/impl.c 
+    ${CURDIR}/../platform/${EP_TARGET}/impl.c 
 
     ${CURDIR}/../../output_base/external/org_iota_common/utils/logger_helper.c
 

--- a/endpoint/endpointComp/endpoint.c
+++ b/endpoint/endpointComp/endpoint.c
@@ -125,7 +125,7 @@ COMPONENT_INIT {
   memcpy(iv, test_iv, AES_IV_SIZE);
   srand(time(NULL));
 
-  device_t* device = ta_device(STRINGIZE(TARGET));
+  device_t* device = ta_device(STRINGIZE(EP_TARGET));
   device->op->get_key(private_key);
   device->op->get_device_id(device_id);
 

--- a/tests/endpoint/test-WP77.sh
+++ b/tests/endpoint/test-WP77.sh
@@ -14,5 +14,5 @@ source $COMMON_FILE
 # setup WP77 leaf shell
 setup_leaf "swi-wp77_3.4.0"
 
-make TESTS=true TARGET=wp77xx EP_TA_HOST=node.deviceproof.org EP_TA_PORT=5566 legato && \
+make TESTS=true EP_TARGET=wp77xx EP_TA_HOST=node.deviceproof.org EP_TA_PORT=5566 legato && \
 tar zcf endpoint.tgz endpoint/_build_endpoint/wp77xx/app/endpoint/staging/read-only/


### PR DESCRIPTION
This commit changed the macro TARGET to EP_TARGET. To avoid the conflict
macro which also defined in Legato AF.

Close #696