### PR TITLE
feat(endpoint): Provide HTTP(S) response for endpoint

### DIFF
--- a/endpoint/connectivity/conn_http.c
+++ b/endpoint/connectivity/conn_http.c
@@ -251,8 +251,3 @@ status_t set_get_request(char const *const path, char const *const host, const u
 
   return SC_OK;
 }
-
-int parser_body_callback(http_parser *parser, const char *at, size_t length) {
-  ta_log_debug("HTTP Response: %s\n", at);
-  return 0;
-}

--- a/endpoint/connectivity/conn_http.h
+++ b/endpoint/connectivity/conn_http.h
@@ -15,7 +15,6 @@ extern "C" {
 
 #include <stdbool.h>
 #include "common/ta_errors.h"
-#include "http_parser.h"
 #include "mbedtls/certs.h"
 #include "mbedtls/ctr_drbg.h"
 #include "mbedtls/entropy.h"
@@ -139,19 +138,6 @@ status_t set_post_request(char const *const path, char const *const host, const 
  * @see #status_t
  */
 status_t set_get_request(char const *const path, char const *const host, const uint32_t port, char **out);
-
-/**
- * @brief Callback function for http parser
- *
- * @param[in] parser HTTP(S) parser
- * @param[in] at HTTP(S) message to parse
- * @param[in] length Length of text at
- *
- * @return
- * - 0 on success
- * - non-zero on error
- */
-int parser_body_callback(http_parser *parser, const char *at, size_t length);
 
 #ifdef __cplusplus
 }

--- a/endpoint/https.h
+++ b/endpoint/https.h
@@ -9,6 +9,7 @@
 #ifndef UTILS_HTTPS_H
 #define UTILS_HTTPS_H
 
+#include <stddef.h>
 #include "common/ta_errors.h"
 
 #ifdef __cplusplus
@@ -18,6 +19,22 @@ extern "C" {
 /**
  * @file endpoint/https.h
  */
+
+/* struct type of HTTP(S) response */
+typedef struct {
+  char* buffer; /**< Message body **/
+  size_t len;   /**< Length of message body */
+} https_response_t;
+
+/* struct type of HTTP(S) context */
+typedef struct {
+  const char* host; /**< HTTP(S) host */
+  const int port;   /**< HTTP(S) port */
+  const char* api; /**< API path for POST or GET request to HTTP(S) server, i.e "transaction/". It must be in string. */
+  const char* ssl_seed;    /**< Seed for ssl connection. This column is optional. */
+  https_response_t* s_req; /**< [in] The message to send */
+  https_response_t* s_res; /**< [out] The message body of HTTP(S) response */
+} https_ctx_t;
 
 /**
  * @brief Initialize logger of HTTP(S)
@@ -34,17 +51,13 @@ void https_logger_init();
 int https_logger_release();
 
 /**
- * @brief Send message via HTTP(S) protocol
+ * @brief Send a POST request message via HTTP(S) protocol
  *
- * @param[in] host HTTP(S) host
- * @param[in] port HTTP(S) port
- * @param[in] api API path for POST request to HTTP(S) server, i.e "transaction/". It must be in string.
- * @param[in] msg Message to send
- * @param[in] ssl_seed Seed for ssl connection
+ * @param[in, out] ctx The pointer points to http context
  *
  * @return #status_t
  */
-status_t send_https_msg(char const *host, char const *port, char const *api, const char *msg, const char *ssl_seed);
+status_t send_https_msg(https_ctx_t* ctx);
 
 #ifdef __cplusplus
 }

--- a/endpoint/unit-test/BUILD
+++ b/endpoint/unit-test/BUILD
@@ -4,6 +4,7 @@ cc_test(
         "test_http.c",
     ],
     deps = [
+        "//endpoint:https",
         "//endpoint/connectivity:conn_http",
         "//tests:test_define",
     ],

--- a/endpoint/unit-test/test_http.c
+++ b/endpoint/unit-test/test_http.c
@@ -2,6 +2,7 @@
 #include <string.h>
 #include "common/ta_errors.h"
 #include "endpoint/connectivity/conn_http.h"
+#include "endpoint/https.h"
 #include "http_parser.h"
 #include "tests/test_define.h"
 
@@ -31,11 +32,13 @@ Content-Length: 224\r\n\
 #define BUF_SIZE 4096
 
 static char* req = NULL;
+static https_response_t my_data;
 
 void setUp(void) { conn_http_logger_init(); }
 
 void tearDown(void) {
   conn_http_logger_release();
+  free(my_data.buffer);
   free(req);
 }
 
@@ -44,7 +47,7 @@ void test_http(void) {
   char post_message[BUF_SIZE] = {0}, response[BUF_SIZE] = {0};
   http_parser parser;
   http_parser_settings settings = {};
-  settings.on_body = parser_body_callback;
+  parser.data = &my_data;
 
   snprintf(post_message, BUF_SIZE, "%s", TEST_POST_MESSAGE);
 

--- a/tests/endpoint/test-endpoint.sh
+++ b/tests/endpoint/test-endpoint.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -uo pipefail
+set -euo pipefail
 
 # Create endpoint app
 make EP_TA_HOST=node.deviceproof.org EP_TA_PORT=5566 legato


### PR DESCRIPTION
The MAM protocol need to handle the HTTP(S) response from
HTTP(S) request. This commit provided the HTTP(S) response from
the http_parser. The buffer of string inside the https_response_t
and the response instance should always be free after the request.

Close #704