### PR TITLE
fix(tests): Fix regression tests connection failure

### DIFF
--- a/tests/regression/router-sanitizer.sh
+++ b/tests/regression/router-sanitizer.sh
@@ -33,7 +33,7 @@ for ((i = 0; i < ${#SAN_OPTIONS[@]}; i++)); do
 	done <<<$(nc -U -l $socket | tr '\0' '\n')
 	echo "==============TA has successfully started=============="
 
-	python3 tests/regression/runner.py ${remaining_args} --url localhost:${TA_PORT}
+	python3 tests/regression/runner.py ${remaining_args} --url ${TA_HOST}:${TA_PORT}
 	rc=$?
 
 	if [ $rc -ne 0 ]; then

--- a/tests/regression/run-api.sh
+++ b/tests/regression/run-api.sh
@@ -35,7 +35,7 @@ for ((i = 0; i < ${#OPTIONS[@]}; i++)); do
 	done <<<$(nc -U -l $socket | tr '\0' '\n')
 	echo "==============TA has successfully started=============="
 
-	python3 tests/regression/runner.py ${remaining_args} --url localhost:${TA_PORT}
+	python3 tests/regression/runner.py ${remaining_args} --url ${TA_HOST}:${TA_PORT}
 	rc=$?
 
 	if [ $rc -ne 0 ]; then


### PR DESCRIPTION
Regression tests failed to connect to tangle-accelerator.
The URL in testing scripts are using environment variable
instead of hard-coded URL now.

Fixes #746


