### PR TITLE
fix(Endpoint): Update doxygen description

### DIFF
--- a/endpoint/endpoint_core.h
+++ b/endpoint/endpoint_core.h
@@ -35,14 +35,8 @@ void endpoint_destroy(void);
  * @param[in] host The host of the tangle-accelerator
  * @param[in] port The port of the tangle-accelerator
  * @param[in] ssl_seed The random seed of the SSL configuration
- * @param[in] value Amount of the IOTA currency will be sent
- * @param[in] message Message of the transaction in Trytes format
- * @param[in] message_fmt Treating message field as specified format. Can be one of `ascii` or `trytes`. Default:
- * `ascii`
- * @param[in] tag Tag of transactions into several classifications. Tag is 27-trytes characters, e.g.
- * POWEREDBYTANGLEACCELERATOR9
- * @param[in] address Address of the receiver where IOTA currency will be sent to
- * @param[in] next_address Next address to be sent inside message
+ * @param[in] mam_seed Channel root seed. It is an 81-trytes string
+ * @param[in] message Message payload of the MAM packet in ASCII
  * @param[in] private_key Private key from device
  * @param[in] device_id Device id from device
  * @param[in,out] iv Initialization vector, must be read/write. The length of iv must be AES_IV_SIZE @see #ta_cipher_ctx


### PR DESCRIPTION
The doxygen comment is not consistent with the function header.
This commit update the doxygen description to consistent with the
function header.