### PR TITLE
Fix(endpoint): Fix device not found error message

### DIFF
--- a/endpoint/endpointComp/endpoint.c
+++ b/endpoint/endpointComp/endpoint.c
@@ -126,21 +126,25 @@ COMPONENT_INIT {
   srand(time(NULL));
 
   device_t* device = ta_device(STRINGIZE(EP_TARGET));
-  device->op->get_key(private_key);
-  device->op->get_device_id(device_id);
-
+  if (device == NULL) {
+    LE_ERROR("Can not get specific device");
+  } else {
+    device->op->get_key(private_key);
+    device->op->get_device_id(device_id);
 #ifdef ENABLE_ENDPOINT_TEST
-  LE_TEST_INIT;
-  LE_TEST_INFO("=== ENDPOINT TEST BEGIN ===");
-  LE_TEST(SC_OK == send_transaction_information(host, port, ssl_seed, value, message, message_fmt, tag, address,
-                                                next_address, private_key, device_id_ptr, iv));
-  LE_TEST_EXIT;
+    LE_TEST_INIT;
+    LE_TEST_INFO("=== ENDPOINT TEST BEGIN ===");
+    LE_TEST(SC_OK == send_transaction_information(host, port, ssl_seed, value, message, message_fmt, tag, address,
+                                                  next_address, private_key, device_id_ptr, iv));
+    LE_TEST_EXIT;
 #else
-  while (true) {
-    status_t ret = send_transaction_information(host, port, ssl_seed, value, message, message_fmt, tag, address,
-                                                next_address, private_key, device_id_ptr, iv);
-    LE_INFO("Send transaction information return: %d", ret);
-    sleep(10);
-  }
+    while (true) {
+      // TODO: listen input from UART here
+      status_t ret = send_transaction_information(host, port, ssl_seed, value, message, message_fmt, tag, address,
+                                                  next_address, private_key, device_id_ptr, iv);
+      LE_INFO("Send transaction information return: %d", ret);
+      sleep(10);
+    }
 #endif
+  }
 }

--- a/endpoint/hal/device.c
+++ b/endpoint/hal/device.c
@@ -27,9 +27,11 @@ device_t *ta_device(const char *type) {
     return NULL;
   }
   p = find_device(type, strlen(type));
-  if (*p) {
-    LE_INFO("Device type %s not found", type);
+  if (*p == NULL) {
+    LE_ERROR("Device type %s not found", type);
+    return NULL;
   }
+  LE_DEBUG("Successfully get %s device", type);
   return *p;
 }
 


### PR DESCRIPTION
The endpoint will always get specific device during compile-time.
This commit fixed the error message which generated from ta_device.