### PR TITLE
fix(Endpoint): Add data connection for socket connection

### DIFF
--- a/docs/endpoint.md
+++ b/docs/endpoint.md
@@ -59,6 +59,7 @@ For setting `host`, `port` and `ssl seed` during compile-time. Add `EP_TA_HOST=x
 ```shell
 $ git clone https://github.com/DLTcollab/tangle-accelerator.git
 $ cd tangle-accelerator
+$ leaf shell
 $ make EP_TARGET=wp77xx EP_TA_HOST=node.deviceproof.org EP_TA_PORT=5566 legato # build endpoint as wp77xx target, and set the connected host to "node.deviceproof.org" with port 5566
 $ make TESTS=true EP_TARGET=wp77xx EP_TA_HOST=node.deviceproof.org EP_TA_PORT=5566 legato # build endpoint as wp77xx target in test mode
 ```

--- a/endpoint/endpoint.adef
+++ b/endpoint/endpoint.adef
@@ -11,13 +11,37 @@ processes:
     }
 }
 
+requires:
+{
+    file:
+    {
+        // needed for curl itself:
+        /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
+        /usr/bin/curl /usr/bin/curl
+
+        // needed for networking:
+        /lib/libnss_compat.so.2 /lib/
+        /lib/libnss_files.so.2 /lib/
+        /lib/libnss_dns.so.2 /lib/
+        /lib/libresolv.so.2 /lib/
+        /etc/nsswitch.conf /etc/
+        /etc/hosts /etc/
+        /etc/resolv.conf /etc/
+
+        /bin/sh /bin/sh
+        /bin/date /bin/date
+    }
+}
+
 #if ${LEGATO_TARGET} = localhost
 #else
 bindings:
 {
     endpoint.endpointComp.le_secStore -> secStore.le_secStore
     endpoint.endpointComp.le_sim -> modemService.le_sim
+    endpoint.endpointComp.le_mdc -> modemService.le_mdc
+    endpoint.endpointComp.le_data -> dataConnectionService.le_data
 }
 #endif
-
+sandboxed: false
 start: manual

--- a/endpoint/endpointComp/Component.cdef
+++ b/endpoint/endpointComp/Component.cdef
@@ -102,6 +102,8 @@ requires:
     {
         le_secStore.api
         modemServices/le_sim.api
+        modemServices/le_mdc.api
+        le_data.api    [manual-start]
     }
 }
 #endif

--- a/endpoint/platform/wp77xx/build.mk
+++ b/endpoint/platform/wp77xx/build.mk
@@ -5,4 +5,5 @@
 # "LICENSE" at the root of this distribution.
 
 platform-build-command = \
-	cd endpoint && leaf shell -c "mkapp -v -t wp77xx $(LEGATO_FLAGS) endpoint.adef"
+	cd endpoint && \
+	mkapp -v -t wp77xx $(LEGATO_FLAGS) -i ${LEGATO_ROOT}/interfaces/modemServices endpoint.adef

--- a/tests/endpoint/common.sh
+++ b/tests/endpoint/common.sh
@@ -34,7 +34,7 @@ function validate_host() {
 	if [[ $1 =~ ^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
 		return 0
 	fi
-	if host "$1" > /dev/null 2>&1; then
+	if host "$1" >/dev/null 2>&1; then
 		return 0
 	fi
 	echo "Please enter a valid host or ip address"


### PR DESCRIPTION
This commits add the data API and the library required by the socket connection.

The sandboxed option should be set to "true" after the DNS problem fixed
by the new firmware release.

The leaf shell should be started manually since the interface search
path for legato was added.

Close #710
