### PR TITLE
fix(core): Find txn object with one txn each time

### DIFF
--- a/accelerator/core/apis.c
+++ b/accelerator/core/apis.c
@@ -98,7 +98,7 @@ status_t api_find_transactions_by_tag(const iota_client_service_t* const service
   flex_trit_t tag_trits[NUM_FLEX_TRITS_TAG];
   find_transactions_req_t* req = find_transactions_req_new();
   find_transactions_res_t* res = find_transactions_res_new();
-  if (req == NULL || res == NULL) {
+  if (obj == NULL || req == NULL || res == NULL) {
     ret = SC_OOM;
     ta_log_error("%s\n", ta_error_to_string(ret));
     goto done;
@@ -142,7 +142,7 @@ status_t api_find_transactions_obj_by_tag(const iota_client_service_t* const ser
   flex_trit_t tag_trits[NUM_FLEX_TRITS_TAG];
   find_transactions_req_t* req = find_transactions_req_new();
   transaction_array_t* res = transaction_array_new();
-  if (req == NULL || res == NULL) {
+  if (req == NULL || res == NULL || obj == NULL) {
     ret = SC_OOM;
     ta_log_error("%s\n", ta_error_to_string(ret));
     goto done;

--- a/accelerator/core/core.c
+++ b/accelerator/core/core.c
@@ -253,6 +253,35 @@ done:
   return ret;
 }
 
+status_t ta_get_txn_objects_with_txn_hash(const iota_client_service_t* const service,
+                                          find_transactions_req_t* tx_queries, transaction_array_t* tx_objs) {
+  status_t ret = SC_OK;
+  find_transactions_res_t* find_tx_res = find_transactions_res_new();
+
+  if (iota_client_find_transactions(service, tx_queries, find_tx_res) != RC_OK) {
+    ret = SC_CCLIENT_FAILED_RESPONSE;
+    ta_log_error("%s\n", ta_error_to_string(ret));
+    goto done;
+  }
+
+  int limit = hash243_queue_count(find_tx_res->hashes);
+  for (int i = 0; i < limit; i++) {
+    get_trytes_req_t* tx_obj_queries = get_trytes_req_new();
+    hash243_queue_push(&tx_obj_queries->hashes, hash243_queue_at(find_tx_res->hashes, i));
+    if (iota_client_get_transaction_objects(service, tx_obj_queries, tx_objs) != RC_OK) {
+      get_trytes_req_free(&tx_obj_queries);
+      ret = SC_CCLIENT_FAILED_RESPONSE;
+      ta_log_error("%s\n", ta_error_to_string(ret));
+      goto done;
+    }
+    get_trytes_req_free(&tx_obj_queries);
+  }
+
+done:
+  find_transactions_res_free(&find_tx_res);
+  return ret;
+}
+
 status_t ta_find_transaction_objects(const iota_client_service_t* const service,
                                      const ta_find_transaction_objects_req_t* const req, transaction_array_t* res) {
   status_t ret = SC_OK;
@@ -306,10 +335,22 @@ status_t ta_find_transaction_objects(const iota_client_service_t* const service,
   }
 
   if (req_get_trytes->hashes != NULL) {
-    if (iota_client_get_transaction_objects(service, req_get_trytes, uncached_txn_array) != RC_OK) {
-      ret = SC_CCLIENT_FAILED_RESPONSE;
-      ta_log_error("%s\n", ta_error_to_string(ret));
-      goto done;
+    int limit = hash243_queue_count(req_get_trytes->hashes);
+    for (int i = 0; i < limit; i++) {
+      get_trytes_req_t* tmp_trytes_req = get_trytes_req_new();
+      transaction_array_t* tmp_txn_array = transaction_array_new();
+
+      hash243_queue_push(&tmp_trytes_req->hashes, hash243_queue_at(req_get_trytes->hashes, i));
+      if (iota_client_get_transaction_objects(service, tmp_trytes_req, uncached_txn_array) != RC_OK) {
+        ret = SC_CCLIENT_FAILED_RESPONSE;
+        ta_log_error("%s\n", ta_error_to_string(ret));
+        get_trytes_req_free(&tmp_trytes_req);
+        transaction_array_free(tmp_txn_array);
+        goto done;
+      }
+      transaction_array_push_back(uncached_txn_array, transaction_array_at(uncached_txn_array, 0));
+      transaction_array_free(tmp_txn_array);
+      get_trytes_req_free(&tmp_trytes_req);
     }
   }
 
@@ -382,7 +423,7 @@ status_t ta_get_bundle(const iota_client_service_t* const service, tryte_t const
   // find transactions by bundle hash
   flex_trits_from_trytes(bundle_hash_flex, NUM_TRITS_BUNDLE, bundle_hash, NUM_TRITS_HASH, NUM_TRYTES_BUNDLE);
   hash243_queue_push(&find_tx_req->bundles, bundle_hash_flex);
-  ret = iota_client_find_transaction_objects(service, find_tx_req, tx_objs);
+  ret = ta_get_txn_objects_with_txn_hash(service, find_tx_req, tx_objs);
   if (ret) {
     ret = SC_CCLIENT_FAILED_RESPONSE;
     ta_log_error("%s\n", ta_error_to_string(ret));

--- a/accelerator/core/core.h
+++ b/accelerator/core/core.h
@@ -115,6 +115,21 @@ status_t ta_find_transactions_obj_by_tag(const iota_client_service_t* const serv
                                          const find_transactions_req_t* const req, transaction_array_t* res);
 
 /**
+ * @brief Get transaction objects with transaction hashes when there are multiple transaction hashes are waiting for
+ * fetching. This function will fetch a transaction object with a transaction hash each time.
+ *
+ * @param[in] service IOTA full node end point service
+ * @param[in] tx_queries Given find_transactions_req_t with transaction hashes
+ * @param[out] tx_objs Return transaction objects
+ *
+ * @return
+ * - SC_OK on success
+ * - non-zero on error
+ */
+status_t ta_get_txn_objects_with_txn_hash(const iota_client_service_t* const service,
+                                          find_transactions_req_t* tx_queries, transaction_array_t* tx_objs);
+
+/**
  * @brief Return transaction object with given transaction hashes.
  *
  * Explore transaction hash information with given transaction hashes. This would
@@ -226,7 +241,7 @@ status_t ta_update_node_connection(ta_config_t* const info, iota_client_service_
  * be popped from the buffer.
  *
  * @param[in] cache Redis configuration variables
- * @param[in] raw_txn_flex_trit_array Raw transcation trytes array in flex_trit_t type
+ * @param[in] raw_txn_flex_trit_array Raw transaction trytes array in flex_trit_t type
  * @param[out] uuid Returned UUID for fetching transaction status and information
  *
  * @return

--- a/accelerator/core/mam_core.c
+++ b/accelerator/core/mam_core.c
@@ -304,9 +304,8 @@ static status_t create_channel_fetch_all_transactions(const iota_client_service_
   flex_trits_from_trytes(chid_flex_trit, NUM_TRITS_ADDRESS, chid, NUM_TRYTES_ADDRESS, NUM_TRYTES_ADDRESS);
   hash243_queue_push(&txn_req->addresses, chid_flex_trit);
   // TODO use `ta_find_transaction_objects(service, obj_req, obj_res)` instead of the original 'iota.c' function
-  retcode_t ret_rc = iota_client_find_transaction_objects(service, txn_req, obj_res);
-  if (ret_rc && ret_rc != RC_NULL_PARAM) {
-    ret = SC_MAM_FAILED_RESPONSE;
+  ret = ta_get_txn_objects_with_txn_hash(service, txn_req, obj_res);
+  if (ret) {
     ta_log_error("%s\n", ta_error_to_string(ret));
     goto done;
   }


### PR DESCRIPTION
'iota_client_find_transaction_objects' would fail when finding too many
transaction objects at one time. Now, tangle-accelerator would find
transaction object one by one.