### PR TITLE
fix(Endpoint): Update private key source

### DIFF
--- a/common/ta_errors.c
+++ b/common/ta_errors.c
@@ -208,6 +208,8 @@ const char* ta_error_to_string(status_t err) {
       return "Error occurred when writing message to UART";
     case SC_ENDPOINT_UART_READ_ERROR:
       return "Error occurred when reading message from UART";
+    case SC_ENDPOINT_SET_KEY_ERROR:
+      return "Fail to set a new AES key";
 
     // Crypto
     case SC_CRYPTO_RAND_ERR:

--- a/common/ta_errors.h
+++ b/common/ta_errors.h
@@ -273,6 +273,8 @@ typedef enum {
   /**< Error occurred when writing message to UART */
   SC_ENDPOINT_UART_READ_ERROR = 0x11 | SC_MODULE_ENDPOINT | SC_SEVERITY_FATAL,
   /**< Error occurred when reading message from UART */
+  SC_ENDPOINT_SET_KEY_ERROR = 0x12 | SC_MODULE_ENDPOINT | SC_SEVERITY_FATAL,
+  /**< Failed to set aes key */
 
   // Crypto module
   SC_CRYPTO_RAND_ERR = 0x01 | SC_MODULE_CRYPTO | SC_SEVERITY_FATAL,

--- a/endpoint/OBDComp/endpointService/Component.cdef
+++ b/endpoint/OBDComp/endpointService/Component.cdef
@@ -47,7 +47,7 @@ requires:
     
     api:
     {
-        le_secStore.api
+        secStoreGlobal = le_secStore.api
         modemServices/le_sim.api
         modemServices/le_mdc.api
         le_data.api    [manual-start]

--- a/endpoint/OBDComp/monitor/Component.cdef
+++ b/endpoint/OBDComp/monitor/Component.cdef
@@ -27,7 +27,7 @@ requires:
     
     api:
     {
-        le_secStore.api
+        secStoreGlobal = le_secStore.api
         modemServices/le_sim.api
         modemServices/le_mdc.api
         le_data.api    [manual-start]

--- a/endpoint/OBDMonitor.adef
+++ b/endpoint/OBDMonitor.adef
@@ -40,12 +40,12 @@ requires:
 bindings:
 {
     OBDService.monitor.endpoint -> endpointService.endpointService.endpoint
-    OBDService.monitor.le_secStore -> secStore.le_secStore
+    OBDService.monitor.secStoreGlobal -> secStore.secStoreGlobal
     OBDService.monitor.le_sim -> modemService.le_sim
     OBDService.monitor.le_mdc -> modemService.le_mdc
     OBDService.monitor.le_data -> dataConnectionService.le_data
 
-    endpointService.endpointService.le_secStore -> secStore.le_secStore
+    endpointService.endpointService.secStoreGlobal -> secStore.secStoreGlobal
     endpointService.endpointService.le_sim -> modemService.le_sim
     endpointService.endpointService.le_mdc -> modemService.le_mdc
     endpointService.endpointService.le_data -> dataConnectionService.le_data

--- a/endpoint/endpoint.adef
+++ b/endpoint/endpoint.adef
@@ -37,7 +37,7 @@ requires:
 #else
 bindings:
 {
-    endpoint.endpointComp.le_secStore -> secStore.le_secStore
+    endpoint.endpointComp.secStoreGlobal -> secStore.secStoreGlobal
     endpoint.endpointComp.le_sim -> modemService.le_sim
     endpoint.endpointComp.le_mdc -> modemService.le_mdc
     endpoint.endpointComp.le_data -> dataConnectionService.le_data

--- a/endpoint/endpointComp/endpoint.c
+++ b/endpoint/endpointComp/endpoint.c
@@ -59,7 +59,6 @@ static void print_help(void) {
       "    Assign the random seed of the SSL configuration for send_transaction_information.\n"
       "    The default value is NULL.\n"
       "\n");
-
   exit(EXIT_SUCCESS);
 }
 
@@ -85,7 +84,12 @@ COMPONENT_INIT {
 
   srand(time(NULL));
 
-  get_device_key(private_key);
+  // Use device key as AES private key
+  if (get_device_key(private_key) != SC_OK) {
+    LE_ERROR("Failed to get device key. Please set the device key first");
+    exit(EXIT_FAILURE);
+  }
+
   get_device_id(device_id);
 
   status_t ret = SC_OK;

--- a/endpoint/platform/impl.h
+++ b/endpoint/platform/impl.h
@@ -12,6 +12,18 @@
 #include "interfaces.h"
 #include "legato.h"
 
+#define ENDPOINT_DEVICE_KEY_NAME "Device key"
+
+/**
+ * @brief Set the device key
+ *
+ * @param[in] key The uint8_t array of the private key
+ * @return
+ * - SC_OK on success
+ * - SC_ENDPOINT_SET_KEY_ERROR on error
+ */
+status_t set_device_key(const char *key);
+
 /**
  * @brief Get the device key
  *
@@ -31,50 +43,3 @@ status_t get_device_key(uint8_t *key);
  * - SC_ENDPOINT_GET_DEVICE_ID_ERROR on error
  */
 status_t get_device_id(char *id);
-
-/**
- * @brief Initialize the secure storage platformService
- *
- * @return
- * - SC_OK on success
- */
-status_t sec_init(void);
-
-/**
- * @brief Write item to secure storage
- *
- * @param[in] name Name of the secure storage item
- * @param[in] buf Buffer containing the data to store
- * @param[in] buf_size Sizeof the item
- * @return
- * - SC_OK on success
- * - SC_ENDPOINT_SEC_FAULT on error
- * - SC_ENDPOINT_SEC_UNAVAILABLE the secure storage is currently unavailable
- */
-status_t sec_write(const char *name, const uint8_t *buf, size_t buf_size);
-
-/**
- * @brief Read item from secure storage
- *
- * @param[in] name Name of the secure storage item
- * @param[out] buf Buffer to store the data in
- * @param[in,out] buf_size Size of the data
- * @return
- * - SC_OK on success
- * - SC_ENDPOINT_SEC_ITEM_NOT_FOUND the item cannot found
- * - SC_ENDPOINT_SEC_UNAVAILABLE the secure storage is currently unavailable
- * - SC_ENDPOINT_SEC_FAULT on error
- */
-status_t sec_read(const char *name, uint8_t *buf, size_t *buf_size);
-
-/**
- * @brief Delete item from secure storage
- *
- * @param[in] name Name of the secure storage item
- * @return
- * - SC_OK on success
- * - SC_ENDPOINT_SEC_ITEM_NOT_FOUND the item cannot found
- * - SC_ENDPOINT_SEC_UNAVAILABLE the secure storage is currently unavailable
- * - SC_ENDPOINT_SEC_FAULT on error
- */
-status_t sec_delete(const char *name);

--- a/endpoint/platform/simulator/impl.c
+++ b/endpoint/platform/simulator/impl.c
@@ -11,83 +11,90 @@
 #include <stdlib.h>
 #include <string.h>
 #include <time.h>
+#include <unistd.h>
 #include "common/ta_errors.h"
-#include "legato.h"
-
-#include "interfaces.h"
-
-/* Setting data to produce predictable results for simulator */
-// device id
-static const char *device_id = "470010171566423";
-// private key
-static const uint8_t private_key[32] = {82,  142, 184, 64,  74, 105, 126, 65,  154, 116, 14,  193, 208, 41,  8,  115,
-                                        158, 252, 228, 160, 79, 5,   167, 185, 13,  159, 135, 113, 49,  209, 58, 68};
-// Hashmap to simulate secure storage
-static le_hashmap_Ref_t simulator_sec_table;
+#include "endpoint/cipher.h"
 
 void simulator_stub_init(void) __attribute__((constructor));
 
-status_t get_device_key(uint8_t *key) {
-  memcpy(key, private_key, 16);
-  LE_INFO("Get device key success");
-  return SC_OK;
-}
+#define ENDPOINT_CONF_NAME "endpoint.conf"
 
-status_t get_device_id(char *id) {
-  memcpy(id, device_id, 16);
-  LE_INFO("Get device id success");
-  return SC_OK;
-}
+static char device_key[AES_CBC_KEY_SIZE + 1];
+static char device_id[IMSI_LEN + 1];
 
-status_t sec_init(void) {
-  LE_INFO("Initialize secure storage");
-  simulator_sec_table =
-      le_hashmap_Create("Simulator secure storage", 32, le_hashmap_HashString, le_hashmap_EqualsString);
-  return SC_OK;
-}
+#define ENDPOINT_DEVICE_ID_NAME "Device ID"
 
-status_t sec_write(const char *name, const uint8_t *buf, size_t buf_size) {
-  uint8_t *data = malloc(buf_size);
-  if (data == NULL) {
-    LE_ERROR("Cannot fetch enough memory");
-    return SC_OOM;
-  }
-  uint8_t *ptr;
-  memcpy(data, buf, buf_size);
+#define ENDPOINT_DEVICE_ID_LEN IMSI_LEN
+#define ENDPOINT_DEVICE_KEY_LEN AES_CBC_KEY_SIZE
 
-  LE_INFO("Write %s into secure storage", name);
+static void gen_random(char* s, const int len) {
+  srand(time(NULL));
+  static const char alphanum[] = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
 
-  // the hashmap will return old value if it is replaced
-  ptr = le_hashmap_Put(simulator_sec_table, name, data);
-  if (ptr != NULL) {
-    free(ptr);
-  }
-  return SC_OK;
-}
-
-status_t sec_read(const char *name, uint8_t *buf, size_t *buf_size) {
-  LE_INFO("Read %s from secure storage", name);
-  uint8_t *data = le_hashmap_Get(simulator_sec_table, name);
-
-  if (data == NULL) {
-    *buf_size = 0;
-    return SC_ENDPOINT_SEC_ITEM_NOT_FOUND;
+  for (int i = 0; i < len; ++i) {
+    s[i] = alphanum[rand() % (sizeof(alphanum) - 1)];
   }
 
-  memcpy(buf, data, *buf_size);
-  return SC_OK;
+  s[len] = 0;
 }
 
-status_t sec_delete(const char *name) {
-  LE_INFO("Delete %s in secure storage", name);
-  uint8_t *data = le_hashmap_Remove(simulator_sec_table, name);
+static void endpoint_conf_init() {
+  memset(device_id, 0, ENDPOINT_DEVICE_ID_LEN + 1);
+  memset(device_key, 0, ENDPOINT_DEVICE_KEY_LEN + 1);
 
-  if (data == NULL) {
-    return SC_ENDPOINT_SEC_ITEM_NOT_FOUND;
+  FILE* fp = fopen(ENDPOINT_CONF_NAME, "rb+");
+  if (fp) {
+    // File exist
+    fscanf(fp, ENDPOINT_DEVICE_ID_NAME ":%s\n" ENDPOINT_DEVICE_KEY_NAME ":%s\n", device_id, device_key);
+
+    if (device_id[0] == '\0' || device_key[0] == '\0') {
+      LE_ERROR("The device ID or device key is not found. Please remove the " ENDPOINT_CONF_NAME " and try again.");
+      fclose(fp);
+      exit(EXIT_FAILURE);
+    }
+  } else {
+    // File doesn't exist
+    fp = fopen(ENDPOINT_CONF_NAME, "wb+");
+    // Use hostname as device ID
+    if (gethostname(device_id, ENDPOINT_DEVICE_ID_LEN) < 0) {
+      LE_ERROR("Can't get hostname as device ID");
+      fclose(fp);
+      exit(EXIT_FAILURE);
+    }
+    gen_random(device_key, ENDPOINT_DEVICE_KEY_LEN);
+    fprintf(fp, ENDPOINT_DEVICE_ID_NAME ":%s\n", device_id);
+    fprintf(fp, ENDPOINT_DEVICE_KEY_NAME ":%s\n", device_key);
   }
 
-  free(data);
+  LE_DEBUG("Device id:%s, Device key:%s", device_id, device_key);
+  fclose(fp);
+}
+
+status_t set_device_key(const char* key) {
+  status_t ret = SC_OK;
+  FILE* fp = fopen(ENDPOINT_CONF_NAME, "wb+");
+
+  fscanf(fp, ENDPOINT_DEVICE_ID_NAME ":%s\n" ENDPOINT_DEVICE_KEY_NAME ":%s\n", device_id, device_key);
+
+  memcpy(device_key, key, ENDPOINT_DEVICE_KEY_LEN);
+  fprintf(fp, ENDPOINT_DEVICE_ID_NAME ":%s\n", device_id);
+  fprintf(fp, ENDPOINT_DEVICE_KEY_NAME ":%s\n", device_key);
+  LE_DEBUG("Change key to %s", key);
+
+  fclose(fp);
+  return ret;
+}
+
+status_t get_device_key(uint8_t* key) {
+  memcpy(key, device_key, ENDPOINT_DEVICE_KEY_LEN);
+  LE_DEBUG("Get device key: %s", device_key);
   return SC_OK;
 }
 
-void simulator_stub_init(void) { sec_init(); }
+status_t get_device_id(char* id) {
+  memcpy(id, device_id, IMSI_LEN);
+  LE_DEBUG("Get device ID: %s", id);
+  return SC_OK;
+}
+
+void simulator_stub_init(void) { endpoint_conf_init(); }


### PR DESCRIPTION
This commit changes the hardcoded private key inside the legato targets
and the simulator.

For legato targets, the private key will be fetched from secure storage.
The key should be set by the legato shell before the endpoint executes.
If the key doesn't exist in the secure storage, the error would be show.

For the simulator, the private key and the device ID will be generated
into the endpoint.conf if the private key and the device ID doesn't
found.

The secure storage adapter also removed inside this commit, since the
simulator would store the private key and device into the "endpoint.conf"
for simulating the secure storage.

Close #779