### PR TITLE
fix(tests): Fix the issues regression test hangs

### DIFF
--- a/accelerator/cli_info.h
+++ b/accelerator/cli_info.h
@@ -56,6 +56,7 @@ typedef enum ta_cli_arg_value_e {
   COMPLETE_LIST,
   HTTP_THREADS_CLI,
   CACHE_CAPACITY,
+  IPC,
 
   /** LOGGER */
   QUIET,
@@ -89,6 +90,7 @@ static struct ta_cli_argument_s {
     {"mwm", optional_argument, NULL, MWM_CLI, "minimum weight magnitude"},
     {"seed", optional_argument, NULL, SEED_CLI, "IOTA seed"},
     {"cache", required_argument, NULL, CACHE, "Enable/Disable cache server. It defaults to off"},
+    {"ipc", required_argument, NULL, IPC, "Set the socket name of initializing notification"},
     {"config", required_argument, NULL, CONF_CLI, "Read configuration file"},
     {"proxy_passthrough", no_argument, NULL, PROXY_API, "Pass proxy API directly to IOTA full node without processing"},
     {"health_track_period", no_argument, NULL, HEALTH_TRACK_PERIOD,

--- a/accelerator/config.c
+++ b/accelerator/config.c
@@ -198,6 +198,9 @@ status_t cli_core_set(ta_core_t* const core, int key, char* const value) {
       }
 
       break;
+    case IPC:
+      ta_conf->socket = strdup(value);
+      break;
 
 #ifdef MQTT_ENABLE
     // MQTT configuration
@@ -334,6 +337,7 @@ status_t ta_core_default_init(ta_core_t* const core) {
   }
   ta_conf->http_tpool_size = DEFAULT_HTTP_TPOOL_SIZE;
   ta_conf->health_track_period = HEALTH_TRACK_PERIOD;
+  ta_conf->socket = DOMAIN_SOCKET;
 #ifdef MQTT_ENABLE
   ta_conf->mqtt_host = MQTT_HOST;
   ta_conf->mqtt_topic_root = TOPIC_ROOT;
@@ -611,9 +615,8 @@ void ta_logger_switch(bool quiet, bool init, ta_config_t* ta_conf) {
   }
 }
 
-#define DOMAIN_SOCKET "/tmp/tangle-accelerator-socket"
 #define START_NOTIFICATION "TA-START"
-void notification_trigger() {
+void notification_trigger(ta_config_t* const ta_conf) {
   int connect_fd;
   static struct sockaddr_un srv_addr;
 
@@ -625,7 +628,7 @@ void notification_trigger() {
   }
 
   srv_addr.sun_family = AF_UNIX;
-  strncpy(srv_addr.sun_path, DOMAIN_SOCKET, strlen(DOMAIN_SOCKET));
+  strncpy(srv_addr.sun_path, ta_conf->socket, strlen(ta_conf->socket));
 
   // Connect to UNIX domain socket server
   if (connect(connect_fd, (struct sockaddr*)&srv_addr, sizeof(srv_addr)) == -1) {
@@ -640,5 +643,5 @@ void notification_trigger() {
 
 done:
   close(connect_fd);
-  unlink(DOMAIN_SOCKET);
+  unlink(ta_conf->socket);
 }

--- a/accelerator/config.c
+++ b/accelerator/config.c
@@ -640,4 +640,5 @@ void notification_trigger() {
 
 done:
   close(connect_fd);
+  unlink(DOMAIN_SOCKET);
 }

--- a/accelerator/config.h
+++ b/accelerator/config.h
@@ -80,6 +80,7 @@ extern "C" {
 #define RESULT_SET_LIMIT \
   100 /**< The maximun returned transaction object number when querying transaction object by tag */
 #define FILE_PATH_SIZE 128
+#define DOMAIN_SOCKET "/tmp/tangle-accelerator-socket"
 
 /** struct type of accelerator configuration */
 typedef struct ta_config_s {
@@ -95,6 +96,7 @@ typedef struct ta_config_s {
 #endif
   uint8_t http_tpool_size; /**< Thread count of tangle-accelerator instance */
   uint32_t cli_options;    /**< Command line options */
+  char* socket;            /**< UNIX domain socket for notify initialization */
 } ta_config_t;
 
 /** Command line options */
@@ -246,8 +248,10 @@ status_t ta_set_iota_client_service(iota_client_service_t* service, char const* 
 
 /**
  * @brief Notify other process with unix domain socket
+ *
+ * @param[in] ta_conf Tangle-accelerator configuration variables
  */
-void notification_trigger();
+void notification_trigger(ta_config_t* const ta_conf);
 
 /**
  * @brief Check whether a command line option is enabled or not

--- a/accelerator/main.c
+++ b/accelerator/main.c
@@ -76,7 +76,7 @@ int main(int argc, char* argv[]) {
   ta_logger_switch(is_option_enabled(&ta_core.ta_conf, CLI_QUIET_MODE), true, &(ta_core.ta_conf));
 
   // Once tangle-accelerator finished initializing, notify regression test script with unix domain socket
-  notification_trigger();
+  notification_trigger(&ta_core.ta_conf);
 
   /* pause() cause TA to sleep until it catch a signal,
    * also the return value and errno should be -1 and EINTR on success.

--- a/tests/regression/common.sh
+++ b/tests/regression/common.sh
@@ -7,9 +7,7 @@ setup_build_opts() {
 		"|--node_host ${NODE_HOST}"
 		"|--node_port ${NODE_PORT}"
 		"|--ta_host ${TA_HOST}"
-		"|--db_host ${DB_HOST}"
 		"|--quiet"
-		"--define db=enable|"
 		"--define build_type=debug|"
 		"--define build_type=profile|"
 	)

--- a/tests/regression/common.sh
+++ b/tests/regression/common.sh
@@ -56,9 +56,6 @@ check_env() {
 
 # Parse command line arguments
 get_cli_args() {
-	socket=$1
 	shift
 	remaining_args=$@ # Get the remaining arguments
 }
-
-start_notification="TA-START"

--- a/tests/regression/run-api-with-db.sh
+++ b/tests/regression/run-api-with-db.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+
+source tests/regression/common.sh
+
+check_env
+setup_build_opts
+
+# Get command line arguments
+# Current arguments parsed are <socket name> <remaining_args>
+get_cli_args $@
+
+# Install prerequisites
+make
+pip3 install --user -r tests/regression/requirements.txt
+
+# FIXME: Check Redis status
+redis-server &
+
+# Iterate over all available build options
+for ((i = 0; i < ${#OPTIONS[@]}; i++)); do
+	option=${OPTIONS[${i}]}
+	cli_arg=$(echo ${option} | cut -d '|' -f 2)
+	build_arg=$(echo ${option} | cut -d '|' -f 1)
+
+	bazel run accelerator --define db=enable ${build_arg} -- --ta_port=${TA_PORT} ${cli_arg} --db_host=${DB_HOST}  --proxy_passthrough &
+	TA=$!
+	trap "kill -9 ${TA};" INT # Trap SIGINT from Ctrl-C to stop TA
+
+	# Wait until tangle-accelerator has been initialized
+	echo "==============Wait for TA starting=============="
+	while read -r line; do
+		if [[ "$line" == "$start_notification" ]]; then
+			echo "$line"
+		fi
+	done <<<$(nc -U -l $socket | tr '\0' '\n')
+	echo "==============TA has successfully started=============="
+
+	python3 tests/regression/runner.py ${remaining_args} --url ${TA_HOST}:${TA_PORT}
+	rc=$?
+
+	if [ $rc -ne 0 ]; then
+		echo "Build option '${option}' failed"
+		fail+=("${option}")
+	else
+		success+=("${option}")
+	fi
+
+	bazel clean
+	wait $(kill -9 ${TA})
+done
+
+echo "--------- Successful build options ---------"
+for ((i = 0; i < ${#success[@]}; i++)); do echo ${success[${i}]}; done
+echo "----------- Failed build options -----------"
+for ((i = 0; i < ${#fail[@]}; i++)); do echo ${fail[${i}]}; done
+
+if [ ${#fail[@]} -gt 0 ]; then
+	exit 1
+fi

--- a/tests/regression/run-api-with-mqtt.sh
+++ b/tests/regression/run-api-with-mqtt.sh
@@ -21,19 +21,24 @@ for ((i = 0; i < ${#OPTIONS[@]}; i++)); do
 	option=${OPTIONS[${i}]}
 	cli_arg=${option} | cut -d '|' -f 1
 	build_arg=${option} | cut -d '|' -f 2
+	socket=$(mktemp)
 
-	bazel run accelerator --define mqtt=enable ${build_arg} -- --quiet --ta_port=${TA_PORT} ${cli_arg} --proxy_passthrough &
+	bazel run accelerator --define mqtt=enable ${build_arg} -- --quiet --ta_port=${TA_PORT} ${cli_arg} --socket=${socket} --proxy_passthrough &
 	TA=$!
 	trap "kill -9 ${TA};" INT # Trap SIGINT from Ctrl-C to stop TA
 
-	# Wait until tangle-accelerator has been initialized
-	echo "==============Wait for TA starting=============="
-	while read -r line; do
-		if [[ "$line" == "$start_notification" ]]; then
-			echo "$line"
-		fi
-	done <<<$(nc -U -l $socket | tr '\0' '\n')
-	echo "==============TA has successfully started=============="
+	# if tangle-accelerator takes more than 30 secs to initialize, then exit and return failure.
+	timeout 30 tests/regression/ta_waiting.sh
+	ret_code=$?
+	if [[ $ret_code -eq 124 ]]; then
+		echo "Timeout in initializing tangle-accelerator."
+		kill -9 ${TA}
+		exit 1
+	elif [[ $ret_code -eq 1 ]]; then
+		echo "Failed to connect to UNIX domain socket."
+		kill -9 ${TA}
+		exit 1
+	fi
 
 	python3 tests/regression/runner.py ${remaining_args} --url "localhost" --mqtt
 	rc=$?

--- a/tests/regression/run-api.sh
+++ b/tests/regression/run-api.sh
@@ -21,19 +21,24 @@ for ((i = 0; i < ${#OPTIONS[@]}; i++)); do
 	option=${OPTIONS[${i}]}
 	cli_arg=$(echo ${option} | cut -d '|' -f 2)
 	build_arg=$(echo ${option} | cut -d '|' -f 1)
+	socket=$(mktemp)
 
-	bazel run accelerator ${build_arg} -- --ta_port=${TA_PORT} ${cli_arg} --proxy_passthrough &
+	bazel run accelerator ${build_arg} -- --ta_port=${TA_PORT} ${cli_arg} --proxy_passthrough --socket=${socket} &
 	TA=$!
 	trap "kill -9 ${TA};" INT # Trap SIGINT from Ctrl-C to stop TA
 
-	# Wait until tangle-accelerator has been initialized
-	echo "==============Wait for TA starting=============="
-	while read -r line; do
-		if [[ "$line" == "$start_notification" ]]; then
-			echo "$line"
-		fi
-	done <<<$(nc -U -l $socket | tr '\0' '\n')
-	echo "==============TA has successfully started=============="
+	# if tangle-accelerator takes more than 30 secs to initialize, then exit and return failure.
+	timeout 30 tests/regression/ta_waiting.sh
+	ret_code=$?
+	if [[ $ret_code -eq 124 ]]; then
+		echo "Timeout in initializing tangle-accelerator."
+		kill -9 ${TA}
+		exit 1
+	elif [[ $ret_code -eq 1 ]]; then
+		echo "Failed to connect to UNIX domain socket."
+		kill -9 ${TA}
+		exit 1
+	fi
 
 	python3 tests/regression/runner.py ${remaining_args} --url ${TA_HOST}:${TA_PORT}
 	rc=$?

--- a/tests/regression/ta_waiting.sh
+++ b/tests/regression/ta_waiting.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+socket=$1
+
+# Whether tangle-accelerator successfully initialzed
+success=0
+
+start_notification="TA-START"
+# Wait until tangle-accelerator has been initialized
+echo "==============Wait for TA starting=============="
+while read -r line; do
+	if [[ "$line" == "$start_notification" ]]; then
+		echo "nc info: $line"
+		success=1
+	fi
+done <<<$(nc -U -l $socket | tr '\0' '\n')
+echo "==============TA has successfully started=============="
+
+if [ "$success" -eq 1 ]; then
+	exit 0
+else
+	exit 1
+fi


### PR DESCRIPTION
Regression tests were hanging since sometimes the file of UNIX domain socket may exist. The existence of UNIX domain socket may be caused by tangle-accelerator didn't  be successfully terminated. Sometimes regression tests were cancelled or failed, in these cases tangle-accelerator may not be terminated, and the port has been used by this hanging tangle-accelerator. We may use docker to solve this issue