### PR TITLE
feat(Endpoint): Implement OBDII component

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -99,8 +99,9 @@ pem/*.inc
 # Legato app related files
 resolv.conf
 output_base/
-_build_endpoint/
-endpoint.*.update
+endpoint/_build_*/
+_build_*/
+*.*.update
 .repo
 legato/
 build/

--- a/.gitmodules
+++ b/.gitmodules
@@ -7,6 +7,9 @@
 [submodule "third_party/mosquitto"]
 	path = third_party/mosquitto
 	url = https://github.com/eclipse/mosquitto.git
+[submodule "third_party/brotli"]
+	path = third_party/brotli
+	url = https://github.com/google/brotli.git
 [submodule "third_party/flatcc"]
 	path = third_party/flatcc
 	url = https://github.com/dvidelabs/flatcc.git

--- a/common/ta_errors.c
+++ b/common/ta_errors.c
@@ -196,7 +196,14 @@ const char* ta_error_to_string(status_t err) {
       return "Error occurred when get device id from endpoint device";
     case SC_ENDPOINT_DNS_RESOLVE_ERROR:
       return "Error occurred when resolving the domain name";
-
+    case SC_ENDPOINT_CAN_OPEN_ERROR:
+      return "Error occurred when opening CAN BUS socket";
+    case SC_ENDPOINT_CAN_SEND_ERROR:
+      return "Error occurred when writing message into CAN BUS socket";
+    case SC_ENDPOINT_CAN_RECV_ERROR:
+      return "Error occurred when reading message from CAN BUS socket";
+    case SC_ENDPOINT_CAN_CLOSE_ERROR:
+      return "Error occurred when closing CAN BUS socket";
     default:
       return "Unknown error.";
   }

--- a/common/ta_errors.h
+++ b/common/ta_errors.h
@@ -260,6 +260,14 @@ typedef enum {
   /**< Failed to get the device id */
   SC_ENDPOINT_DNS_RESOLVE_ERROR = 0x0B | SC_MODULE_ENDPOINT | SC_SEVERITY_FATAL,
   /**< Failed to resolve the domain name address */
+  SC_ENDPOINT_CAN_OPEN_ERROR = 0x0C | SC_MODULE_ENDPOINT | SC_SEVERITY_FATAL,
+  /**< Failed to open CAN BUS socket */
+  SC_ENDPOINT_CAN_SEND_ERROR = 0x0D | SC_MODULE_ENDPOINT | SC_SEVERITY_FATAL,
+  /**< Failed to write message to CAN BUS socket */
+  SC_ENDPOINT_CAN_RECV_ERROR = 0x0E | SC_MODULE_ENDPOINT | SC_SEVERITY_FATAL,
+  /**< Failed to read message from CAN BUS socket */
+  SC_ENDPOINT_CAN_CLOSE_ERROR = 0x0F | SC_MODULE_ENDPOINT | SC_SEVERITY_FATAL,
+  /**< Failed to close CAN BUS socket */
 
 } status_t;
 

--- a/docs/endpoint.md
+++ b/docs/endpoint.md
@@ -9,6 +9,10 @@ A message sent by endpoint needs to be encrypted locally, which avoids message b
 
 ## How to build endpoint
 
