### PR TITLE
refactor: Migrate Docker Hub repo to biilabs

### DIFF
--- a/accelerator/BUILD
+++ b/accelerator/BUILD
@@ -97,7 +97,7 @@ cc_image(
 container_image(
     name = "docker_image",
     base = ":docker_base_image",
-    repository = "dltcollab",
+    repository = "biilabs",
     stamp = True,
 )
 


### PR DESCRIPTION
For some operating issues, the repository on Docker Hub has been moved
from `dltcollab` to `biilabs`.