### PR TITLE
fix(cache): Report when cache failed to initialize

### DIFF
--- a/accelerator/config.c
+++ b/accelerator/config.c
@@ -192,7 +192,7 @@ status_t cli_core_set(ta_core_t* const core, int key, char* const value) {
       ta_log_info("Initializing cache state\n");
       cache->state = !cache->state;
       if (cache->state) {
-        if (cache_init(&cache->rwlock, cache->state, cache->host, cache->port)) {
+        if (!cache_init(&cache->rwlock, cache->state, cache->host, cache->port)) {
           ta_log_error("%s\n", "Failed to initialize lock to caching service.");
         }
       }

--- a/utils/cache/backend_redis.c
+++ b/utils/cache/backend_redis.c
@@ -266,6 +266,7 @@ void redis_get_capacity(redisContext* c) {
 bool cache_init(pthread_rwlock_t** rwlock, bool input_state, const char* host, int port) {
   state = input_state;
   if (!state) {
+    ta_log_error("Caching service is not enabled.\n");
     return false;
   }
 


### PR DESCRIPTION
Tangle-accelerator reports failed to initialize caching service, when
caching service successfully started.