+### Install flatcc compiler
+The endpoint use flatbuffer as serializer. The `flatcc` tool should be found in `$PATH` environment variable.
+About the installation of flatcc compiler, you can refer to [dvidelabs flatcc](https://github.com/dvidelabs/flatcc#quickstart).
+
 ### Setup Legato application framework development environment
 
 The endpoint uses the Legato application framework as based runtime system. Developers need to set up the Sierra development environment to build endpoint as specific target.

--- a/endpoint/Makefile
+++ b/endpoint/Makefile
@@ -5,6 +5,7 @@ TARGETS := wp77xx
 # Third party library
 FLATCC_DIR=$(ROOT_DIR)/third_party/flatcc
 MBEDTLS_DIR=$(ROOT_DIR)/third_party/mbedtls
+BROTLI_DIR=$(ROOT_DIR)/third_party/brotli
 
 OBD_SCHEMA=$(ROOT_DIR)/third_party/vehicle-scheme/vehicle_obd.fbs
 ENDPOINT_SCHEMA=$(ROOT_DIR)/third_party/vehicle-scheme/endpoint.fbs
@@ -18,8 +19,10 @@ FLATCC_CMAKE_DIR=$(OUT)/flatcc
 MBEDTLS_INCLUDE=$(MBEDTLS_DIR)/include
 MBEDTLS_LIB=$(MBEDTLS_DIR)/library
 
-INCLUDE_FLAGS=-I../ -I$(FLATCC_INCLUDE) -I$(MBEDTLS_INCLUDE)
-LDFLAGS=-L$(FLATCC_LIB) -L$(MBEDTLS_LIB) -lmbedcrypto -lmbedx509 -lmbedtls -lflatccrt -lm
+BROTLI_INCLUDE=$(BROTLI_DIR)/c/include
+
+INCLUDE_FLAGS=-I../ -I$(FLATCC_INCLUDE) -I$(MBEDTLS_INCLUDE) -I$(BROTLI_INCLUDE) 
+LDFLAGS=-L$(FLATCC_LIB) -L$(MBEDTLS_LIB) -L$(BROTLI_DIR) -lbrotli -lmbedcrypto -lmbedx509 -lmbedtls -lflatccrt -lm
 
 THIRD_PARTY_CFLAGS= -fPIC
 
@@ -50,6 +53,9 @@ obd_header:
 mbedtls_lib:
 	$(MAKE) -C $(MBEDTLS_DIR) CC=$(CC) CFLAGS=$(THIRD_PARTY_CFLAGS) lib
 
+brotli_lib:
+	$(MAKE) -C $(BROTLI_DIR) CC=$(CC) CFLAGS=$(THIRD_PARTY_CFLAGS) lib
+
 flatcc_lib:
 	mkdir -p $(FLATCC_CMAKE_DIR)
 	cd $(FLATCC_CMAKE_DIR); \
@@ -64,11 +70,12 @@ flatcc_lib:
 
 clean:
 	$(MAKE) -C $(MBEDTLS_DIR) clean
-	rm -rf build
+	$(MAKE) -C $(BROTLI_DIR) clean
+	rm -rf $(OUT) 
 	rm -rf _build_* *.*.update
 
 simulator: export LEGATO_ROOT=$(PWD)/legato
-simulator: obd_header mbedtls_lib flatcc_lib
+simulator: obd_header mbedtls_lib flatcc_lib brotli_lib
 	export PATH=$(LEGATO_ROOT)/bin:$(LEGATO_ROOT)build/localhost/framework/bin:$(PATH) ; \
 	export LEGATO_TARGET=localhost ; \
 	mkapp -v -t localhost \
@@ -79,13 +86,28 @@ simulator: obd_header mbedtls_lib flatcc_lib
 		  -C -fPIC \
 		  -C -DEP_TARGET=simulator \
           --interface-search=$(LEGATO_ROOT)/interfaces/modemServices \
-          endpoint.adef
+          endpoint.adef  && \
+	mkapp -t localhost \
+		  $(LEGATO_INCLUDE_FLAGS) \
+		  $(LEGATO_LDFLAGS) \
+		  $(LEGATO_FLAGS) \
+		  -C -DENABLE_ENDPOINT_TEST \
+		  -C -fPIC \
+		  -C -DEP_TARGET=simulator \
+          --interface-search=$(LEGATO_ROOT)/interfaces/modemServices \
+          OBDMonitor.adef
 
 $(TARGETS): export TARGET=$@
-$(TARGETS): obd_header mbedtls_lib flatcc_lib
+$(TARGETS): obd_header mbedtls_lib flatcc_lib brotli_lib
 	mkapp -v -t $@ \
 		  $(LEGATO_INCLUDE_FLAGS) \
 		  $(LEGATO_LDFLAGS) \
 		  $(LEGATO_FLAGS) \
           --interface-search=$(LEGATO_ROOT)/interfaces/modemServices \
           endpoint.adef
+	mkapp -t $@ \
+		  $(LEGATO_INCLUDE_FLAGS) \
+		  $(LEGATO_LDFLAGS) \
+		  $(LEGATO_FLAGS) \
+          --interface-search=$(LEGATO_ROOT)/interfaces/modemServices \
+          OBDMonitor.adef

--- a/endpoint/OBDComp/BUILD
+++ b/endpoint/OBDComp/BUILD
@@ -1,0 +1,6 @@
+package(default_visibility = ["//visibility:public"])
+
+cc_library(
+    name = "obd_pid",
+    hdrs = ["obd_pid.h"],
+)

--- a/endpoint/OBDComp/can-bus/BUILD
+++ b/endpoint/OBDComp/can-bus/BUILD
@@ -1,0 +1,10 @@
+package(default_visibility = ["//visibility:public"])
+
+cc_library(
+    name = "can-utils",
+    srcs = ["can-utils.c"],
+    hdrs = ["can-utils.h"],
+    deps = [
+        "//common:ta_errors",
+    ],
+)

--- a/endpoint/OBDComp/can-bus/can-utils.c
+++ b/endpoint/OBDComp/can-bus/can-utils.c
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2019-2020 BiiLabs Co., Ltd. and Contributors
+ * All Rights Reserved.
+ * This is free software; you can redistribute it and/or modify it under the
+ * terms of the MIT license. A copy of the license can be found in the file
+ * "LICENSE" at the root of this distribution.
+ */
+
+#include "can-utils.h"
+
+// Linux headers
+#include <net/if.h>
+#include <sys/ioctl.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+#include <stdio.h>
+#include <string.h>
+
+status_t can_open(char* dev, int* fd) {
+  int s;
+  struct sockaddr_can addr;
+  struct ifreq ifr;
+  status_t ret = SC_OK;
+  if ((s = socket(PF_CAN, SOCK_RAW, CAN_RAW)) < 0) {
+    ret = SC_ENDPOINT_CAN_OPEN_ERROR;
+    goto exit;
+  }
+
+  snprintf(ifr.ifr_name, IFNAMSIZ, "%s", dev);
+  ioctl(s, SIOCGIFINDEX, &ifr);
+
+  memset(&addr, 0, sizeof(addr));
+  addr.can_family = AF_CAN;
+  addr.can_ifindex = ifr.ifr_ifindex;
+
+  if (bind(s, (struct sockaddr*)&addr, sizeof(addr)) < 0) {
+    ret = SC_ENDPOINT_CAN_OPEN_ERROR;
+    goto exit;
+  }
+  *fd = s;
+exit:
+  if (ret != SC_OK) can_close(s);
+  return ret;
+}
+
+status_t can_close(int fd) {
+  if (close(fd) < 0) {
+    return SC_ENDPOINT_CAN_CLOSE_ERROR;
+  }
+  return SC_OK;
+}
+
+status_t can_send(int fd, struct can_frame* frame) {
+  if (write(fd, frame, sizeof(struct can_frame)) != sizeof(struct can_frame)) {
+    return SC_ENDPOINT_CAN_SEND_ERROR;
+  }
+  return SC_OK;
+}
+
+status_t can_recv(int fd, struct can_frame* frame) {
+  if (read(fd, frame, sizeof(struct can_frame)) < 0) {
+    return SC_ENDPOINT_CAN_RECV_ERROR;
+  }
+  return SC_OK;
+}

--- a/endpoint/OBDComp/can-bus/can-utils.h
+++ b/endpoint/OBDComp/can-bus/can-utils.h
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2019-2020 BiiLabs Co., Ltd. and Contributors
+ * All Rights Reserved.
+ * This is free software; you can redistribute it and/or modify it under the
+ * terms of the MIT license. A copy of the license can be found in the file
+ * "LICENSE" at the root of this distribution.
+ */
+
+#ifndef CAN_UTILS_H
+#define CAN_UTILS_H
+
+/**
+ * @file endpoint/OBDComp/can-bus/can-utils.h
+ */
+
+#include "common/ta_errors.h"
+
+#include <linux/can.h>
+#include <linux/can/raw.h>
+
+/**
+ * @brief Open CAN BUS socket
+ *
+ * @param[in] dev CAN BUS device
+ * @param[out] fd File descriptor
+ * @return
+ * - SC_OK on success
+ * - SC_ENDPOINT_CAN_OPEN_ERROR on failed
+ */
+status_t can_open(char* dev, int* fd);
+
+/**
+ * @brief Receive CAN BUS packet
+ *
+ * @param[in] fd File descriptor
+ * @param[in] frame The buffer to store CAN BUS packet
+ * @return
+ * - SC_OK on success
+ * - SC_ENDPOINT_CAN_RECV_ERROR on failed
+ */
+status_t can_recv(int fd, struct can_frame* frame);
+
+/**
+ * @brief Send CAN BUS packet
+ *
+ * @param[in] fd File descriptor
+ * @param[in] frame The CAN BUS packet to be sent
+ * @return
+ * - SC_OK on success
+ * - SC_ENDPOINT_CAN_SEND_ERROR on failed
+ */
+status_t can_send(int fd, struct can_frame* frame);
+
+/**
+ * @brief Close CAN BUS file descriptor
+ *
+ * @param[in] fd File descriptor
+ * @return
+ * - SC_OK on success
+ * - SC_ENDPOINT_CAN_CLOSE_ERROR on failed
+ */
+status_t can_close(int fd);
+
+#endif  // CAN_UTILS_H

--- a/endpoint/OBDComp/monitor/BUILD
+++ b/endpoint/OBDComp/monitor/BUILD
@@ -1,0 +1,11 @@
+cc_binary(
+    name = "monitor",
+    srcs = [
+        "monitor.c",
+    ],
+    deps = [
+        "//common:ta_errors",
+        "//endpoint/OBDComp:obd_pid",
+        "//endpoint/OBDComp/can-bus:can-utils",
+    ],
+)

--- a/endpoint/OBDComp/monitor/Component.cdef
+++ b/endpoint/OBDComp/monitor/Component.cdef
@@ -1,0 +1,34 @@
+sources:
+{
+    monitor.c
+    ../can-bus/can-utils.c
+    ${CURDIR}/../../platform/${EP_TARGET}/impl.c
+    ${CURDIR}/../../hal/device.c
+}
+
+cflags:
+{
+    -g -O0
+
+    -I${CURDIR}/../../../
+    -I${CURDIR}/../can-bus/
+}
+
+#if ${LEGATO_TARGET} = localhost
+#else
+requires:
+{
+    device:
+    {
+        [rw] /dev/ttyHS0 /dev/ttyHS0
+    }
+    
+    api:
+    {
+        le_secStore.api
+        modemServices/le_sim.api
+        modemServices/le_mdc.api
+        le_data.api    [manual-start]
+    }
+}
+#endif

--- a/endpoint/OBDComp/monitor/monitor.c
+++ b/endpoint/OBDComp/monitor/monitor.c
@@ -1,0 +1,298 @@
+/*
+ * Copyright (C) 2019-2020 BiiLabs Co., Ltd. and Contributors
+ * All Rights Reserved.
+ * This is free software; you can redistribute it and/or modify it under the
+ * terms of the MIT license. A copy of the license can be found in the file
+ * "LICENSE" at the root of this distribution.
+ */
+
+#include "interfaces.h"
+#include "legato.h"
+
+#include "brotli/decode.h"
+#include "brotli/encode.h"
+#include "build/obd_generated.h"
+#include "endpoint/OBDComp/can-bus/can-utils.h"
+#include "endpoint/OBDComp/obd_pid.h"
+#include "hal/device.h"
+
+#include "legato.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static int string_compress(uint8_t *origin, size_t len, uint8_t **out_buffer, size_t *out_size) {
+  int lgwin = BROTLI_DEFAULT_WINDOW;
+  int bufferSize = len;
+  uint8_t *buffer = malloc(bufferSize);
+  uint8_t *inBuffer = malloc(bufferSize);
+
+  memcpy(inBuffer, origin, len);
+
+  size_t encodedSize = bufferSize;
+
+  bool brotliStatus = BrotliEncoderCompress(BROTLI_DEFAULT_QUALITY, lgwin, BROTLI_MODE_GENERIC, len,
+                                            (const uint8_t *)inBuffer, &encodedSize, buffer);
+
+  *out_buffer = buffer;
+  *out_size = encodedSize;
+
+  free(inBuffer);
+  return brotliStatus;
+}
+
+#undef ns
+#define ns(x) FLATBUFFERS_WRAP_NAMESPACE(OBD, x)  // Specified in the schema.
+
+static uint32_t hex_to_obd_data(uint8_t *arr, int offset, size_t len) {
+  uint32_t result = 0;
+
+  for (size_t i = offset; i < len; i++) {
+    result |= arr[i];
+    result = result << 4;
+  }
+  return result;
+}
+
+static char *vin_hex_to_string(uint8_t *arr, size_t len) {
+  char *str = malloc(len);
+  memset(str, 0, len);
+  memcpy(str, &arr[3], len - 3);
+  return str;
+}
+
+int create_obd2_flatbuffer(uint8_t **flat_msg, size_t *flat_buf_len, le_hashmap_Ref_t OBD_datasets) {
+  flatcc_builder_t builder;
+
+  // Initialize the builder object.
+  flatcc_builder_init(&builder);
+
+  OBD_data_t *vin_obd_data = le_hashmap_Get(OBD_datasets, "VEHICLE_IDENTIFICATION_NUMBER");
+  char *vin_id = vin_hex_to_string(vin_obd_data->data, vin_obd_data->data_len);
+
+  flatbuffers_string_ref_t vin = flatbuffers_string_create_str(&builder, vin_id);
+
+  uint32_t engine_load = hex_to_obd_data(le_hashmap_Get(OBD_datasets, "CALCULATED_ENGINE_LOAD"), 4, 8);
+  uint32_t engine_coolant_temperature =
+      hex_to_obd_data(le_hashmap_Get(OBD_datasets, "ENGINE_COOLANT_TEMPERATURE"), 4, 8);
+  uint32_t fuel_pressure = hex_to_obd_data(le_hashmap_Get(OBD_datasets, "FUEL_PRESSURE"), 4, 8);
+  uint32_t engine_speed = hex_to_obd_data(le_hashmap_Get(OBD_datasets, "ENGINE_RPM"), 4, 8);
+  uint32_t vehicle_speed = hex_to_obd_data(le_hashmap_Get(OBD_datasets, "VEHICLE_SPEED"), 4, 8);
+  uint32_t intake_air_temperature = hex_to_obd_data(le_hashmap_Get(OBD_datasets, "INTAKE_AIR_TEMPERATURE"), 4, 8);
+  uint32_t mass_air_flow = hex_to_obd_data(le_hashmap_Get(OBD_datasets, "MASS_AIR_FLOW"), 4, 8);
+  uint32_t fuel_tank_level_input = hex_to_obd_data(le_hashmap_Get(OBD_datasets, "FUEL_TANK_LEVEL_INPUT"), 4, 8);
+  uint32_t absolute_barometric_pressure =
+      hex_to_obd_data(le_hashmap_Get(OBD_datasets, "ABSOLUTE_BAROMETRIC_PRESSURE"), 4, 8);
+  uint32_t control_module_voltage = hex_to_obd_data(le_hashmap_Get(OBD_datasets, "CONTROL_MODULE_VOLTAGE"), 4, 8);
+  uint32_t throttle_position = hex_to_obd_data(le_hashmap_Get(OBD_datasets, "THROTTLE_POSITION"), 4, 8);
+  uint32_t ambient_air_temperature = hex_to_obd_data(le_hashmap_Get(OBD_datasets, "AMBIENT_AIR_TEMPERATURE"), 4, 8);
+  uint32_t relative_accelerator_pedal_position =
+      hex_to_obd_data(le_hashmap_Get(OBD_datasets, "RELATIVE_ACCELERATOR_PEDAL_POSITION"), 4, 8);
+  uint32_t engine_oil_temperature = hex_to_obd_data(le_hashmap_Get(OBD_datasets, "ENGINE_OIL_TEMPERATURE"), 4, 8);
+  uint32_t engine_fuel_rate = hex_to_obd_data(le_hashmap_Get(OBD_datasets, "ENGINE_FUEL_RATE"), 4, 8);
+  uint32_t service_distance = hex_to_obd_data(le_hashmap_Get(OBD_datasets, "SERVICE_DISTANCE"), 4, 8);
+  uint32_t anti_lock_barking_active = hex_to_obd_data(le_hashmap_Get(OBD_datasets, "ANTI_LOCK_BRAKING_ACTIVE"), 4, 8);
+  uint32_t steering_wheel_angle = hex_to_obd_data(le_hashmap_Get(OBD_datasets, "STEERING_WHEEL_ANGLE"), 4, 8);
+  uint32_t position_of_doors = hex_to_obd_data(le_hashmap_Get(OBD_datasets, "POSITION_OF_DOORS"), 4, 8);
+  uint32_t right_left_turn_signal_light =
+      hex_to_obd_data(le_hashmap_Get(OBD_datasets, "RIGHT_LEFT_TURN_SIGNAL_LIGHT"), 4, 8);
+  uint32_t alternate_beam_head_light = hex_to_obd_data(le_hashmap_Get(OBD_datasets, "ALTERNATE_BEAM_HEAD_LIGHT"), 4, 8);
+  uint32_t high_beam_head_light = hex_to_obd_data(le_hashmap_Get(OBD_datasets, "HIGH_BEAM_HEAD_LIGHT"), 4, 8);
+
+  ns(OBD2_data_ref_t) obd2_flatbuffer = ns(OBD2_data_create(
+      &builder, vin, engine_load, engine_coolant_temperature, fuel_pressure, engine_speed, vehicle_speed,
+      intake_air_temperature, mass_air_flow, fuel_tank_level_input, absolute_barometric_pressure,
+      control_module_voltage, throttle_position, ambient_air_temperature, relative_accelerator_pedal_position,
+      engine_coolant_temperature, engine_fuel_rate, service_distance, anti_lock_barking_active, steering_wheel_angle,
+      position_of_doors, right_left_turn_signal_light, alternate_beam_head_light, high_beam_head_light));
+
+  struct timespec t;
+  clock_gettime(CLOCK_MONOTONIC, &t);
+
+  device_t *device = ta_device(STRINGIZE(EP_TARGET));
+  char device_id[16] = {0};
+  device->op->get_device_id(device_id);
+
+  flatbuffers_string_ref_t deviceID = flatbuffers_string_create_str(&builder, device_id);
+  ns(OBD2Meta_ref_t) obd2_meta = ns(OBD2Meta_create(&builder, deviceID, t.tv_sec, obd2_flatbuffer));
+
+  uint8_t *buf;
+  size_t buf_size;
+
+  buf = flatcc_builder_get_direct_buffer(&builder, &buf_size);
+
+  size_t encodeSize = 0;
+  uint8_t *encode_result;
+  string_compress(buf, buf_size, &encode_result, &encodeSize);
+
+  *flat_msg = encode_result;
+  *flat_buf_len = encodeSize;
+
+  free(vin_id);
+  flatcc_builder_clear(&builder);
+  return 0;
+}
+
+enum MESSAGE_TYPE { SINGLE, FIRST, CONSECUTIVE, FLOW };
+
+static int check_message_type(struct can_frame *frame) {
+  uint8_t header_byte = frame->data[0];
+  return header_byte >> 4;
+}
+
+static le_result_t obd_query(int fd, canid_t can_id, uint8_t service, uint8_t pid, struct can_frame *frame_recv) {
+  if (frame_recv == NULL) {
+    LE_ERROR("Input frame should not be none");
+    return LE_FAULT;
+  }
+
+  struct can_frame frame;
+  memset(&frame, 0, sizeof(struct can_frame));
+  memset(frame_recv, 0, sizeof(struct can_frame));
+  frame.can_id = can_id;
+  frame.can_dlc = 8;
+
+  frame.data[0] = 2;        // Number of additional bytes
+  frame.data[1] = service;  // Service/Mode
+  frame.data[2] = pid;      // PID
+
+  can_send(fd, &frame);
+  can_recv(fd, frame_recv);
+  return LE_OK;
+}
+
+static le_result_t obd_message(int fd, struct can_frame *frame_recv, OBD_data_t *obd_data) {
+  static int append_data = 0;
+
+  size_t _size = 0;
+  uint8_t *buffer = NULL;
+
+  bool need_flow_control = false;
+  switch (check_message_type(frame_recv)) {
+    case SINGLE:
+      _size = 8;
+      buffer = malloc(_size);
+      memset(buffer, 0, _size);
+      memcpy(buffer, frame_recv->data, _size);
+      obd_data->data = buffer;
+      obd_data->data_len = _size;
+      return LE_OK;
+    case FIRST:
+      // allocate data buffer for consecutive data
+      _size = ((uint16_t)(frame_recv->data[0] & 0x0F) << 8) | frame_recv->data[1];
+      buffer = malloc(_size);
+      memset(buffer, 0, _size);
+      // copy other 6 bytes
+      memcpy(buffer, &frame_recv->data[2], 6);
+      obd_data->data = buffer;
+      obd_data->data_len = _size;
+      append_data += 6;
+      need_flow_control = true;
+      break;
+    case CONSECUTIVE:
+      // copy other 7 bytes
+      memcpy(&obd_data->data[append_data], &frame_recv->data[1], 7);
+      append_data += 7;
+      break;
+  }
+
+  if (need_flow_control) {
+    struct can_frame flow_control_frame;
+    memset(&flow_control_frame, 0, sizeof(struct can_frame));
+    flow_control_frame.can_id = frame_recv->can_id - OBD_REQUEST_RESPONSE_OFFSET;
+    flow_control_frame.can_dlc = 8;
+    flow_control_frame.data[0] = FLOW << 4;
+
+    can_send(fd, &flow_control_frame);
+  }
+
+  // check consecutive message is complete
+  if (obd_data->data_len == append_data) {
+    return LE_OK;
+  }
+  can_recv(fd, frame_recv);
+  return obd_message(fd, frame_recv, obd_data);
+}
+
+static void free_obd_hashmap_datasets(le_hashmap_Ref_t OBD_datasets) {
+  const char *next_key;
+  OBD_data_t *obd_data_ptr;
+
+  le_hashmap_It_Ref_t myIter = le_hashmap_GetIterator(OBD_datasets);
+
+  while (LE_OK == le_hashmap_NextNode(myIter)) {
+    next_key = le_hashmap_GetKey(myIter);
+    obd_data_ptr = le_hashmap_Remove(OBD_datasets, next_key);
+    free(obd_data_ptr->data);
+    free(obd_data_ptr);
+  }
+  le_hashmap_RemoveAll(OBD_datasets);
+}
+
+static void get_obd_datasets(int fd) {
+  PID *tmp_pid = PIDS;
+  struct can_frame frame_recv;
+
+  le_hashmap_Ref_t obd2_data_table =
+      le_hashmap_Create("obd2 data table", LENGTH_OF_PIDS, le_hashmap_HashString, le_hashmap_EqualsString);
+
+  for (size_t i = 0; i < LENGTH_OF_PIDS; ++i) {
+    OBD_data_t *obd_data = malloc(sizeof(OBD_data_t));
+    uint32_t pid = tmp_pid[i].pid;
+    memset(&frame_recv, 0, sizeof(frame_recv));
+    memset(obd_data, 0, sizeof(OBD_data_t));
+    obd_query(fd, OBD_BROADCAST_ID, tmp_pid[i].service, pid, &frame_recv);
+    obd_message(fd, &frame_recv, obd_data);
+    le_hashmap_Put(obd2_data_table, pid_to_string(i), obd_data);
+  }
+
+  uint8_t *flatbuffer_msg = NULL;
+  size_t flatbuffer_msg_len = 0;
+  flatcc_builder_t builder;
+  create_obd2_flatbuffer(&flatbuffer_msg, &flatbuffer_msg_len, obd2_data_table);
+  free_obd_hashmap_datasets(obd2_data_table);
+  LE_INFO("Success to create flatbuffer for obd2 datasets");
+  LE_INFO("Flatbuffer length: %zu", flatbuffer_msg_len);
+  // TODO: Send flatbuffer message via endpoint
+
+  free(flatbuffer_msg);
+}
+
+static void print_help(void) {
+  puts(
+      "NAME\n"
+      "OBDService - The obd2 service for sending OBDII message to Tangle-accelerator.\n"
+      "\n"
+      "SYNOPSIS\n"
+      "  OBDService [-h]\n"
+      "  OBDService [--help]\n"
+      "\n"
+      "OPTIONS\n"
+      "  -h\n"
+      "  --help\n"
+      "    Print the information for helping the users. Ignore other arguments.\n"
+      "  -i\n"
+      "  --can-interface\n"
+      "    Set the can interface.\n"
+      "\n");
+
+  exit(EXIT_SUCCESS);
+}
+
+COMPONENT_INIT {
+  const char *interface = NULL;
+  le_arg_SetStringVar(&interface, "i", "can-interface");
+  le_arg_SetFlagCallback(print_help, "h", "help");
+  le_arg_Scan();
+
+  if (interface == NULL) {
+    print_help();
+  }
+
+  int fd;
+  can_open((char *)interface, &fd);
+  get_obd_datasets(fd);
+  can_close(fd);
+  exit(EXIT_SUCCESS);
+}

