### PR TITLE
fix(test): Notify initialization by domain socket 

### DIFF
--- a/accelerator/config.h
+++ b/accelerator/config.h
@@ -130,7 +130,7 @@ typedef struct ta_core_s {
 } ta_core_t;
 
 /**
- * Initializes configurations with default values
+ * @brief Initializes configurations with default values
  *
  * @param[in] core Pointer to Tangle-accelerator core configuration structure
  *
@@ -152,7 +152,7 @@ static inline struct option* cli_build_options() {
 };
 
 /**
- * Set configurations with command line inputs
+ * @brief Set configurations with command line inputs
  *
  * @param[in] core Pointer to Tangle-accelerator core configuration structure
  * @param[in] key CLI command key
@@ -165,7 +165,7 @@ static inline struct option* cli_build_options() {
 status_t cli_core_set(ta_core_t* const core, int key, char* const value);
 
 /**
- * Initializes configurations with configuration file
+ * @brief Initializes configurations with configuration file
  *
  * @param[in] core Pointer to Tangle-accelerator core configuration structure
  * @param[in] argc Number of argument of CLI
@@ -178,7 +178,7 @@ status_t cli_core_set(ta_core_t* const core, int key, char* const value);
 status_t ta_core_file_init(ta_core_t* const core, int argc, char** argv);
 
 /**
- * Initializes configurations with CLI values
+ * @brief Initializes configurations with CLI values
  *
  * @param[in] core Pointer to Tangle-accelerator core configuration structure
  * @param[in] argc Number of argument of CLI
@@ -191,7 +191,7 @@ status_t ta_core_file_init(ta_core_t* const core, int argc, char** argv);
 status_t ta_core_cli_init(ta_core_t* const core, int argc, char** argv);
 
 /**
- * Start services after configurations are set
+ * @brief Start services after configurations are set
  *
  * @param[in] core Pointer to Tangle-accelerator core configuration structure
  *
@@ -210,7 +210,7 @@ status_t ta_core_set(ta_core_t* const core);
 void ta_core_destroy(ta_core_t* const core);
 
 /**
- * Initializes iota_client_service
+ * @brief Initializes iota_client_service
  *
  * @param[in] service IOTA client service
  * @param[in] host host of connecting service
@@ -223,6 +223,11 @@ void ta_core_destroy(ta_core_t* const core);
  */
 status_t ta_set_iota_client_service(iota_client_service_t* service, char const* host, uint16_t port,
                                     char const* const ca_pem);
+
+/**
+ * @brief Notify other process with unix domain socket
+ */
+void notification_trigger();
 
 #ifdef __cplusplus
 }

--- a/accelerator/main.c
+++ b/accelerator/main.c
@@ -134,9 +134,8 @@ int main(int argc, char* argv[]) {
     br_logger_init();
   }
 
