### PR TITLE
fix(regression): Fix failed send_trytes test suite

### DIFF
--- a/tests/regression/common.sh
+++ b/tests/regression/common.sh
@@ -9,7 +9,6 @@ setup_build_opts() {
 		"|--ta_host ${TA_HOST}"
 		"|--db_host ${DB_HOST}"
 		"|--quiet"
-		"|--proxy_passthrough"
 		"--define db=enable|"
 		"--define build_type=debug|"
 		"--define build_type=profile|"

--- a/tests/regression/run-api-with-mqtt.sh
+++ b/tests/regression/run-api-with-mqtt.sh
@@ -22,7 +22,7 @@ for ((i = 0; i < ${#OPTIONS[@]}; i++)); do
 	cli_arg=${option} | cut -d '|' -f 1
 	build_arg=${option} | cut -d '|' -f 2
 
-	bazel run accelerator --define mqtt=enable ${build_arg} -- --quiet --ta_port=${TA_PORT} ${cli_arg} &
+	bazel run accelerator --define mqtt=enable ${build_arg} -- --quiet --ta_port=${TA_PORT} ${cli_arg} --proxy_passthrough &
 	TA=$!
 	trap "kill -9 ${TA};" INT # Trap SIGINT from Ctrl-C to stop TA
 

--- a/tests/regression/run-api.sh
+++ b/tests/regression/run-api.sh
@@ -22,7 +22,7 @@ for ((i = 0; i < ${#OPTIONS[@]}; i++)); do
 	cli_arg=$(echo ${option} | cut -d '|' -f 2)
 	build_arg=$(echo ${option} | cut -d '|' -f 1)
 
-	bazel run accelerator ${build_arg} -- --ta_port=${TA_PORT} ${cli_arg} &
+	bazel run accelerator ${build_arg} -- --ta_port=${TA_PORT} ${cli_arg} --proxy_passthrough &
 	TA=$!
 	trap "kill -9 ${TA};" INT # Trap SIGINT from Ctrl-C to stop TA
 
@@ -34,11 +34,6 @@ for ((i = 0; i < ${#OPTIONS[@]}; i++)); do
 		fi
 	done <<<$(nc -U -l $socket | tr '\0' '\n')
 	echo "==============TA has successfully started=============="
-
-	python3 tests/regression/runner.py ${remaining_args} --url localhost:${TA_PORT}
-	rc=$?
-
-	trap "kill -9 ${TA};" INT # Trap SIGINT from Ctrl-C to stop TA
 
 	python3 tests/regression/runner.py ${remaining_args} --url localhost:${TA_PORT}
 	rc=$?

--- a/tests/regression/test_suite/send_trytes.py
+++ b/tests/regression/test_suite/send_trytes.py
@@ -3,6 +3,7 @@ import json
 import unittest
 import time
 import logging
+from urllib import request
 import urllib3
 
 class SendTrytes(unittest.TestCase):
@@ -80,16 +81,13 @@ class SendTrytes(unittest.TestCase):
                 "command": "getTransactionsToApprove",
                 "depth": 4,
             }
-
-            stringified = json.dumps(command)
-
             headers = {
                 'content-type': 'application/json',
                 'X-IOTA-API-Version': '1'
             }
             global URL
-            request = urllib3.Request(url=URL, data=stringified, headers=headers)
-            returnData = urllib3.urlopen(request).read()
+            req = request.Request(url=URL, data=json.dumps(command).encode(), headers=headers)
+            returnData = request.urlopen(req).read()
 
             jsonData = json.loads(returnData)
             rand_trytes.append(all_9_context + jsonData["trunkTransaction"] +


### PR DESCRIPTION
Fixes #717.
Since "tips/pair" API is removed, we can no longer depend on
the original API.

However, the original modification to send_trytes test suite
depends on the proxy_passthrough feature. Therefore, I removed
proxy_passthrough from build options and enable it everytime we
run the regression test.