--- a/endpoint/OBDComp/obd_pid.h
+++ b/endpoint/OBDComp/obd_pid.h
@@ -1,0 +1,88 @@
+/*
+ * Copyright (C) 2019-2020 BiiLabs Co., Ltd. and Contributors
+ * All Rights Reserved.
+ * This is free software; you can redistribute it and/or modify it under the
+ * terms of the MIT license. A copy of the license can be found in the file
+ * "LICENSE" at the root of this distribution.
+ */
+
+#ifndef OBD_PID_H
+#define OBD_PID_H
+
+#include <stdint.h>
+
+/**
+ * @file endpoint/OBDComp/obd_pid.h
+ */
+
+#define OBD_BROADCAST_ID 0x7DF
+#define OBD_FIRST_ECU_RESPONSE 0x7E8
+#define OBD_LAST_ECU_RESPONSE 0x7EF
+
+// An ECU responds to a message with an ID 8 less than the request
+// For example, the engine control unit responds with 0x7E0 (8 less than 0x7E8)
+#define OBD_REQUEST_RESPONSE_OFFSET 8
+
+/**
+ * @brief Struct of OBDII PID
+ *
+ */
+typedef struct pid {
+  uint8_t service;  //< Service
+  uint16_t pid;     //< Query PID
+} PID;
+
+typedef struct OBD_data {
+  uint8_t* data;
+  size_t data_len;
+} OBD_data_t;
+
+/**
+ * @brief List of OBDII PID
+ *
+ */
+#define PIDS_INIT_LIST                                                                      \
+  X(VEHICLE_IDENTIFICATION_NUMBER, 0x09, 0x02, "VEHICLE_IDENTIFICATION_NUMBER")             \
+  X(CALCULATED_ENGINE_LOAD, 0x01, 0x04, "CALCULATED_ENGINE_LOAD")                           \
+  X(ENGINE_COOLANT_TEMPERATURE, 0x01, 0x05, "ENGINE_COOLANT_TEMPERATURE")                   \
+  X(FUEL_PRESSURE, 0x01, 0x0A, "FUEL_PRESSURE")                                             \
+  X(ENGINE_RPM, 0x01, 0x0C, "ENGINE_RPM")                                                   \
+  X(VEHICLE_SPEED, 0x01, 0x0D, "VEHICLE_SPEED")                                             \
+  X(INTAKE_AIR_TEMPERATURE, 0x01, 0x0F, "INTAKE_AIR_TEMPERATURE")                           \
+  X(MASS_AIR_FLOW, 0x01, 0x10, "MASS_AIR_FLOW")                                             \
+  X(FUEL_TANK_LEVEL_INPUT, 0x01, 0x01F, "FUEL_TANK_LEVEL_INPUT")                            \
+  X(ABSOLUTE_BAROMETRIC_PRESSURE, 0x01, 0x33, "ABSOLUTE_BAROMETRIC_PRESSURE")               \
+  X(CONTROL_MODULE_VOLTAGE, 0x01, 0x42, "CONTROL_MODULE_VOLTAGE")                           \
+  X(THROTTLE_POSITION, 0x01, 0x45, "THROTTLE_POSITION")                                     \
+  X(AMBIENT_AIR_TEMPERATURE, 0x01, 0x46, "AMBIENT_AIR_TEMPERATURE")                         \
+  X(RELATIVE_ACCELERATOR_PEDAL_POSITION, 0x01, 0x5A, "RELATIVE_ACCELERATOR_PEDAL_POSITION") \
+  X(ENGINE_OIL_TEMPERATURE, 0x01, 0x5C, "ENGINE_OIL_TEMPERATURE")                           \
+  X(ENGINE_FUEL_RATE, 0x01, 0x5E, "ENGINE_FUEL_RATE")                                       \
+  X(SERVICE_DISTANCE, 0x01, 0xE1, "SERVICE_DISTANCE")                                       \
+  X(ANTI_LOCK_BRAKING_ACTIVE, 0x01, 0xE2, "ANTI_LOCK_BRAKING_ACTIVE")                       \
+  X(STEERING_WHEEL_ANGLE, 0x01, 0xE3, "STEERING_WHEEL_ANGLE")                               \
+  X(POSITION_OF_DOORS, 0x01, 0xE5, "POSITION_OF_DOORS")                                     \
+  X(RIGHT_LEFT_TURN_SIGNAL_LIGHT, 0x01, 0xE6, "RIGHT_LEFT_TURN_SIGNAL_LIGHT")               \
+  X(ALTERNATE_BEAM_HEAD_LIGHT, 0x01, 0xE7, "ALTERNATE_BEAM_HEAD_LIGHT")                     \
+  X(HIGH_BEAM_HEAD_LIGHT, 0x01, 0xE8, "HIGH_BEAM_HEAD_LIGHT")
+
+#define X(a, b, c, d) a,
+enum ENUM_PID { PIDS_INIT_LIST };
+#undef X
+
+static PID PIDS[] = {
+#define X(a, b, c, d) {.service = b, .pid = c},
+    PIDS_INIT_LIST
+#undef X
+};
+
+#define LENGTH_OF_PIDS (sizeof(PIDS) / sizeof(PID))
+
+static const char* pid_to_string(int value) {
+#define X(a, b, c, d) d,
+  static char* table[] = {PIDS_INIT_LIST};
+#undef X
+  return table[value];
+}
+
+#endif  // OBD_PID_H

