### PR TITLE
fix(Endpoint): Ignore make clean failed error

### DIFF
--- a/endpoint/Makefile
+++ b/endpoint/Makefile
@@ -69,10 +69,10 @@ flatcc_lib:
 	$(MAKE) -C $(FLATCC_CMAKE_DIR)
 
 clean:
-	$(MAKE) -C $(MBEDTLS_DIR) clean
-	$(MAKE) -C $(BROTLI_DIR) clean
+	-$(MAKE) -C $(MBEDTLS_DIR) clean
+	-$(MAKE) -C $(BROTLI_DIR) clean
 	rm -rf $(OUT) 
-	rm -rf _build_* *.*.update
+	-rm -rf _build_* *.*.update
 
 simulator: export LEGATO_ROOT=$(PWD)/legato
 simulator: obd_header mbedtls_lib flatcc_lib brotli_lib


### PR DESCRIPTION
The github actions will failed on endpoint make clean. But this is
not error. This commit add a fix to ignore error when make clean
failed.