-  // Once tangle-accelerator finished initializing, return 'SIGUSR1' to parent process
-  pid_t pid = getppid();
-  kill(pid, SIGUSR1);
+  // Once tangle-accelerator finished initializing, notify regression test script with unix domain socket
+  notification_trigger();
 
   /* pause() cause TA to sleep until it catch a signal,
    * also the return value and errno should be -1 and EINTR on success.

--- a/endpoint/unit-test/driver.sh
+++ b/endpoint/unit-test/driver.sh
@@ -34,22 +34,18 @@ function run_test_suite(){
 
 function start_ta(){
     # Create tangle-accelerator for unit-test
-    trap 'TA_INIT=1' USR1
     bazel run accelerator &
     TA=$!
-    TA_INIT=0
-
-    # Wait for tangle-acclerator build finish
-    while [ "$TA_INIT" -ne 1 ]; do
-        if ps -p $TA > /dev/null; then
-            echo "waiting for tangle-accelerator initialization"
-            sleep 1
-            continue
-        else
-            # pid does not exist
-            break
-        fi
-    done
+    # Wait until tangle-accelerator has been initialized
+    echo "==============Wait for TA starting=============="
+    while read -r line  
+    do  
+        if [[ "$line" == "TA-START" ]]
+    then 
+        echo "$line"
+    fi
+    done <<< $(nc -U -l $socket | tr '\0' '\n')
+    echo "==============TA has successfully started=============="
 }
 
 echo "Start unit-test for endpoint"

--- a/tests/regression/common.sh
+++ b/tests/regression/common.sh
@@ -59,7 +59,9 @@ check_env() {
 
 # Parse command line arguments
 get_cli_args () {
-    sleep_time=$1
+    socket=$1
     shift
     remaining_args=$@ # Get the remaining arguments
 }
+
+start_notification="TA-START"

--- a/tests/regression/router-sanitizer.sh
+++ b/tests/regression/router-sanitizer.sh
@@ -6,7 +6,7 @@ check_env
 setup_sanitizer_opts
 
 # Get command line arguments
-# Current arguments parsed are <sleep_time> <remaining_args>
+# Current arguments parsed are <socket name> <remaining_args>
 get_cli_args $@
 
 # Install prerequisites
@@ -20,23 +20,20 @@ redis-server &
 for (( i = 0; i < ${#SAN_OPTIONS[@]}; i++ )); do
     option=${SAN_OPTIONS[${i}]}
 
-    trap 'TA_INIT=1' USR1
     bazel run accelerator ${option} -c dbg -- --ta_port=${TA_PORT} &
     TA=$!
-    
-    TA_INIT=0
-    while [ "$TA_INIT" -ne 1 ]; do
-        if ps -p $TA > /dev/null; then
-            echo "waiting for tangle-accelerator initialization"
-            sleep 1
-            continue
-        else
-            # pid does not exist
-            break
-        fi
-    done
-    
     trap "kill -9 ${TA};" INT # Trap SIGINT from Ctrl-C to stop TA
+
+    # Wait until tangle-accelerator has been initialized
+    echo "==============Wait for TA starting=============="
+    while read -r line  
+    do  
+        if [[ "$line" == "$start_notification" ]]
+    then 
+        echo "$line"
+    fi
+    done <<< $(nc -U -l $socket | tr '\0' '\n')
+    echo "==============TA has successfully started=============="
 
     python3 tests/regression/runner.py ${remaining_args} --url localhost:${TA_PORT}
     rc=$?

--- a/tests/regression/run-api-with-mqtt.sh
+++ b/tests/regression/run-api-with-mqtt.sh
@@ -6,7 +6,7 @@ check_env
 setup_build_opts
 
 # Get command line arguments
-# Current arguments parsed are <sleep_time> <remaining_args>
+# Current arguments parsed are <socket name> <remaining_args>
 get_cli_args $@
 
 # Install prerequisites
@@ -22,17 +22,20 @@ for (( i = 0; i < ${#OPTIONS[@]}; i++ )); do
     cli_arg=${option} | cut -d '|' -f 1
     build_arg=${option} | cut -d '|' -f 2
 
-    trap 'TA_INIT=1' USR1
     bazel run accelerator --define mqtt=enable ${build_arg} -- --quiet --ta_port=${TA_PORT} ${cli_arg} &
     TA=$!
-    
-    TA_INIT=0
-    while [ "$TA_INIT" -ne 1 ]; do
-        echo "waiting for tangle-accelerator initialization"
-        sleep 1
-    done
-    
     trap "kill -9 ${TA};" INT # Trap SIGINT from Ctrl-C to stop TA
+
+    # Wait until tangle-accelerator has been initialized
+    echo "==============Wait for TA starting=============="
+    while read -r line  
+    do  
+        if [[ "$line" == "$start_notification" ]]
+    then 
+        echo "$line"
+    fi
+    done <<< $(nc -U -l $socket | tr '\0' '\n')
+    echo "==============TA has successfully started=============="
 
     python3 tests/regression/runner.py ${remaining_args} --url "localhost" --mqtt
     rc=$?

--- a/tests/regression/run-api.sh
+++ b/tests/regression/run-api.sh
@@ -6,7 +6,7 @@ check_env
 setup_build_opts
 
 # Get command line arguments
-# Current arguments parsed are <sleep_time> <remaining_args>
+# Current arguments parsed are <socket name> <remaining_args>
 get_cli_args $@
 
 # Install prerequisites
@@ -22,23 +22,20 @@ for (( i = 0; i < ${#OPTIONS[@]}; i++ )); do
     cli_arg=$(echo ${option} | cut -d '|' -f 2)
     build_arg=$(echo ${option} | cut -d '|' -f 1)
 
-    trap 'TA_INIT=1' USR1
     bazel run accelerator ${build_arg} -- --ta_port=${TA_PORT} ${cli_arg} &
     TA=$!
-    
-    TA_INIT=0
-    while [ "$TA_INIT" -ne 1 ]; do
-        if ps -p $TA > /dev/null; then
-            echo "waiting for tangle-accelerator initialization"
-            sleep 1
-            continue
-        else
-            # pid does not exist
-            break
-        fi
-    done
-    
     trap "kill -9 ${TA};" INT # Trap SIGINT from Ctrl-C to stop TA
+
+    # Wait until tangle-accelerator has been initialized
+    echo "==============Wait for TA starting=============="
+    while read -r line  
+    do  
+        if [[ "$line" == "$start_notification" ]]
+    then 
+        echo "$line"
+    fi
+    done <<< $(nc -U -l $socket | tr '\0' '\n')
+    echo "==============TA has successfully started=============="
 
     python3 tests/regression/runner.py ${remaining_args} --url localhost:${TA_PORT}
     rc=$?


### PR DESCRIPTION
Passing signal `SIGUSR1` to parent process to notify parent process
that tangle-accelerator has been successfully initialized would cauase
tangle-accelerator terminate immediatrly.

To fix this, UNIX domain socket is used to notify regression test
script that tangle-accelerator has been successfully initialized.