### PR TITLE
fix(Endpoint): Fix double free error

### DIFF
--- a/endpoint/connectivity/conn_http.c
+++ b/endpoint/connectivity/conn_http.c
@@ -159,7 +159,6 @@ status_t http_open(connect_info_t *const info, char const *const seed_nonce, cha
   }
 
 exit:
-  if (ret != SC_OK) free_info_context(info);
   return ret;
 }
 


### PR DESCRIPTION
The double free error would occurred when HTTP connection failed.
This commit fix the double free error inside http_open.

Close #723