### PR TITLE
fix(Endpoint): Specify host info from CLI

### DIFF
--- a/tests/endpoint/common.sh
+++ b/tests/endpoint/common.sh
@@ -29,3 +29,22 @@ function setup_leaf() {
 	fi
 	leaf --non-interactive setup legato-latest -p "$1"
 }
+
+function validate_host() {
+	if [[ $1 =~ ^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+		return 0
+	fi
+	if host "$1" > /dev/null 2>&1; then
+		return 0
+	fi
+	echo "Please enter a valid host or ip address"
+	exit 1
+}
+
+function validate_port() {
+	re='^[0-9]+$'
+	if ! [[ $1 =~ $re ]]; then
+		echo "Please enter a valid port number"
+		exit 1
+	fi
+}

--- a/tests/endpoint/test-WP77.sh
+++ b/tests/endpoint/test-WP77.sh
@@ -1,4 +1,10 @@
 #!/usr/bin/env bash
+# Usage: ./test-WP77.sh [HOST or IP] [PORT]
+
+if [ "$#" -ne 2 ]; then
+	echo "Usage: ./test-WP77.sh [HOST or IP] [PORT]" >&2
+	exit 1
+fi
 
 set -uo pipefail
 
@@ -10,8 +16,12 @@ if [ ! -f "$COMMON_FILE" ]; then
 fi
 source $COMMON_FILE
 
+# Check ip is validity or not
+validate_host "$1"
+validate_port "$2"
+
 # setup WP77 leaf shell
 setup_leaf "swi-wp77_3.4.0"
 
-make TESTS=true EP_TARGET=wp77xx EP_TA_HOST=node.deviceproof.org EP_TA_PORT=5566 legato &&
+make TESTS=true EP_TARGET=wp77xx EP_TA_HOST="$1" EP_TA_PORT="$2" legato &&
 	tar zcf endpoint.tgz endpoint/_build_endpoint/wp77xx/app/endpoint/staging/read-only/

--- a/tests/endpoint/test-endpoint.sh
+++ b/tests/endpoint/test-endpoint.sh
@@ -1,9 +1,27 @@
 #!/usr/bin/env bash
+# Usage: ./test-endpoint.sh [HOST or IP] [PORT]
+
+if [ "$#" -ne 2 ]; then
+	echo "Usage: ./test-endpoint.sh [HOST or IP] [PORT]" >&2
+	exit 1
+fi
 
 set -euo pipefail
 
+COMMON_FILE="tests/endpoint/common.sh"
+
+if [ ! -f "$COMMON_FILE" ]; then
+	echo "$COMMON_FILE is not exists."
+	exit 1
+fi
+source $COMMON_FILE
+
+# Check ip is validity or not
+validate_host "$1"
+validate_port "$2"
+
 # Create endpoint app
-make EP_TA_HOST=node.deviceproof.org EP_TA_PORT=5566 legato
+make EP_TA_HOST="$1" EP_TA_PORT="$2" legato
 
 # Run endpoint app test here
 endpoint/_build_endpoint/localhost/app/endpoint/staging/read-only/bin/endpoint


### PR DESCRIPTION
Change the host and port input from the terminal will let endpoint
to test on buildkite more friendly.

Close #729