--- a/endpoint/OBDMonitor.adef
+++ b/endpoint/OBDMonitor.adef
@@ -1,0 +1,26 @@
+executables:
+{
+    OBDService = ( OBDComp/monitor )
+}
+
+processes:
+{
+    run:
+    {
+        (OBDService)
+    }
+}
+
+sandboxed: false
+start: manual
+
+#if ${LEGATO_TARGET} = localhost
+#else
+bindings:
+{
+    OBDService.monitor.le_secStore -> secStore.le_secStore
+    OBDService.monitor.le_sim -> modemService.le_sim
+    OBDService.monitor.le_mdc -> modemService.le_mdc
+    OBDService.monitor.le_data -> dataConnectionService.le_data
+}
+#endif

--- a/hooks/ci_buildifier_check
+++ b/hooks/ci_buildifier_check
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-buildifier -mode=check $(find . -type f | grep -E "WORKSPACE|BUILD(\.(bazel|bzl))?\$")
+buildifier -mode=check $(find . -type f | grep -E "WORKSPACE|BUILD(\.(bazel|bzl))?\$" | egrep -v -f hooks/format-exclude-list)


### PR DESCRIPTION
This commit implements the OBDII component which receives OBDII
packet from the CAN BUS socket. The packet will be serialized by
flatbuffer and be compressed by brotli.

The can-bus directory implements the CAN BUS utility for CAN BUS
communication.

There are various standard interfaces for OBD. For TA-endpoint,
we use OBD-II standard interfaces.

For a specific purpose, we only implements service 01 and service 09
with some of pids. Those service and pids can be seen to
OBDComp/obd_pid.h.

Close #752